### PR TITLE
Jenkinsfile bug fix

### DIFF
--- a/jenkins/release.jenkinsfile
+++ b/jenkins/release.jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
                     }
 
 
-                    if (ref_final == null || ref_final == '' || ref_final.startsWith('opensearch-operator') || ref_final.startsWith('opensearch-cluster')) { {
+                    if (ref_final == null || ref_final == '' || ref_final.startsWith('opensearch-operator') || ref_final.startsWith('opensearch-cluster')) {
                         currentBuild.result = 'ABORTED'
                         error("Missing git tag reference.")
                     }


### PR DESCRIPTION
### Description
Coming from initial PR https://github.com/opensearch-project/opensearch-k8s-operator/pull/893 to exclude helm tags for triggering the jenkins promotion workflow, a small bug caused the build failure https://build.ci.opensearch.org/job/opensearch-operator-release/19/console.

The helm version update PR was merged https://github.com/opensearch-project/opensearch-k8s-operator/pull/754 causing it to create a tag and run the jenkins promotion workflow.

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/830

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
