### PR TITLE
Add support for additional volumes and volumeMounts for the operator

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -68,6 +68,8 @@ spec:
         {{- end }}
         securityContext:
 {{- toYaml .Values.manager.securityContext | nindent 10 }}
+        volumeMounts:
+{{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
       nodeSelector:
 {{- toYaml .Values.nodeSelector | nindent 8 }}
       tolerations:
@@ -80,3 +82,5 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "opensearch-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      volumes:
+{{- toYaml .Values.manager.extraVolumes | nindent 8 }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -9,6 +9,18 @@ manager:
   securityContext:
     allowPrivilegeEscalation: false
   extraEnv: []
+
+  # Specify extra volumes to provide to the Pod
+  # - name: extras
+  #   emptyDir: {}
+  extraVolumes: []
+
+  # Specify where to mount the above extraVolumes
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+  extraVolumeMounts: []
+  
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
### Description
Add the capability to add additional volumes to the operator pod and mount them to the controller manager container

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-k8s-operator/issues/795

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
