### PR TITLE
Fix upgrade detection during parallel recovery

### DIFF
--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -777,7 +777,7 @@ var _ = Describe("Builders", func() {
 			Expect(result.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold).To(Equal(int32(9)))
 		})
 	})
-	
+
 	When("Configuring InitHelper Resources", func() {
 		It("should propagate Resources to all init containers", func() {
 			clusterObject := ClusterDescWithVersion("2.2.1")

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -200,7 +200,7 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool,
 		} else {
 			// A failure is assumed if n PVCs exist but less than n-1 pods (one missing pod is allowed for rolling restart purposes)
 			// We can assume the cluster is in a failure state and cannot recover on its own
-			if !helpers.UpgradeInProgress(r.instance.Status) &&
+			if !helpers.IsUpgradeInProgress(r.instance.Status) &&
 				pvcCount >= int(nodePool.Replicas) && existing.Status.ReadyReplicas < nodePool.Replicas-1 {
 				r.logger.Info(fmt.Sprintf("Detected recovery situation for nodepool %s: PVC count: %d, replicas: %d. Recreating STS with parallel mode", nodePool.Component, pvcCount, existing.Status.Replicas))
 				if existing.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
@@ -301,7 +301,7 @@ func (r *ClusterReconciler) checkForEmptyDirRecovery() (*ctrl.Result, error) {
 			Description: nodePool.Component,
 		}
 		comp := r.instance.Status.ComponentsStatus
-		_, found := helpers.FindFirstPartial(comp, componentStatus, helpers.GetByDescriptionAndGroup)
+		_, found := helpers.FindFirstPartial(comp, componentStatus, helpers.GetByDescriptionAndComponent)
 
 		if found {
 			return &ctrl.Result{}, nil

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -21,11 +20,9 @@ import (
 
 func newConfigurationReconciler(
 	client *k8s.MockK8sClient,
-	ctx context.Context,
 	recorder record.EventRecorder,
 	reconcilerContext *ReconcilerContext,
 	instance *opsterv1.OpenSearchCluster,
-	opts ...reconciler.ResourceReconcilerOption,
 ) *ConfigurationReconciler {
 	return &ConfigurationReconciler{
 		client:            client,
@@ -69,7 +66,6 @@ var _ = Describe("Configuration Controller", func() {
 
 			underTest := newConfigurationReconciler(
 				mockClient,
-				context.Background(),
 				&helpers.MockEventRecorder{},
 				&reconcilerContext,
 				&spec,
@@ -116,7 +112,6 @@ var _ = Describe("Configuration Controller", func() {
 
 			underTest := newConfigurationReconciler(
 				mockClient,
-				context.Background(),
 				&helpers.MockEventRecorder{},
 				&reconcilerContext,
 				&spec,

--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -110,6 +110,7 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 				lg.V(1).Info("Restart complete. Reactivating shard allocation")
 				return ctrl.Result{Requeue: true}, err
 			}
+			r.recorder.AnnotatedEventf(r.instance, map[string]string{"cluster-name": r.instance.GetName()}, "Normal", "RollingRestart", "Rolling restart completed")
 			if err = r.updateStatus(statusFinished); err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
@@ -129,7 +130,7 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 	if err := r.updateStatus(statusInProgress); err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}
-	r.recorder.AnnotatedEventf(r.instance, map[string]string{"cluster-name": r.instance.GetName()}, "Normal", "RollingRestart", "Starting to rolling restart")
+	r.recorder.AnnotatedEventf(r.instance, map[string]string{"cluster-name": r.instance.GetName()}, "Normal", "RollingRestart", "Starting rolling restart")
 
 	// If there is work to do create an Opensearch Client
 	var err error

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -78,7 +78,7 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 		Description: nodePool.Component,
 	}
 	comp := r.instance.Status.ComponentsStatus
-	currentStatus, found := helpers.FindFirstPartial(comp, componentStatus, helpers.GetByDescriptionAndGroup)
+	currentStatus, found := helpers.FindFirstPartial(comp, componentStatus, helpers.GetByDescriptionAndComponent)
 
 	desireReplicaDiff := *currentSts.Spec.Replicas - nodePool.Replicas
 	if desireReplicaDiff == 0 {

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -162,7 +162,7 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 	}
 
 	r.logger.Info("Starting securityconfig update job")
-	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Security", "Starting to securityconfig update job")
+	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Security", "Starting securityconfig update job")
 
 	job = builders.NewSecurityconfigUpdateJob(
 		r.instance,


### PR DESCRIPTION
### Description
Fixes a bug where parallel recovery did not engage if the cluster had gone through a version upgrade beforehand.
Reason was that the upgrade logic added the status for each nodepool twice leading to the recovery logic incorrectly detecting if an upgrade was in progress.
Also did a small refactoring of names and constants and fixed a warning by my IDE about unused parameters.

No changes to the CRDs or functionality, just internal logic fixes.

### Issues Resolved
Fixes #730 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [-] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [-] Changes to CRDs documented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
