### PR TITLE
Fix userguide for projectedVolumes

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -756,7 +756,7 @@ spec:
       path: /path/to/mount/volume
       projected:
         sources:
-          serviceAccountToken:
+        - serviceAccountToken:
             path: "token"
   dashboards:
     additionalVolumes:


### PR DESCRIPTION
### Description
Deploying an OpenSearch cluster with projected volumes as described in the current documentation leads to the following error
```
OpenSearchCluster.opensearch.opster.io "opensearch" is invalid: spec.general.additionalVolumes[1].projected.sources: Invalid value: "object": spec.general.additionalVolumes[1].projected.sources in body must be of type array: "object"
```
This PR corrects the userguide on how to add a projected volume to OpenSearchCluster CRD.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
