### PR TITLE
Add securitycontext to keystore container

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -436,7 +436,8 @@ func NewSTSForNodePool(
 				cp -a /usr/share/opensearch/config/opensearch.keystore /tmp/keystore/
 				`,
 			},
-			VolumeMounts: initContainerVolumeMounts,
+			VolumeMounts:    initContainerVolumeMounts,
+			SecurityContext: securityContext,
 		}
 
 		initContainers = append(initContainers, keystoreInitContainer)


### PR DESCRIPTION
### Description
This fixes the issue found in this kubernetes event log:

```log
create Pod opensearch-data-0 in StatefulSet opensearch-data failed error: pods "opensearch-data-0" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "keystore" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "keystore" must set securityContext.capabilities.drop=["ALL"])  
```

When we are running

```yaml
labels:
    pod-security.kubernetes.io/enforce: restricted
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
