### PR TITLE
Fixed the duplicate key entries

### DIFF
--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -17,12 +17,12 @@ spec:
   {{- end }}
   {{- with .Values.cluster.dashboards }}
   dashboards:
-    {{- . | toYaml | nindent 4 }}
+    {{- omit . "image" | toYaml | nindent 4 }}
     image: {{ .image }}:{{ .version }}
   {{- end }}
   {{- with .Values.cluster.general }}
   general:
-    {{- . | toYaml | nindent 4 }}
+    {{- omit . "image" "serviceName" | toYaml | nindent 4 }}
     image: {{ .image }}:{{ .version }}
     serviceName: {{ .serviceName | default $clusterName }}
   {{- end }}


### PR DESCRIPTION
### Description
Duplicate keys under general and dashboards in opensearch-cluster helm chart is removed.

### Issues Resolved
Fixes #939

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] No linter warnings (`make lint`)

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
