### PR TITLE
[WIP] Add DisableSSL option to OpenSearchCluster CRD

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -3351,6 +3351,9 @@ spec:
                     type: string
                   defaultRepo:
                     type: string
+                  disableSSL:
+                    description: Disable SSL for the cluster
+                    type: boolean
                   drainDataNodes:
                     description: Drain data nodes controls whether to drain data notes
                       on rolling restart operations

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -70,6 +70,8 @@ type GeneralConfig struct {
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// Set security context for the cluster pods' container
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+	// Disable SSL for the cluster
+	DisableSSL bool `json:"disableSSL,omitempty"`
 }
 
 type PdbConfig struct {

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -3351,6 +3351,9 @@ spec:
                     type: string
                   defaultRepo:
                     type: string
+                  disableSSL:
+                    description: Disable SSL for the cluster
+                    type: boolean
                   drainDataNodes:
                     description: Drain data nodes controls whether to drain data notes
                       on rolling restart operations

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -286,7 +286,7 @@ func NewSTSForNodePool(
 	} else {
 		curlCmd += "https://localhost:" + fmt.Sprint(httpPort)
 	}
-	
+
 	readinessProbe := corev1.Probe{
 		InitialDelaySeconds: readinessProbeInitialDelaySeconds,
 		PeriodSeconds:       readinessProbePeriodSeconds,
@@ -1049,13 +1049,13 @@ func PortForCluster(cr *opsterv1.OpenSearchCluster) int32 {
 
 func URLForCluster(cr *opsterv1.OpenSearchCluster) string {
 	httpPort := PortForCluster(cr)
-	
+
 	// Use HTTP instead of HTTPS if SSL is disabled
 	protocol := "https"
 	if cr.Spec.General.DisableSSL {
 		protocol = "http"
 	}
-	
+
 	return fmt.Sprintf("%s://%s.svc.%s:%d", protocol, DnsOfService(cr), helpers.ClusterDnsBase(), httpPort)
 }
 

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -280,7 +280,13 @@ func NewSTSForNodePool(
 	// Because the http endpoint requires auth we need to do it as a curl script
 	httpPort := PortForCluster(cr)
 
-	curlCmd := "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail https://localhost:" + fmt.Sprint(httpPort)
+	curlCmd := "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail "
+	if cr.Spec.General.DisableSSL {
+		curlCmd += "http://localhost:" + fmt.Sprint(httpPort)
+	} else {
+		curlCmd += "https://localhost:" + fmt.Sprint(httpPort)
+	}
+	
 	readinessProbe := corev1.Probe{
 		InitialDelaySeconds: readinessProbeInitialDelaySeconds,
 		PeriodSeconds:       readinessProbePeriodSeconds,
@@ -576,6 +582,11 @@ func NewSTSForNodePool(
 				Privileged: pointer.Bool(true),
 			},
 		})
+	}
+
+	// Add plugins.security.disabled=true to environment variables if SSL is disabled
+	if cr.Spec.General.DisableSSL {
+		extraConfig["plugins.security.disabled"] = "true"
 	}
 
 	return sts
@@ -1038,7 +1049,14 @@ func PortForCluster(cr *opsterv1.OpenSearchCluster) int32 {
 
 func URLForCluster(cr *opsterv1.OpenSearchCluster) string {
 	httpPort := PortForCluster(cr)
-	return fmt.Sprintf("https://%s.svc.%s:%d", DnsOfService(cr), helpers.ClusterDnsBase(), httpPort)
+	
+	// Use HTTP instead of HTTPS if SSL is disabled
+	protocol := "https"
+	if cr.Spec.General.DisableSSL {
+		protocol = "http"
+	}
+	
+	return fmt.Sprintf("%s://%s.svc.%s:%d", protocol, DnsOfService(cr), helpers.ClusterDnsBase(), httpPort)
 }
 
 func PasswordSecret(cr *opsterv1.OpenSearchCluster, username, password string) *corev1.Secret {
@@ -1227,6 +1245,12 @@ func NewServiceMonitor(cr *opsterv1.OpenSearchCluster) *monitoring.ServiceMonito
 		monitorLabel[k] = v
 	}
 
+	// Use HTTP instead of HTTPS for ServiceMonitor if SSL is disabled
+	scheme := "https"
+	if cr.Spec.General.DisableSSL {
+		scheme = "http"
+	}
+
 	return &monitoring.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name + "-monitor",
@@ -1251,7 +1275,7 @@ func NewServiceMonitor(cr *opsterv1.OpenSearchCluster) *monitoring.ServiceMonito
 					BearerTokenFile: "",
 					HonorLabels:     false,
 					BasicAuth:       &user,
-					Scheme:          "https",
+					Scheme:          scheme,
 				},
 			},
 			Selector:          selector,


### PR DESCRIPTION
### Description
This PR adds the ability to disable SSL/TLS in the OpenSearch cluster by introducing a new configuration option DisableSSL in the OpenSearchCluster CRD. When enabled, this option configures the cluster to operate without SSL encryption, which can be useful for development environments or in secure, isolated networks.

### Issues Resolved
#967
### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
