### PR TITLE
Decouple Helm Release with the Operator Release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,33 @@
+name: Release Helm Charts
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.14.3
+
+      - name: Run chart-releaser for opensearch-cluster
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: charts/opensearch-cluster
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,24 +23,23 @@ jobs:
         id: github-ver
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-
+  
       - name: Make sure helm chart has correct versions
         run: |
           sed -i -e 's/^appVersion:.*/appVersion: '$RELEASE_VERSION'/' charts/opensearch-operator/Chart.yaml
           sed -i -e 's/^version:.*/version: '$RELEASE_VERSION'/' charts/opensearch-operator/Chart.yaml
-          sed -i -e 's/^appVersion:.*/appVersion: '$RELEASE_VERSION'/' charts/opensearch-cluster/Chart.yaml
-          sed -i -e 's/^version:.*/version: '$RELEASE_VERSION'/' charts/opensearch-cluster/Chart.yaml
 
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
           version: v3.14.3
 
-      - name: Publish helm chart
-        uses: stefanprodan/helm-gh-pages@master
+      - name: Run chart-releaser for opensearch-operator
+        uses: helm/chart-releaser-action@v1.6.0
         with:
-          charts_dir: charts/
-          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts/opensearch-operator
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/charts/opensearch-cluster/CHANGELOG.md
+++ b/charts/opensearch-cluster/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
+
+## [2.6.1]
+### Added
+### Changed
+- Updated `version` and `appVersion` to `2.6.1` for the initial release after the helm release decouple.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+[Unreleased]: https://github.com/opensearch-project/opensearch-k8s-operator/compare/opensearch-operator-2.6.1...HEAD
+[2.6.1]: https://github.com/opensearch-project/opensearch-k8s-operator/compare/opensearch-operator-2.6.0...opensearch-operator-2.6.1
+

--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -2,5 +2,9 @@ apiVersion: v2
 name: opensearch-cluster
 description: A Helm chart for OpenSearch Cluster
 type: application
-version: 2.6.0
-appVersion: 2.6.0
+
+## The opensearch-cluster Helm Chart version
+version: 2.6.1
+
+## The operator version
+appVersion: 2.6.1

--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -12,12 +12,12 @@ description: The OpenSearch Operator Helm chart for Kubernetes
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
+# This is the opensearch-operator chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 2.6.0
 
-# This is the version number of the application being deployed. This version number should be
+# This is the version number of the application being deployed (the operator). This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.


### PR DESCRIPTION
### Description
Decouple Helm Release with the Operator Release.

- Update the `release.yaml` to exclude the helm release.
- Onboard new helm release workflow `helm-release.yaml`.
- The `helm-release.yaml` use the [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) which identifies the chart version and releases incrementally.
- The `helm-release.yaml` runs once the PR is merged to `main` and releases only once there is a change with chart `version`, inside the [charts/ ](https://github.com/opensearch-project/opensearch-k8s-operator/tree/main/charts)folder.

The expectation from the user is to create a PR with with updates changes, along with modifying the `version` of the chart, once merged the `helm/chart-releaser-action` will identify the new chart version and does a helm release.

Whenever there is an operator version release, the `appVersion` along with `version` has to be updated and thereafter the process is same  `helm/chart-releaser-action` will identify the new chart version and does a helm release.


### Issues Resolved
Coming from https://github.com/opensearch-project/opensearch-k8s-operator/issues/830

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
