### PR TITLE
Avoid dialog in terminal during s3 key creation

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -937,7 +937,9 @@ func NewBootstrapPod(
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				/usr/share/opensearch/bin/opensearch-keystore create
+				if [ ! -f /usr/share/opensearch/config/opensearch.keystore ]; then
+				  /usr/share/opensearch/bin/opensearch-keystore create
+				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -420,11 +420,13 @@ func NewSTSForNodePool(
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				/usr/share/opensearch/bin/opensearch-keystore create
+				if [ ! -f /usr/share/opensearch/config/opensearch.keystore ]; then
+				  /usr/share/opensearch/bin/opensearch-keystore create
+				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i"
+				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
@@ -939,7 +941,7 @@ func NewBootstrapPod(
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i"
+				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup


### PR DESCRIPTION
### Description
Fixes error when creating cluster with snapshot and s3 keys.

Heres the "issue":

### What is the bug?
When using snapshot feature to s3 via the operator we have to add s3 keys.

When specifying these (at least in my k8s cluster) i have issues with these secrets already exsisting. The current command is basically asking the user to confirm the creation of keystore file and also for each already existing key in this keystore. We never get our s3 accessKey/secretKey written.

### How can one reproduce the bug?
Create an opensearch cluster using the operator. Enable snapshot and s3 key mapping like shown in the attached cluster.yaml (feel free to use this in the docs?)

### What is the expected behavior?
s3 keys would work so snapshots can be created

### What is your host/environment?
kubernetes

### Do you have any screenshots?
No

### Do you have any additional context?

See attached cluster.txt (yaml)
[cluster.txt](https://github.com/user-attachments/files/18364705/cluster.txt)



### Issues Resolved
Unable to create an issue (Green button not working in my browser)...

### Check List
- [no] Commits are signed per the DCO using --signoff 
- [no] Unittest added for the new/changed functionality and all unit tests are successful
- [no] Customer-visible features documented
- [no] No linter warnings (`make lint`)


Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
