### PR TITLE
solve #751 by adding `spec.port.0.appProtocol: "HTTPS"` for compliance with GKE gateways

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -650,6 +650,7 @@ func NewServiceForCR(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 				{
 					Name:     "http",
 					Protocol: "TCP",
+					AppProtocol: "HTTPS",
 					Port:     cr.Spec.General.HttpPort,
 					TargetPort: intstr.IntOrString{
 						IntVal: cr.Spec.General.HttpPort,


### PR DESCRIPTION
### Description
As Operator deploy only HTTPS cluster this PR just add a static `AppProtocol: "HTTPS"` in port[0] of opensearch service (9200 default).
This properties let possible GKE gateway to now to use this backend with TLS protocol as described in https://cloud.google.com/kubernetes-engine/docs/how-to/secure-gateway#load-balancer-tls

### Issues Resolved
solve issue #751 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
