### PR TITLE
Rewrote ISM Policy reconciler

### DIFF
--- a/opensearch-operator/opensearch-gateway/requests/IsmPolicy.go
+++ b/opensearch-operator/opensearch-gateway/requests/IsmPolicy.go
@@ -1,14 +1,11 @@
 package requests
 
-type Policy struct {
-	PolicyID       string    `json:"_id,omitempty"`
-	PrimaryTerm    *int      `json:"_primary_term,omitempty"`
-	SequenceNumber *int      `json:"_seq_no,omitempty"`
-	Policy         ISMPolicy `json:"policy"`
+type ISMPolicy struct {
+	Policy ISMPolicySpec `json:"policy"`
 }
 
 // ISMPolicySpec is the specification for the ISM policy for OS.
-type ISMPolicy struct {
+type ISMPolicySpec struct {
 	// The default starting state for each index that uses this policy.
 	DefaultState string `json:"default_state"`
 	// A human-readable description of the policy.

--- a/opensearch-operator/opensearch-gateway/responses/ISMPolicyResponse.go
+++ b/opensearch-operator/opensearch-gateway/responses/ISMPolicyResponse.go
@@ -1,5 +1,0 @@
-package responses
-
-import "github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/requests"
-
-type GetISMPoliciesResponse requests.Policy

--- a/opensearch-operator/opensearch-gateway/responses/IsmPolicy.go
+++ b/opensearch-operator/opensearch-gateway/responses/IsmPolicy.go
@@ -1,0 +1,10 @@
+package responses
+
+import "github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/requests"
+
+type GetISMPolicyResponse struct {
+	PolicyID       string `json:"_id"`
+	PrimaryTerm    int    `json:"_primary_term"`
+	SequenceNumber int    `json:"_seq_no"`
+	Policy         requests.ISMPolicySpec
+}

--- a/opensearch-operator/opensearch-gateway/services/os_ism_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_ism_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/requests"
+	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opensearch-project/opensearch-go/opensearchutil"
@@ -16,7 +17,7 @@ import (
 var ErrNotFound = errors.New("policy not found")
 
 // ShouldUpdateISMPolicy checks if the passed policy is same as existing or needs update
-func ShouldUpdateISMPolicy(ctx context.Context, newPolicy, existingPolicy requests.Policy) (bool, error) {
+func ShouldUpdateISMPolicy(ctx context.Context, newPolicy, existingPolicy requests.ISMPolicy) (bool, error) {
 	if cmp.Equal(newPolicy, existingPolicy, cmpopts.EquateEmpty()) {
 		return false, nil
 	}
@@ -27,23 +28,8 @@ func ShouldUpdateISMPolicy(ctx context.Context, newPolicy, existingPolicy reques
 	return true, nil
 }
 
-// PolicyExists checks if the passed policy already exists or not
-func PolicyExists(ctx context.Context, service *OsClusterClient, policyName string) (bool, error) {
-	resp, err := service.GetISMConfig(ctx, policyName)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == 404 {
-		return false, nil
-	} else if resp.IsError() {
-		return false, fmt.Errorf("response from API is %s", resp.Status())
-	}
-	return true, nil
-}
-
 // GetPolicy fetches the passed policy
-func GetPolicy(ctx context.Context, service *OsClusterClient, policyName string) (*requests.Policy, error) {
+func GetPolicy(ctx context.Context, service *OsClusterClient, policyName string) (*responses.GetISMPolicyResponse, error) {
 	resp, err := service.GetISMConfig(ctx, policyName)
 	if err != nil {
 		return nil, err
@@ -51,10 +37,11 @@ func GetPolicy(ctx context.Context, service *OsClusterClient, policyName string)
 	defer resp.Body.Close()
 	if resp.StatusCode == 404 {
 		return nil, ErrNotFound
-	} else if resp.IsError() {
+	}
+	if resp.IsError() {
 		return nil, fmt.Errorf("response from API is %s", resp.Status())
 	}
-	ismResponse := requests.Policy{}
+	ismResponse := responses.GetISMPolicyResponse{}
 	if resp != nil && resp.Body != nil {
 		err := json.NewDecoder(resp.Body).Decode(&ismResponse)
 		if err != nil {
@@ -66,7 +53,7 @@ func GetPolicy(ctx context.Context, service *OsClusterClient, policyName string)
 }
 
 // CreateISMPolicy creates the passed policy
-func CreateISMPolicy(ctx context.Context, service *OsClusterClient, ismpolicy requests.Policy, policyId string) error {
+func CreateISMPolicy(ctx context.Context, service *OsClusterClient, ismpolicy requests.ISMPolicy, policyId string) error {
 	spec := opensearchutil.NewJSONReader(ismpolicy)
 	resp, err := service.PutISMConfig(ctx, policyId, spec)
 	if err != nil {
@@ -80,15 +67,15 @@ func CreateISMPolicy(ctx context.Context, service *OsClusterClient, ismpolicy re
 }
 
 // UpdateISMPolicy updates the given policy
-func UpdateISMPolicy(ctx context.Context, service *OsClusterClient, ismpolicy requests.Policy, seqno, primterm *int, policyName string) error {
+func UpdateISMPolicy(ctx context.Context, service *OsClusterClient, ismpolicy requests.ISMPolicy, seqno, primterm *int, policyId string) error {
 	spec := opensearchutil.NewJSONReader(ismpolicy)
-	resp, err := service.UpdateISMConfig(ctx, policyName, *seqno, *primterm, spec)
+	resp, err := service.UpdateISMConfig(ctx, policyId, *seqno, *primterm, spec)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.IsError() {
-		return fmt.Errorf("failed to create ism policy: %s", resp.String())
+		return fmt.Errorf("failed to update ism policy: %s", resp.String())
 	}
 	return nil
 }

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/util"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
@@ -22,7 +24,10 @@ import (
 )
 
 const (
-	ismPolicyExists = "ism policy already exists in Opensearch"
+	opensearchIsmPolicyExists       = "ISM Policy already exists in Opensearch"
+	opensearchIsmPolicyNameMismatch = "OpensearchISMPolicyNameMismatch"
+	opensearchClusterRequeueAfter   = 10 * time.Second
+	defaultRequeueAfter             = 30 * time.Second
 )
 
 type IsmPolicyReconciler struct {
@@ -58,6 +63,7 @@ func NewIsmReconciler(
 func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) {
 	var reason string
 	var policyId string
+
 	defer func() {
 		if !pointer.BoolDeref(r.updateStatus, true) {
 			return
@@ -71,24 +77,23 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 				instance.Status.State = opsterv1.OpensearchISMPolicyError
 			}
 			// Requeue after is 10 seconds if waiting for OpenSearch cluster
-			if retResult.Requeue && retResult.RequeueAfter == 10*time.Second {
+			if retResult.Requeue && retResult.RequeueAfter == opensearchClusterRequeueAfter {
 				instance.Status.State = opsterv1.OpensearchISMPolicyPending
 			}
-			// Requeue is after 30 seconds for normal reconciliation after creation/update
-			if retErr == nil && retResult.RequeueAfter == 30*time.Second {
+			if retErr == nil && retResult.Requeue {
 				instance.Status.State = opsterv1.OpensearchISMPolicyCreated
 				instance.Status.PolicyId = policyId
 			}
-			if reason == ismPolicyExists {
+			if reason == opensearchIsmPolicyExists {
 				instance.Status.State = opsterv1.OpensearchISMPolicyIgnored
 			}
 		})
+
 		if err != nil {
 			r.logger.Error(err, "failed to update status")
 		}
 	}()
 
-	var err error
 	r.cluster, retErr = util.FetchOpensearchCluster(r.client, r.ctx, types.NamespacedName{
 		Name:      r.instance.Spec.OpensearchRef.Name,
 		Namespace: r.instance.Namespace,
@@ -97,167 +102,184 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 		reason = "error fetching opensearch cluster"
 		r.logger.Error(retErr, "failed to fetch opensearch cluster")
 		r.recorder.Event(r.instance, "Warning", opensearchError, reason)
-		return
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: opensearchClusterRequeueAfter,
+		}, retErr
 	}
 	if r.cluster == nil {
 		r.logger.Info("opensearch cluster does not exist, requeueing")
 		reason = "waiting for opensearch cluster to exist"
 		r.recorder.Event(r.instance, "Normal", opensearchPending, reason)
-		retResult = ctrl.Result{
+		return ctrl.Result{
 			Requeue:      true,
-			RequeueAfter: 10 * time.Second,
-		}
-		return
+			RequeueAfter: opensearchClusterRequeueAfter,
+		}, nil
 	}
+
 	// Check cluster ref has not changed
-	if r.instance.Status.ManagedCluster != nil {
-		if *r.instance.Status.ManagedCluster != r.cluster.UID {
-			reason = "cannot change the cluster a role refers to"
-			retErr = fmt.Errorf("%s", reason)
-			r.recorder.Event(r.instance, "Warning", opensearchRefMismatch, reason)
-			return
-		}
-	} else {
-		if pointer.BoolDeref(r.updateStatus, true) {
-			retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
-				instance := object.(*opsterv1.OpenSearchISMPolicy)
-				instance.Status.ManagedCluster = &r.cluster.UID
-			})
-			if retErr != nil {
-				reason = fmt.Sprintf("failed to update status: %s", retErr)
-				r.recorder.Event(r.instance, "Warning", statusError, reason)
-				return
-			}
+	managedCluster := r.instance.Status.ManagedCluster
+	if managedCluster != nil && *managedCluster != r.cluster.UID {
+		reason = "cannot change the cluster a resource refers to"
+		retErr = fmt.Errorf("%s", reason)
+		r.recorder.Event(r.instance, "Warning", opensearchRefMismatch, reason)
+		return ctrl.Result{
+			Requeue: false,
+		}, retErr
+	}
+
+	if pointer.BoolDeref(r.updateStatus, true) {
+		retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
+			object.(*opsterv1.OpenSearchISMPolicy).Status.ManagedCluster = &r.cluster.UID
+		})
+		if retErr != nil {
+			reason = fmt.Sprintf("failed to update status: %s", retErr)
+			r.recorder.Event(r.instance, "Warning", statusError, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: opensearchClusterRequeueAfter,
+			}, retErr
 		}
 	}
+
 	// Check cluster is ready
 	if r.cluster.Status.Phase != opsterv1.PhaseRunning {
 		r.logger.Info("opensearch cluster is not running, requeueing")
 		reason = "waiting for opensearch cluster status to be running"
 		r.recorder.Event(r.instance, "Normal", opensearchPending, reason)
-		retResult = ctrl.Result{
+		return ctrl.Result{
 			Requeue:      true,
-			RequeueAfter: 10 * time.Second,
-		}
-		return
+			RequeueAfter: opensearchClusterRequeueAfter,
+		}, nil
 	}
 
-	r.osClient, err = util.CreateClientForCluster(r.client, r.ctx, r.cluster, r.osClientTransport)
-	if err != nil {
-		reason := "error creating opensearch client"
-		r.recorder.Event(r.instance, "Warning", opensearchError, reason)
-		retResult = ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: 30 * time.Second,
-		}
-		retErr = err
-		return
-	}
-
-	// If PolicyID not provided explicitly, use metadata.name by default
-	policyId = r.instance.Spec.PolicyID
-	if r.instance.Spec.PolicyID == "" {
-		policyId = r.instance.Name
-	}
-	// Check ism policy state to make sure we don't touch preexisting ism policy
-	if r.instance.Status.ExistingISMPolicy == nil {
-		var exists bool
-		exists, retErr = services.PolicyExists(r.ctx, r.osClient, policyId)
-		if retErr != nil {
-			reason = "failed to get policy status from Opensearch API"
-			r.logger.Error(retErr, reason)
-			r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
-			return
-		}
-		if pointer.BoolDeref(r.updateStatus, true) {
-			retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
-				instance := object.(*opsterv1.OpenSearchISMPolicy)
-				instance.Status.ExistingISMPolicy = &exists
-			})
-			if retErr != nil {
-				reason = fmt.Sprintf("failed to update status: %s", retErr)
-				r.recorder.Event(r.instance, "Warning", statusError, reason)
-				return
-			}
-		} else {
-			// Emit an event for unit testing assertion
-			r.recorder.Event(r.instance, "Normal", "UnitTest", fmt.Sprintf("exists is %t", exists))
-			return
-		}
-	}
-
-	// If ism policy is existing do nothing
-	if *r.instance.Status.ExistingISMPolicy {
-		reason = ismPolicyExists
-		return
-	}
-
-	ismpolicy, retErr := r.CreateISMPolicyRequest()
+	r.osClient, retErr = util.CreateClientForCluster(r.client, r.ctx, r.cluster, r.osClientTransport)
 	if retErr != nil {
-		reason = "failed to get create the ism policy request"
+		reason = "error creating opensearch client"
+		r.recorder.Event(r.instance, "Warning", opensearchError, reason)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: opensearchClusterRequeueAfter,
+		}, retErr
+	}
+
+	// If PolicyID is not provided explicitly, use metadata.name by default
+	policyId = r.instance.Name
+	if r.instance.Spec.PolicyID != "" {
+		policyId = r.instance.Spec.PolicyID
+	}
+
+	newPolicy, retErr := r.CreateISMPolicy()
+	if retErr != nil {
 		r.logger.Error(retErr, reason)
-		r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
-		return
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueAfter,
+		}, retErr
 	}
 
 	existingPolicy, retErr := services.GetPolicy(r.ctx, r.osClient, policyId)
-	if retErr != nil && retErr != services.ErrNotFound {
-		reason = "failed to get policy from Opensearch API"
-		r.logger.Error(retErr, reason)
-		r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
-		return
-	}
+	// If not exists, create
 	if errors.Is(retErr, services.ErrNotFound) {
-		r.logger.V(1).Info(fmt.Sprintf("policy %s not found, creating.", r.instance.Spec.PolicyID))
-		retErr = services.CreateISMPolicy(r.ctx, r.osClient, *ismpolicy, policyId)
+		request := requests.ISMPolicy{
+			Policy: *newPolicy,
+		}
+		retErr = services.CreateISMPolicy(r.ctx, r.osClient, request, policyId)
 		if retErr != nil {
 			reason = "failed to create ism policy"
 			r.logger.Error(retErr, reason)
 			r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
-			return
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, retErr
 		}
-		r.recorder.Event(r.instance, "Normal", opensearchAPIUpdated, "policy created in opensearch")
-		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, retErr
+		// Mark the ISM Policy as not pre-existing (created by the operator)
+		retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
+			object.(*opsterv1.OpenSearchISMPolicy).Status.ExistingISMPolicy = pointer.Bool(false)
+		})
+		if retErr != nil {
+			reason = "failed to update custom resource object"
+			r.logger.Error(retErr, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, retErr
+		}
+
+		r.recorder.Event(r.instance, "Normal", opensearchAPIUpdated, "policy successfully created in OpenSearch Cluster")
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueAfter,
+		}, nil
 	}
-	priterm := existingPolicy.PrimaryTerm
-	seqno := existingPolicy.SequenceNumber
-	// Reset
-	existingPolicy.PrimaryTerm = nil
-	existingPolicy.SequenceNumber = nil
-	shouldUpdate, retErr := services.ShouldUpdateISMPolicy(r.ctx, *ismpolicy, *existingPolicy)
+
+	// If other error, report
 	if retErr != nil {
-		reason = "failed to compare the policies"
+		reason = "failed to get the ism policy from Opensearch API"
 		r.logger.Error(retErr, reason)
 		r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
-		return
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueAfter,
+		}, retErr
 	}
 
-	if !shouldUpdate {
-		r.logger.V(1).Info(fmt.Sprintf("policy %s is in sync", r.instance.Spec.PolicyID))
-		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, retErr
+	// If the ISM policy exists in OpenSearch cluster and was not created by the operator, update the status and return
+	if r.instance.Status.ExistingISMPolicy == nil || *r.instance.Status.ExistingISMPolicy {
+		retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
+			object.(*opsterv1.OpenSearchISMPolicy).Status.ExistingISMPolicy = pointer.Bool(true)
+		})
+		if retErr != nil {
+			reason = "failed to update custom resource object"
+			r.logger.Error(retErr, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, retErr
+		}
+		reason = "the ISM policy already exists in the OpenSearch cluster"
+		r.logger.Error(errors.New(opensearchIsmPolicyExists), reason)
+		r.recorder.Event(r.instance, "Warning", opensearchIsmPolicyExists, reason)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueAfter,
+		}, nil
 	}
 
-	// the policyId  is immutable, so check the old name (r.instance.Status.PolicyId) against the new
-	if r.instance.Status.PolicyId != "" && policyId != r.instance.Status.PolicyId {
-		reason = "can't change PolicyID"
-		r.recorder.Event(r.instance, "Warning", opensearchError, reason)
-		return
-
+	// Return if there are no changes
+	if r.instance.Spec.PolicyID == existingPolicy.PolicyID && cmp.Equal(*newPolicy, existingPolicy.Policy, cmpopts.EquateEmpty()) {
+		r.logger.V(1).Info(fmt.Sprintf("user %s is in sync", r.instance.Name))
+		r.recorder.Event(r.instance, "Normal", opensearchAPIUnchanged, "policy is in sync")
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueAfter,
+		}, nil
 	}
-	retErr = services.UpdateISMPolicy(r.ctx, r.osClient, *ismpolicy, seqno, priterm, policyId)
+
+	request := requests.ISMPolicy{
+		Policy: *newPolicy,
+	}
+	retErr = services.UpdateISMPolicy(r.ctx, r.osClient, request, &existingPolicy.SequenceNumber, &existingPolicy.PrimaryTerm, existingPolicy.PolicyID)
 	if retErr != nil {
 		reason = "failed to update ism policy with Opensearch API"
 		r.logger.Error(retErr, reason)
 		r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueAfter,
+		}, retErr
 	}
 
 	r.recorder.Event(r.instance, "Normal", opensearchAPIUpdated, "policy updated in opensearch")
-
-	return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, retErr
+	return ctrl.Result{
+		Requeue:      true,
+		RequeueAfter: defaultRequeueAfter,
+	}, nil
 }
 
-func (r *IsmPolicyReconciler) CreateISMPolicyRequest() (*requests.Policy, error) {
-	policy := requests.ISMPolicy{
+func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error) {
+	policy := requests.ISMPolicySpec{
 		DefaultState: r.instance.Spec.DefaultState,
 		Description:  r.instance.Spec.Description,
 	}
@@ -378,35 +400,35 @@ func (r *IsmPolicyReconciler) CreateISMPolicyRequest() (*requests.Policy, error)
 						shrink.ForceUnsafe = action.Shrink.ForceUnsafe
 					}
 					if action.Shrink.MaxShardSize == nil && action.Shrink.NumNewShards == nil && action.Shrink.PercentageOfSourceShards == nil {
-						reason := "Either of MaxShardSize or NumNewShards or PercentageOfSourceShards is required"
-						r.recorder.Event(r.instance, "Error", opensearchError, reason)
-						return nil, nil
+						reason := "either of MaxShardSize or NumNewShards or PercentageOfSourceShards is required"
+						r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
+						return nil, errors.New(reason)
 					}
 
 					if action.Shrink.MaxShardSize != nil {
 						if action.Shrink.NumNewShards == nil && action.Shrink.PercentageOfSourceShards == nil {
 							shrink.MaxShardSize = action.Shrink.MaxShardSize
 						} else {
-							reason := "MaxShardSize can't exist with NumNewShards or PercentageOfSourceShards. Keep one of these."
-							r.recorder.Event(r.instance, "Error", opensearchError, reason)
-							return nil, nil
+							reason := "maxShardSize can't exist with NumNewShards or PercentageOfSourceShards. Keep one of these"
+							r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
+							return nil, errors.New(reason)
 						}
 						if action.Shrink.NumNewShards != nil {
 							if action.Shrink.MaxShardSize == nil && action.Shrink.PercentageOfSourceShards == nil {
 								shrink.NumNewShards = action.Shrink.NumNewShards
 							} else {
-								reason := "NumNewShards can't exist with MaxShardSize or PercentageOfSourceShards. Keep one of these."
-								r.recorder.Event(r.instance, "Error", opensearchError, reason)
-								return nil, nil
+								reason := "numNewShards can't exist with MaxShardSize or PercentageOfSourceShards. Keep one of these"
+								r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
+								return nil, errors.New(reason)
 							}
 						}
 						if action.Shrink.PercentageOfSourceShards != nil {
 							if action.Shrink.NumNewShards == nil && action.Shrink.MaxShardSize == nil {
 								shrink.PercentageOfSourceShards = action.Shrink.PercentageOfSourceShards
 							} else {
-								reason := "PercentageOfSourceShards can't exist with MaxShardSize or NumNewShards. Keep one of these."
-								r.recorder.Event(r.instance, "Error", opensearchError, reason)
-								return nil, nil
+								reason := "percentageOfSourceShards can't exist with MaxShardSize or NumNewShards. Keep one of these"
+								r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
+								return nil, errors.New(reason)
 							}
 						}
 						if action.Shrink.TargetIndexNameTemplate != nil {
@@ -515,10 +537,8 @@ func (r *IsmPolicyReconciler) CreateISMPolicyRequest() (*requests.Policy, error)
 			policy.States = append(policy.States, requests.State{Actions: actions, Name: state.Name, Transitions: transitions})
 		}
 	}
-	ismPolicy := requests.Policy{
-		Policy: policy,
-	}
-	return &ismPolicy, nil
+
+	return &policy, nil
 }
 
 // Delete ISM policy from the OS cluster
@@ -527,10 +547,12 @@ func (r *IsmPolicyReconciler) Delete() error {
 	if r.instance.Status.ExistingISMPolicy == nil {
 		return nil
 	}
+
 	if *r.instance.Status.ExistingISMPolicy {
 		r.logger.Info("policy was pre-existing; not deleting")
 		return nil
 	}
+
 	var err error
 	r.cluster, err = util.FetchOpensearchCluster(r.client, r.ctx, types.NamespacedName{
 		Name:      r.instance.Spec.OpensearchRef.Name,
@@ -544,15 +566,18 @@ func (r *IsmPolicyReconciler) Delete() error {
 		// If the opensearch cluster doesn't exist, we don't need to delete anything
 		return nil
 	}
+
 	r.osClient, err = util.CreateClientForCluster(r.client, r.ctx, r.cluster, r.osClientTransport)
 	if err != nil {
 		return err
 	}
+
 	// If PolicyID not provided explicitly, use metadata.name by default
 	policyId := r.instance.Spec.PolicyID
-	if r.instance.Spec.PolicyID == "" {
+	if policyId == "" {
 		policyId = r.instance.Name
 	}
+
 	err = services.DeleteISMPolicy(r.ctx, r.osClient, policyId)
 	if err != nil {
 		return err

--- a/opensearch-operator/pkg/reconcilers/reconcilers.go
+++ b/opensearch-operator/pkg/reconcilers/reconcilers.go
@@ -14,13 +14,15 @@ import (
 )
 
 const (
-	opensearchPending     = "OpensearchPending"
-	opensearchError       = "OpensearchError"
-	opensearchAPIError    = "OpensearchAPIError"
-	opensearchRefMismatch = "OpensearchRefMismatch"
-	opensearchAPIUpdated  = "OpensearchAPIUpdated"
-	passwordError         = "PasswordError"
-	statusError           = "StatusUpdateError"
+	opensearchPending             = "OpensearchPending"
+	opensearchError               = "OpensearchError"
+	opensearchAPIError            = "OpensearchAPIError"
+	opensearchRefMismatch         = "OpensearchRefMismatch"
+	opensearchAPIUpdated          = "OpensearchAPIUpdated"
+	opensearchAPIUnchanged        = "OpensearchAPIUnchanged"
+	opensearchCustomResourceError = "OpensearchCustomResourceError"
+	passwordError                 = "PasswordError"
+	statusError                   = "StatusUpdateError"
 )
 
 type ComponentReconciler func() (reconcile.Result, error)


### PR DESCRIPTION
### Description
The ISM Policy reconciler was constantly trying to update the ISM Policy and it was not handling reconciliation requeue in some cases. There were possibly other issues as well. Below I have described what caused the different issues I encountered

- The ISM Policy request was different from the response, but they were both made with the same struct. This caused the reconciler to always see the existing ISM Policy and the ISM Policy from the CR as different and try to update it. I have created a separate struct model for each to separate the logic and in the code I now compare the existing policy with the policy from the CR by comparing both the Policy IDs and the policy spec
- There were some very complex cases in the code that were very difficult to understand so I have attempted to make the code more concise and easy to read and understand
- I have added reconciliation requeuing to all cases so the operator doesn't just stop reconciling the ISM Policy in some cases

One thing I am wondering is that I am not sure why we would want to create a CR without specifying the cluster ID and then the operator automatically links it to that cluster ID so it breaks if the OpenSearch CR is deleted. Is this intended and why? I'm talking about the section with the comment "Check cluster ref has not changed"

Tested cases:
- A new ISM Policy is created through a CR and the operator creates it in the OpenSearch Cluster
- The CR for an ISM Policy that is created by the operator is removed and the operator removes it in the OpenSearch Cluster
- An ISM Policy that already exists in the OpenSearch Cluster is created through a CR and the operator ignores it and marks it as existing
- The CR for an ISM Policy that was pre-existing and therefore was not created by the operator is removed and the operator does not remove the ISM Policy from the OpenSearch Cluster
- An ISM Policy that already exists in the OpenSearch Cluster is created through a CR and the operator ignores it and marks it as existing. The ISM Policy is then manually removed from the OpenSearch Cluster and the operator now applies the ISM Policy from the CR

The test for ISM Policies is currently failing miserably, but I decided to create the PR to get feedback before I dive into fixing it.

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/833
https://github.com/opensearch-project/opensearch-k8s-operator/issues/732
Possibly other issues

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
