### PR TITLE
Rename timestampField back to how it was released

### DIFF
--- a/opensearch-operator/api/v1/opensearch_index_types.go
+++ b/opensearch-operator/api/v1/opensearch_index_types.go
@@ -11,7 +11,7 @@ type OpensearchDatastreamTimestampFieldSpec struct {
 
 type OpensearchDatastreamSpec struct {
 	// TimestampField for dataStream
-	TimestampField OpensearchDatastreamTimestampFieldSpec `json:"timestampField,omitempty"`
+	TimestampField OpensearchDatastreamTimestampFieldSpec `json:"timestamp_field,omitempty"`
 }
 
 // Describes the specs of an index

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -4770,21 +4770,25 @@ spec:
                               resource requirements.
                             properties:
                               claims:
-                                description: "Claims lists the names of resources,
-                                  defined in spec.resourceClaims, that are used by
-                                  this container. \n This is an alpha field and requires
-                                  enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable. It can only be set for
-                                  containers."
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+
+                                  This field is immutable. It can only be set for containers.
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one
-                                        entry in pod.spec.resourceClaims of the Pod
-                                        where this field is used. It makes that resource
-                                        available inside a container.
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -4800,8 +4804,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4810,12 +4815,11 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. Requests cannot exceed Limits. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                         type: object


### PR DESCRIPTION
### Description
Due to some oversight the timestampField from https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/opensearch-operator/api/v1/opensearch_index_types.go#L14 was released as `timestamp_field` in the helm chart (https://github.com/opensearch-project/opensearch-k8s-operator/blob/v2.6.0/charts/opensearch-operator/files/opensearch.opster.io_opensearchindextemplates.yaml#L57). To prevent an incompatible renaming in the released CRDs this PR renames the field in the code to be consistent.

### Issues Resolved
Originally discovered in #805 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [-] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [-] Changes to CRDs documented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
