### PR TITLE
Automatically update User password on Secret change

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_security_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_security_service.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	K8sAttributeField = "k8s-uid"
+	K8sAttributeField              = "k8s-uid"
+	K8sAttributeSecretVersionField = "secret-version"
 
 	ROLES         = "roles"
 	INTERNALUSERS = "internalusers"

--- a/opensearch-operator/pkg/reconcilers/users_test.go
+++ b/opensearch-operator/pkg/reconcilers/users_test.go
@@ -60,8 +60,9 @@ var _ = Describe("users reconciler", func() {
 		}
 		password = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-password",
-				Namespace: "test-user",
+				Name:            "test-password",
+				Namespace:       "test-user",
+				ResourceVersion: "123456789",
 			},
 			Data: map[string][]byte{
 				"password": []byte("testpassword"),
@@ -231,7 +232,8 @@ var _ = Describe("users reconciler", func() {
 				mockClient.EXPECT().GetSecret(mock.Anything, mock.Anything).Return(*password, nil)
 				userRequest := requests.User{
 					Attributes: map[string]string{
-						services.K8sAttributeField: "testuid",
+						services.K8sAttributeField:              "testuid",
+						services.K8sAttributeSecretVersionField: "123456789",
 					},
 				}
 				transport.RegisterResponder(
@@ -310,7 +312,8 @@ var _ = Describe("users reconciler", func() {
 			BeforeEach(func() {
 				userRequest := requests.User{
 					Attributes: map[string]string{
-						services.K8sAttributeField: "testuid",
+						services.K8sAttributeField:              "testuid",
+						services.K8sAttributeSecretVersionField: "123456789",
 					},
 				}
 				recorder = record.NewFakeRecorder(1)
@@ -360,6 +363,34 @@ var _ = Describe("users reconciler", func() {
 				for msg := range recorder.Events {
 					events = append(events, msg)
 				}
+				Expect(createdSecret).ToNot(BeNil())
+				Expect(len(events)).To(Equal(1))
+				Expect(events[0]).To(Equal(fmt.Sprintf("Normal %s user updated in opensearch", opensearchAPIUpdated)))
+			})
+			It("should update the user password", func() {
+				instance.Spec.BackendRoles = []string{}
+				password.ObjectMeta.ResourceVersion = "987654321"
+				mockClient.EXPECT().GetSecret(mock.Anything, mock.Anything).Return(*password, nil)
+				var createdSecret *corev1.Secret
+				mockClient.On("CreateSecret", mock.Anything).
+					Return(func(secret *corev1.Secret) (*ctrl.Result, error) {
+						createdSecret = secret
+						return &ctrl.Result{}, nil
+					})
+
+				go func() {
+					defer GinkgoRecover()
+					defer close(recorder.Events)
+
+					_, err := reconciler.Reconcile()
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				var events []string
+				for msg := range recorder.Events {
+					events = append(events, msg)
+				}
+
 				Expect(createdSecret).ToNot(BeNil())
 				Expect(len(events)).To(Equal(1))
 				Expect(events[0]).To(Equal(fmt.Sprintf("Normal %s user updated in opensearch", opensearchAPIUpdated)))


### PR DESCRIPTION
### Description
Solving a problem with updating User password if it was changed in the Secret by adding an additional attribute to the Opensearch user - `secret-version`. The logic relies on a default Kubernetes `ResourceVersion` behavior.

### Issues Resolved
Closes #908 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
