### PR TITLE
Fix rollingRestart reconcile for multiple same named clusters

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -247,7 +247,7 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opsterv1.OpenSearc
 	selector := labels.NewSelector()
 	selector = selector.Add(*clusterReq, *componentReq)
 	// List pods matching selector
-	list, err := k8sClient.ListPods(&client.ListOptions{LabelSelector: selector})
+	list, err := k8sClient.ListPods(&client.ListOptions{Namespace: cr.Namespace, LabelSelector: selector})
 	if err != nil {
 		return 0, err
 	}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -281,7 +281,7 @@ func CountPVCsForNodePool(k8sClient k8s.K8sClient, cr *opsterv1.OpenSearchCluste
 	}
 	selector := labels.NewSelector()
 	selector = selector.Add(*clusterReq, *componentReq)
-	list, err := k8sClient.ListPVCs(&client.ListOptions{LabelSelector: selector})
+	list, err := k8sClient.ListPVCs(&client.ListOptions{Namespace: cr.Namespace, LabelSelector: selector})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Description
Fixes a bug where reconcile breaks, if there are multiple same named OpensearchClusters in different namespaces.
The rollingRestart reconciler selects pods in all namespaces when evaluating if the Pods are healthy and matches them with the desired replicas. Only pods in the own namespace should be checked.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
