### PR TITLE
Docs: Fixes link for internal_users.yml

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -986,7 +986,7 @@ Note: To change the `diskSize` from `G` to `Gi` or vice-versa, first make sure d
 
 ## User and role management
 
-An important part of any OpenSearch cluster is the user and role management to give users access to the cluster (via the opensearch-security plugin). By default the operator will use the included demo securityconfig with default users (see [internal_users.yml](https://github.com/opensearch-project/security/blob/main/securityconfig/internal_users.yml) for a list of users). For any production installation you should swap that out with your own configuration.
+An important part of any OpenSearch cluster is the user and role management to give users access to the cluster (via the opensearch-security plugin). By default the operator will use the included demo securityconfig with default users (see [internal_users.yml](https://github.com/opensearch-project/security/blob/main/config/internal_users.yml) for a list of users). For any production installation you should swap that out with your own configuration.
 There are two ways to do that with the operator:
 
 * Defining your own securityconfig


### PR DESCRIPTION
### Description
Fixes the link for the internal_users.yml on the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
