### PR TITLE
Add warning about cert expiration

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -13,7 +13,7 @@ jobs:
           go-version: '1.19'
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.22
+          version: v1
           k3d-name: opensearch-operator-tests
           k3d-args: --agents 2 -p 30000-30005:30000-30005@agent:0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           go-version: '1.19'
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.22
+          version: v1
           k3d-name: opensearch-operator-tests
           k3d-args: --agents 2 -p 30000-30005:30000-30005@agent:0
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -169,7 +169,7 @@ For security reasons, encryption is required for communication with the OpenSear
 
 Depending on your requirements, the Operator offers two ways of managing TLS certificates. You can either supply your own certificates, or the Operator will generate its own CA and sign certificates for all nodes using that CA. The second option is recommended, unless you want to directly expose your OpenSearch cluster outside your Kubernetes cluster, or your organization has rules about using self-signed certificates for internal communication.
 
-> :warning: **Clusters with operator-generated certificates will stop working after 1 year**: Make sure you are test certificate renewals in your cluster before putting it in production!
+> :warning: **Clusters with operator-generated certificates will stop working after 1 year**: Make sure you have tested certificate renewals in your cluster before putting it in production!
 
 TLS certificates are used in three places, and each can be configured independently.
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -169,6 +169,8 @@ For security reasons, encryption is required for communication with the OpenSear
 
 Depending on your requirements, the Operator offers two ways of managing TLS certificates. You can either supply your own certificates, or the Operator will generate its own CA and sign certificates for all nodes using that CA. The second option is recommended, unless you want to directly expose your OpenSearch cluster outside your Kubernetes cluster, or your organization has rules about using self-signed certificates for internal communication.
 
+> :warning: **Clusters with operator-generated certificates will stop working after 1 year**: Make sure you are test certificate renewals in your cluster before putting it in production!
+
 TLS certificates are used in three places, and each can be configured independently.
 
 #### Node Transport


### PR DESCRIPTION
### Description
This PR adds a warning to make users aware of the 1-year validity time of operator-generated certificates. When documentation for renewing the certificates is available, it would be good to add link to it from here.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
