### PR TITLE
feat(helm): add option to set resources for initHelper

### DIFF
--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -27,6 +27,27 @@ spec:
     imagePullSecrets:
       {{ toYaml .Values.opensearchCluster.initHelper.imagePullSecrets | nindent 6 }}
     {{- end }}
+    {{- if .Values.opensearchCluster.initHelper.resources }}
+    resources:
+      {{- if .Values.opensearchCluster.initHelper.resources.requests }}
+      requests:
+        {{- if .Values.opensearchCluster.initHelper.resources.requests.memory }}
+        memory: {{ .Values.opensearchCluster.initHelper.resources.requests.memory }}
+        {{- end }}
+        {{- if .Values.opensearchCluster.initHelper.resources.requests.cpu }}
+        cpu: {{ .Values.opensearchCluster.initHelper.resources.requests.cpu }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.opensearchCluster.initHelper.resources.limits }}
+      limits:
+        {{- if .Values.opensearchCluster.initHelper.resources.limits.memory }}
+        memory: {{ .Values.opensearchCluster.initHelper.resources.limits.memory }}
+        {{- end }}
+        {{- if .Values.opensearchCluster.initHelper.resources.limits.cpu }}
+        cpu: {{ .Values.opensearchCluster.initHelper.resources.limits.cpu }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
   {{- end }}
   general:
     {{- if .Values.opensearchCluster.general.version }}

--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -29,24 +29,7 @@ spec:
     {{- end }}
     {{- if .Values.opensearchCluster.initHelper.resources }}
     resources:
-      {{- if .Values.opensearchCluster.initHelper.resources.requests }}
-      requests:
-        {{- if .Values.opensearchCluster.initHelper.resources.requests.memory }}
-        memory: {{ .Values.opensearchCluster.initHelper.resources.requests.memory }}
-        {{- end }}
-        {{- if .Values.opensearchCluster.initHelper.resources.requests.cpu }}
-        cpu: {{ .Values.opensearchCluster.initHelper.resources.requests.cpu }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.opensearchCluster.initHelper.resources.limits }}
-      limits:
-        {{- if .Values.opensearchCluster.initHelper.resources.limits.memory }}
-        memory: {{ .Values.opensearchCluster.initHelper.resources.limits.memory }}
-        {{- end }}
-        {{- if .Values.opensearchCluster.initHelper.resources.limits.cpu }}
-        cpu: {{ .Values.opensearchCluster.initHelper.resources.limits.cpu }}
-        {{- end }}
-      {{- end }}
+      {{- toYaml .Values.opensearchCluster.initHelper.resources | nindent 6 }}
     {{- end }}
   {{- end }}
   general:

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -27,6 +27,17 @@ opensearchCluster:
       limits:
         memory: "1Gi"
         cpu: "500m"
+  initHelper:
+    imagePullSecrets: []
+    # - registryKeySecretName
+    imagePullPolicy: IfNotPresent
+    resources: {}
+    # requests:
+    #   memory: "1Gi"
+    #   cpu: "500m"
+    # limits:
+    #   memory: "1Gi"
+    #   cpu: "500m"
   nodePools:
     - component: masters
       diskSize: "30Gi"


### PR DESCRIPTION
### Description

This PR adds an option to define resources for initHelper container.

### Issues Resolved

Closes this issue https://github.com/opensearch-project/opensearch-k8s-operator/issues/866

### Check List
- [X] Commits are signed per the DCO using --signoff 
- [X] Unittest added for the new/changed functionality and all unit tests are successful
- [X] Customer-visible features documented
- [X] No linter warnings (`make lint`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
