### PR TITLE
Update example config

### DIFF
--- a/opensearch-operator/examples/2.x/opensearch-hot-warm-cold.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-hot-warm-cold.yaml
@@ -36,7 +36,7 @@ spec:
          memory: "512Mi"
          cpu: "200m"
   nodePools:
-    - component: cluster_managers
+    - component: cluster-managers
       replicas: 3
       jvm: -Xmx2G -Xms2G
       resources:


### PR DESCRIPTION
Correct a `nodePool` component to use a dash `-` instead of an underscore `_` as this string is used in a web address and needs to be URL compliant.

### Description
This makes a minor change to the `component` name in an example manifest. Using an underscore causes the operator to fail to create the resource with the following error message:
```
{
    "level": "error",
    "msg": "Reconciler error",
    "controller": "opensearchcluster",
    "controllerGroup": "opensearch.opster.io",
    "controllerKind": "OpenSearchCluster",
    "OpenSearchCluster": {
        "name": "central-logging-cluster-manager",
        "namespace": "monitoring"
    },
    "namespace": "monitoring",
    "name": "central-logging-cluster-manager",
    "error": "failed to create resource: creating resource failed: Service \"central-logging-opensearch-cluster_manager\" is invalid: metadata.name: Invalid value: \"central-logging-opensearch-cluster_manager\": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?');  failed to create resource: creating resource failed: StatefulSet.apps \"central-logging-cluster-manager-cluster_manager\" is invalid: metadata.name: Invalid value: \"central-logging-cluster-manager-cluster_manager\": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"
}
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
