### PR TITLE
feat: fix istio protocol selection

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -265,7 +265,7 @@ func NewSTSForNodePool(
 		FailureThreshold:    livenessProbeFailureThreshold,
 		SuccessThreshold:    livenessProbeSuccessThreshold,
 		InitialDelaySeconds: livenessProbeInitialDelaySeconds,
-		ProbeHandler:        corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: cr.Spec.General.HttpPort}}},
+		ProbeHandler:        corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: cr.Spec.General.Port}}},
 	}
 
 	startupProbe := corev1.Probe{
@@ -651,7 +651,7 @@ func NewServiceForCR(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name:     "http",
+					Name:     "https",
 					Protocol: "TCP",
 					Port:     cr.Spec.General.HttpPort,
 					TargetPort: intstr.IntOrString{

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -265,7 +265,7 @@ func NewSTSForNodePool(
 		FailureThreshold:    livenessProbeFailureThreshold,
 		SuccessThreshold:    livenessProbeSuccessThreshold,
 		InitialDelaySeconds: livenessProbeInitialDelaySeconds,
-		ProbeHandler:        corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: cr.Spec.General.Port}}},
+		ProbeHandler:        corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: cr.Spec.General.HttpPort}}},
 	}
 
 	startupProbe := corev1.Probe{


### PR DESCRIPTION
### Description
Fix istio protocol autodetection to allow https communication using istio. (Because operator will use https always and can't be disabled)

### Issues Resolved
None

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
