### PR TITLE
OpenSearchISMPolicy - shrink action has a maxShardSize required property which is invalid

### DIFF
--- a/opensearch-operator/api/v1/opensearchism_types.go
+++ b/opensearch-operator/api/v1/opensearchism_types.go
@@ -210,7 +210,7 @@ type Shrink struct {
 	// If true, executes the shrink action even if there are no replicas.
 	ForceUnsafe *bool `json:"forceUnsafe,omitempty"`
 	// The maximum size in bytes of a shard for the target index.
-	MaxShardSize *string `json:"maxShardSize"`
+	MaxShardSize *string `json:"maxShardSize,omitempty"`
 	// The maximum number of primary shards in the shrunken index.
 	NumNewShards *int `json:"numNewShards,omitempty"`
 	// Percentage of the number of original primary shards to shrink.

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
@@ -326,8 +326,6 @@ spec:
                               targetIndexNameTemplate:
                                 description: The name of the shrunken index.
                                 type: string
-                            required:
-                            - maxShardSize
                             type: object
                           snapshot:
                             description: Back up your cluster’s indexes and state


### PR DESCRIPTION
I have the following `OpenSearchISMPolicy`

```yaml
apiVersion: opensearch.opster.io/v1
kind: OpenSearchISMPolicy
metadata:
  name: platypus-otto-shared
spec:
  opensearchCluster:
    name: opensearch
  _meta:
    description: platypus-otto-shared
  policyId: platypus-otto-shared
  description: A sample description of the policy
  states:
    - name: hot
      actions:
        - indexPriority:
            priority: 100
      transitions:
        - conditions:
            minIndexAge: 400d
          stateName: warm
    - name: warm
      actions:
        - shrink:
            numNewShards: 1
          forceMerge:
            maxNumSegments: 1
      transitions:
        - conditions:
            minIndexAge: 800d
          stateName: cold
    - name: cold
      actions:
        - readOnly: {}
      transitions:
        - conditions:
            minIndexAge: 3650d
          stateName: delete
    - name: delete
      actions:
        - delete: {}
      transitions: []
  defaultState: hot
  ismTemplate:
    priority: 1
    indexPatterns:
      - otto-reading_*

```

And I am receving the following error when validating the schema:

```log
stdin - OpenSearchISMPolicy platypus-otto-shared is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/states/1/actions/0/shrink' does not validate with file:///.../v1.26.5-standalone-strict/opensearchismpolicy-opensearch-v1.json#/properties/spec/properties/states/items/properties/actions/items/properties/shrink/required: missing properties: 'maxShardSize'
```

The error is saying that the `maxShardSize` property is required, but the `maxShardSize` property is not required in the `shrink` action for all permutations of how it can be used. 
See the official documentation:

<https://opensearch.org/docs/latest/im-plugin/ism/policies/#shrink>
![image](https://github.com/opensearch-project/opensearch-k8s-operator/assets/73483987/bcddf575-9192-4bdd-9bbe-0f2a8d9f0c0d)


You are already handling the properties here:
opensearch-operator/pkg/reconcilers/ismpolicy.go

But we need to update the schema.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
