### PR TITLE
Add ability to Set PodManagementPolicy specific to Nodegroup from Specs

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -4849,6 +4849,14 @@ spec:
                               type: string
                           type: object
                       type: object
+                    podManagementPolicy:
+                      default: OrderedReady
+                      description: PodManagementPolicyType defines the policy for
+                        creating pods under a stateful set.
+                      enum:
+                      - OrderedReady
+                      - Parallel
+                      type: string
                     priorityClassName:
                       type: string
                     probes:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -106,8 +107,12 @@ type ReadinessProbeConfig struct {
 }
 
 type NodePool struct {
-	Component                 string                            `json:"component"`
-	Replicas                  int32                             `json:"replicas"`
+	Component string `json:"component"`
+	Replicas  int32  `json:"replicas"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=OrderedReady;Parallel
+	// +kubebuilder:default:=OrderedReady
+	PodManagementPolicy       appsv1.PodManagementPolicyType    `json:"podManagementPolicy,omitempty"`
 	DiskSize                  string                            `json:"diskSize,omitempty"`
 	Resources                 corev1.ResourceRequirements       `json:"resources,omitempty"`
 	Jvm                       string                            `json:"jvm,omitempty"`

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -4849,6 +4849,14 @@ spec:
                               type: string
                           type: object
                       type: object
+                    podManagementPolicy:
+                      default: OrderedReady
+                      description: PodManagementPolicyType defines the policy for
+                        creating pods under a stateful set.
+                      enum:
+                      - OrderedReady
+                      - Parallel
+                      type: string
                     priorityClassName:
                       type: string
                     probes:

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -455,7 +455,7 @@ func NewSTSForNodePool(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: matchLabels,
 			},
-			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy: node.PodManagementPolicy,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -182,8 +182,9 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool,
 	}
 
 	// Detect cluster failure and initiate parallel recovery
+	// Unless PodManagementPolicy is already set as "Parallel" while cluster creation
 	if helpers.ParallelRecoveryMode() &&
-		(nodePool.Persistence == nil || nodePool.Persistence.PersistenceSource.PVC != nil) {
+		(nodePool.PodManagementPolicy != appsv1.ParallelPodManagement && (nodePool.Persistence == nil || nodePool.Persistence.PersistenceSource.PVC != nil)) {
 		// This logic only works if the STS uses PVCs
 		// First check if the STS already has a readable status (CurrentRevision == "" indicates the STS is newly created and the controller has not yet updated the status properly)
 		if existing.Status.CurrentRevision == "" {


### PR DESCRIPTION
### Description
Add ability to Set PodManagementPolicy for Node groups. Default to OrderedReady.

PodManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`.  This PR will help to set `Parallel` mode where pods are created in parallel to match the desired scale without waiting.

OpenSearch Operator is already managing deletion ordering itself, it wont matter much to have Parallel. 
If we look at the official helm chart of OpenSearch its already set to `Parallel` by default.

Also, for specs with PodManagementPolicy = Parallel, the recoverymode logic is bypassed.

### Issues Resolved


### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
