### PR TITLE
helm template: switch places for default value

### DIFF
--- a/charts/opensearch-cluster/templates/_helpers.tpl
+++ b/charts/opensearch-cluster/templates/_helpers.tpl
@@ -6,7 +6,7 @@ Expand the name of the chart.
 {{- end }}
 
 {{- define "opensearch-cluster.cluster-name" -}}
-{{- default .Values.cluster.name .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- default .Release.Name .Values.cluster.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### Description
Names the cluster according to `.Values.cluster.name`, it seems to treat the Helm Release-name as the given value now, so it will be ignoring the config from `.Values.cluster.name`

### Issues Resolved

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
