### PR TITLE
Sort component template fields before compare to avoid false positives

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -476,6 +476,20 @@ func ShouldUpdateComponentTemplate(
 		return false, fmt.Errorf("returned component template named '%s' does not equal the requested name '%s'", componentTemplateResponse.Name, componentTemplateName)
 	}
 
+	if componentTemplateResponse.ComponentTemplate.Template.Settings != nil {
+		componentTemplateResponse.ComponentTemplate.Template.Settings, err = helpers.SortedJsonKeys(componentTemplateResponse.ComponentTemplate.Template.Settings)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if componentTemplateResponse.ComponentTemplate.Template.Mappings != nil {
+		componentTemplateResponse.ComponentTemplate.Template.Mappings, err = helpers.SortedJsonKeys(componentTemplateResponse.ComponentTemplate.Template.Mappings)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	if cmp.Equal(componentTemplate, componentTemplateResponse.ComponentTemplate, cmpopts.EquateEmpty()) {
 		return false, nil
 	}


### PR DESCRIPTION
### Description
This fixes the same issue that previously existed with `OpenSearchIndexTemplate` resources (#731), which was fixed in #727 but did not apply the fix to `OpenSearchComponentTemplate` resources.

### Issues Resolved
Fixes #799 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
