### PR TITLE
Exclude helm tags for triggering the jenkins promotion workflow 

### DIFF
--- a/jenkins/release.jenkinsfile
+++ b/jenkins/release.jenkinsfile
@@ -66,7 +66,8 @@ pipeline {
                         currentBuild.description = """User/Timer: <a href="${ref_url}">${ref_url}</a>"""
                     }
 
-                    if (ref_final == null || ref_final == '') {
+
+                    if (ref_final == null || ref_final == '' || ref_final.startsWith('opensearch-operator') || ref_final.startsWith('opensearch-cluster')) { {
                         currentBuild.result = 'ABORTED'
                         error("Missing git tag reference.")
                     }


### PR DESCRIPTION
### Description
Exclude helm tags for triggering the jenkins promotion workflow. The Jenkins job https://build.ci.opensearch.org/job/opensearch-operator-release/ will be triggered once the tags are created, exclude this job trigger for helm chart tags and only trigger for actual release.

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/891

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
