### PR TITLE
Fix issue with conflicting User annotations

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1146,6 +1146,9 @@ The namespace of the `OpenSearchUser` must be the namespace the OpenSearch clust
 
 Note that a secret called `sample-user-password` will need to exist in the `default` namespace with the base64 encoded password in the `password` key.
 
+Also, it is possible to store multiple Users password in the same Secret. To do this, you should create a secret where
+each key will be equal to a username and value is a user password.
+
 #### Opensearch Roles
 
 It is possible to manage Opensearch roles in Kubernetes with the operator. The operator will not modify roles that already exist. You can create an example role as follows:

--- a/opensearch-operator/pkg/reconcilers/users.go
+++ b/opensearch-operator/pkg/reconcilers/users.go
@@ -244,7 +244,10 @@ func (r *UserReconciler) managePasswordSecret(username string, namespace string)
 		secret.Annotations = make(map[string]string)
 	}
 
-	secret.Annotations[helpers.OsUserNameAnnotation] = username
+	// Only put OsUserNameAnnotation if Secret contain a single key, otherwise, consider as multi-user Secret
+	if len(secret.Data) == 1 {
+		secret.Annotations[helpers.OsUserNameAnnotation] = username
+	}
 	secret.Annotations[helpers.OsUserNamespaceAnnotation] = namespace
 
 	if _, err := r.client.CreateSecret(&secret); err != nil {

--- a/opensearch-operator/pkg/reconcilers/users_test.go
+++ b/opensearch-operator/pkg/reconcilers/users_test.go
@@ -308,7 +308,6 @@ var _ = Describe("users reconciler", func() {
 		})
 		When("user exists and is different", func() {
 			BeforeEach(func() {
-				mockClient.EXPECT().GetSecret(mock.Anything, mock.Anything).Return(*password, nil)
 				userRequest := requests.User{
 					Attributes: map[string]string{
 						services.K8sAttributeField: "testuid",
@@ -342,6 +341,7 @@ var _ = Describe("users reconciler", func() {
 				)
 			})
 			It("should update the user", func() {
+				mockClient.EXPECT().GetSecret(mock.Anything, mock.Anything).Return(*password, nil)
 				var createdSecret *corev1.Secret
 				mockClient.On("CreateSecret", mock.Anything).
 					Return(func(secret *corev1.Secret) (*ctrl.Result, error) {
@@ -364,7 +364,8 @@ var _ = Describe("users reconciler", func() {
 				Expect(len(events)).To(Equal(1))
 				Expect(events[0]).To(Equal(fmt.Sprintf("Normal %s user updated in opensearch", opensearchAPIUpdated)))
 			})
-			It("should update the secret with opensearch annotations", func() {
+			It("should update the secret with User and Namespace annotations", func() {
+				mockClient.EXPECT().GetSecret(mock.Anything, mock.Anything).Return(*password, nil)
 				var createdSecret *corev1.Secret
 				mockClient.On("CreateSecret", mock.Anything).
 					Return(func(secret *corev1.Secret) (*ctrl.Result, error) {
@@ -384,6 +385,46 @@ var _ = Describe("users reconciler", func() {
 				expectedNamespace := "test-user"
 				Expect(actualName).To(Equal(expectedName))
 				Expect(actualNamespace).To(Equal(expectedNamespace))
+			})
+			It("should update the secret only with Namespace annotation", func() {
+				instance.Spec.PasswordFrom = corev1.SecretKeySelector{
+					Key: instance.Name,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "multi-user-secret",
+					},
+				}
+				password = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-user-secret",
+						Namespace: "test-user",
+					},
+					Data: map[string][]byte{
+						instance.Name: []byte("user1password"),
+						"test-user2":  []byte("user2password"),
+					},
+				}
+				mockClient.EXPECT().GetSecret(mock.Anything, mock.Anything).Return(*password, nil)
+
+				var createdSecret *corev1.Secret
+				mockClient.On("CreateSecret", mock.Anything).
+					Return(func(secret *corev1.Secret) (*ctrl.Result, error) {
+						createdSecret = secret
+						secret.Name = "multi-user-secret"
+						return &ctrl.Result{}, nil
+					})
+				defer close(recorder.Events)
+				_, err := reconciler.Reconcile()
+				Expect(err).ToNot(HaveOccurred())
+
+				annotations := createdSecret.GetAnnotations()
+
+				_, nameOk := annotations[helpers.OsUserNameAnnotation]
+				actualNamespace := annotations[helpers.OsUserNamespaceAnnotation]
+
+				expectedNamespace := "test-user"
+				Expect(actualNamespace).To(Equal(expectedNamespace))
+				Expect(nameOk).To(BeFalse(), "Expected Name annotation to be absent for Secret with multiple user passwords")
+				Expect(len(createdSecret.Data)).To(Equal(2), "Expected secret to contain 2 keys")
 			})
 		})
 		When("user does not exist", func() {


### PR DESCRIPTION
### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
