### PR TITLE
feat(helm): add remaining options for bootstrap

### DIFF
--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -11,6 +11,22 @@ spec:
     additionalConfig:
       {{ toYaml .Values.opensearchCluster.bootstrap.additionalConfig | nindent 6 }}
     {{- end }}
+    {{- if .Values.opensearchCluster.bootstrap.resources }}
+    affinity:
+      {{ toYaml .Values.opensearchCluster.bootstrap.affinity | nindent 6 }}
+    {{- end }}
+    {{- if .Values.opensearchCluster.bootstrap.resources }}
+    jvm:
+      {{ toYaml .Values.opensearchCluster.bootstrap.jvm | nindent 6 }}
+    {{- end }}
+    {{- if .Values.opensearchCluster.bootstrap.resources }}
+    nodeSelector:
+      {{ toYaml .Values.opensearchCluster.bootstrap.nodeSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.opensearchCluster.bootstrap.resources }}
+    resources:
+      {{ toYaml .Values.opensearchCluster.bootstrap.resources | nindent 6 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.opensearchCluster.initHelper }}
   initHelper:

--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -7,26 +7,7 @@ metadata:
 spec:
   {{- if .Values.opensearchCluster.bootstrap }}
   bootstrap:
-    {{- if .Values.opensearchCluster.bootstrap.additionalConfig }}
-    additionalConfig:
-      {{ toYaml .Values.opensearchCluster.bootstrap.additionalConfig | nindent 6 }}
-    {{- end }}
-    {{- if .Values.opensearchCluster.bootstrap.resources }}
-    affinity:
-      {{ toYaml .Values.opensearchCluster.bootstrap.affinity | nindent 6 }}
-    {{- end }}
-    {{- if .Values.opensearchCluster.bootstrap.resources }}
-    jvm:
-      {{ toYaml .Values.opensearchCluster.bootstrap.jvm | nindent 6 }}
-    {{- end }}
-    {{- if .Values.opensearchCluster.bootstrap.resources }}
-    nodeSelector:
-      {{ toYaml .Values.opensearchCluster.bootstrap.nodeSelector | nindent 6 }}
-    {{- end }}
-    {{- if .Values.opensearchCluster.bootstrap.resources }}
-    resources:
-      {{ toYaml .Values.opensearchCluster.bootstrap.resources | nindent 6 }}
-    {{- end }}
+    {{ toYaml .Values.opensearchCluster.bootstrap | nindent 4 }}
   {{- end }}
   {{- if .Values.opensearchCluster.initHelper }}
   initHelper:


### PR DESCRIPTION
### Description
This PR adds the possibility to pass any option for the bootstrap component on the `opensearch-cluster` chart. As of now the only one that can be set using the chart is `additionalConfig`.

### Issues Resolved
 https://github.com/opensearch-project/opensearch-k8s-operator/issues/667 . At least on the chart aspect.

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
