### PR TITLE
Add Eliatra developers as Maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @idanl21 @ido-opster @dbason @swoehrl-mw @prudhvigodithi
+* @idanl21 @ido-opster @dbason @swoehrl-mw @prudhvigodithi @jochenkressin @pchmielnik @salyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,12 +1,15 @@
 # Maintainers
 
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Idan Levy | [idanl21](https://github.com/idanl21) | Opster |
-| Ido | [ido-opster](https://github.com/ido-opster) | Opster |
-| Dan Bason | [dbason](https://github.com/dbason) | SUSE |
+| Maintainer | GitHub ID | Affiliation  |
+| --------------- | --------- |--------------|
+| Idan Levy | [idanl21](https://github.com/idanl21) | Opster       |
+| Ido | [ido-opster](https://github.com/ido-opster) | Opster       |
+| Dan Bason | [dbason](https://github.com/dbason) | SUSE         |
 | Sebastian Woehrl | [swoehrl-mw](https://github.com/swoehrl-mw) | MaibornWolff |
-| Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon |
+| Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon       |
+| Jochen Kressin | [jochenkressin](https://github.com/jochenkressin) | Eliatra      |
+| Piotr Chmielnik | [pchmielnik](https://github.com/pchmielnik) | Eliatra       |
+| Hendrik Saly | [salyh](https://github.com/salyh) | Eliatra       |
 
 The following sections explain what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
 


### PR DESCRIPTION
### Description
Update the maintainers and codeowners list to add Eliatra developers.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
