### PR TITLE
Add Missing caSecret in Helm Template

### DIFF
--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -332,11 +332,11 @@ spec:
         secret:
           name: {{ .Values.opensearchCluster.security.tls.transport.secret.name }}
         {{- end }}
-        {{- if .Values.opensearchCluster.security.tls.transport.adminDn }}
         {{- if .Values.opensearchCluster.security.tls.transport.caSecret }}
         caSecret:
           name: {{ .Values.opensearchCluster.security.tls.transport.caSecret.name }}
         {{- end }}
+        {{- if .Values.opensearchCluster.security.tls.transport.adminDn }}
         adminDn:
           {{ toYaml .Values.opensearchCluster.security.tls.transport.adminDn | nindent 10 }}
         {{- end }}

--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -333,6 +333,10 @@ spec:
           name: {{ .Values.opensearchCluster.security.tls.transport.secret.name }}
         {{- end }}
         {{- if .Values.opensearchCluster.security.tls.transport.adminDn }}
+        {{- if .Values.opensearchCluster.security.tls.transport.caSecret }}
+        caSecret:
+          name: {{ .Values.opensearchCluster.security.tls.transport.caSecret.name }}
+        {{- end }}
         adminDn:
           {{ toYaml .Values.opensearchCluster.security.tls.transport.adminDn | nindent 10 }}
         {{- end }}
@@ -349,6 +353,10 @@ spec:
         {{- if .Values.opensearchCluster.security.tls.http.secret }}
         secret:
           name: {{ .Values.opensearchCluster.security.tls.http.secret.name }}
+        {{- end }}
+        {{- if .Values.opensearchCluster.security.tls.http.caSecret }}
+        caSecret:
+          name: {{ .Values.opensearchCluster.security.tls.http.caSecret.name }}
         {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
### Description
Added missing caSecret option in opensearch-cluster helm chart

### Issues Resolved
#902

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
