### PR TITLE
Implement single-node cluster support (#233)

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -78,8 +78,6 @@ If you'd like to delete your cluster, run: `kubectl delete -f cluster.yaml`. The
 
 The minimal cluster you deployed in this section is only intended for demo purposes. Please see the next sections on how to configure and manage the different aspects of your cluster.
 
-**Single-Node clusters are currently not supported**. Your cluster must have at least 3 nodes with the `master/cluster_manager` role configured.
-
 ## Configuring the operator
 
 The majority of this guide deals with configuring and managing OpenSearch clusters. But there are some general options that can be configured for the operator itself. All of this is done using helm values your provide during installation: `helm install opensearch-operator opensearch-operator/opensearch-operator -f values.yaml`.

--- a/opensearch-operator/functionaltests/operatortests/deploy-single-node.yaml
+++ b/opensearch-operator/functionaltests/operatortests/deploy-single-node.yaml
@@ -1,0 +1,32 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchCluster
+metadata:
+  name: deploy-single-node
+  namespace: default
+spec:
+  general:
+    version: 1.3.0
+    httpPort: 9200
+    vendor: opensearch
+    serviceName: deploy-single-node
+    additionalConfig:
+      cluster.routing.allocation.disk.watermark.low: 500m
+      cluster.routing.allocation.disk.watermark.high: 300m
+      cluster.routing.allocation.disk.watermark.flood_stage: 100m
+  confMgmt:
+    smartScaler: true
+  nodePools:
+    - component: masters
+      replicas: 1
+      diskSize: "5Gi"
+      NodeSelector:
+      resources:
+         requests:
+            memory: "1Gi"
+            cpu: "500m"
+         limits:
+            memory: "2Gi"
+            cpu: "500m"
+      roles:
+        - "master"
+        - "data"

--- a/opensearch-operator/functionaltests/operatortests/deploy_single_node_test.go
+++ b/opensearch-operator/functionaltests/operatortests/deploy_single_node_test.go
@@ -1,0 +1,37 @@
+package operatortests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("DeploySingleNode", Ordered, func() {
+	name := "deploy-single-node"
+	namespace := "default"
+
+	BeforeAll(func() {
+		CreateKubernetesObjects(name)
+	})
+
+	When("creating a cluster", Ordered, func() {
+		It("should have 1 ready master pod", func() {
+			sts := appsv1.StatefulSet{}
+			Eventually(func() int32 {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name + "-masters", Namespace: namespace}, &sts)
+				if err == nil {
+					return sts.Status.ReadyReplicas
+				}
+				return 0
+			}, time.Minute*15, time.Second*5).Should(Equal(int32(1)))
+		})
+	})
+
+	AfterAll(func() {
+		Cleanup(name)
+	})
+})

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -445,6 +445,15 @@ func NewSTSForNodePool(
 		initContainers = append(initContainers, keystoreInitContainer)
 	}
 
+	discoveryType := ""
+	initialMasterNodes := BootstrapPodName(cr)
+
+	// Support for single-node clusters
+	if cr.Spec.NodePools[0].Replicas < 2 {
+		discoveryType = "single-node"
+		initialMasterNodes = ""
+	}
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name + "-" + node.Component,
@@ -472,7 +481,11 @@ func NewSTSForNodePool(
 							Env: []corev1.EnvVar{
 								{
 									Name:  "cluster.initial_master_nodes",
-									Value: BootstrapPodName(cr),
+									Value: initialMasterNodes,
+								},
+								{
+									Name:  "discovery.type",
+									Value: discoveryType,
 								},
 								{
 									Name:  "discovery.seed_hosts",


### PR DESCRIPTION
### Description
Add support for single-node OpenSearch clusters. 

### Issues Resolved
Closes #233

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
