### PR TITLE
Fix setup-k3d-k3s functional tests

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -13,7 +13,7 @@ jobs:
           go-version: '1.19'
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.22
+          version: v1
           k3d-name: opensearch-operator-tests
           k3d-args: --agents 2 -p 30000-30005:30000-30005@agent:0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           go-version: '1.19'
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.22
+          version: v1
           k3d-name: opensearch-operator-tests
           k3d-args: --agents 2 -p 30000-30005:30000-30005@agent:0
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Fix the error running Functional tests with open PR's.
```
Error: No matching K3s versions were found.
Error: Process completed with exit code 1
```

Example: https://github.com/opensearch-project/opensearch-k8s-operator/actions/runs/7890709537/job/21543655443?pr=728 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
