### PR TITLE
add imagepullsecret option to general and dashboard section of...

### DIFF
--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -36,6 +36,10 @@ spec:
     {{- if .Values.opensearchCluster.general.image }}
     image: {{ .Values.opensearchCluster.general.image | quote }}
     {{- end }}
+    {{- if .Values.opensearchCluster.general.imagePullSecrets }}
+    imagePullSecrets:
+      {{ toYaml .Values.opensearchCluster.general.imagePullSecrets | nindent 6 }}
+    {{- end }}
     {{- if .Values.opensearchCluster.general.httpPort }}
     httpPort: {{ .Values.opensearchCluster.general.httpPort }}
     {{- end }}
@@ -91,6 +95,10 @@ spec:
   dashboards:
     {{- if .Values.opensearchCluster.dashboards.image }}
     image: {{ .Values.opensearchCluster.dashboards.image | quote }}
+    {{- end }}
+    {{- if .Values.opensearchCluster.dashboards.imagePullSecrets }}
+    imagePullSecrets:
+      {{ toYaml .Values.opensearchCluster.dashboards.imagePullSecrets | nindent 6 }}
     {{- end }}
     version: {{ .Values.opensearchCluster.dashboards.version }}
     {{- if .Values.opensearchCluster.dashboards.enable }}


### PR DESCRIPTION
...opensearch-cluster chart

### Description
add possibility to set image pull secret for general and dashboard images in opensearch-cluster helm chart

### Issues Resolved
[904](https://github.com/opensearch-project/opensearch-k8s-operator/issues/904)

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
