### PR TITLE
Add additionalConfig settings to overwrite default security plugin settings

### DIFF
--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -67,6 +67,11 @@ func (r *ConfigurationReconciler) Reconcile() (ctrl.Result, error) {
 		r.reconcilerContext.AddConfig("plugins.security.system_indices.enabled", "true")
 		r.reconcilerContext.AddConfig("plugins.security.system_indices.indices", string(systemIndices))
 
+		if len(r.instance.Spec.General.AdditionalConfig) > 0 {
+			for k, v := range r.instance.Spec.General.AdditionalConfig {
+				r.reconcilerContext.AddConfig(k, v)
+			}
+		}
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
### Description

This PR seeks to build a way to overwrite the default security plugin settings from [here](https://github.com/opensearch-project/opensearch-k8s-operator/blob/b80b606964dccb0dd18d1ea01d0c0815eaf0be68/opensearch-operator/pkg/reconcilers/configuration.go#L62-L68). I'm not able to overwrite this settings by adding `plugins.security.audit.type: log4j` to `spec.general.additionalConfig`. I can confirm that these changes produce the desired output by looking at the output being printed [here](https://github.com/opensearch-project/opensearch-k8s-operator/blob/b80b606964dccb0dd18d1ea01d0c0815eaf0be68/opensearch-operator/pkg/reconcilers/configuration.go#L86), but I do not know how to adequately test the changes in this repo. Opening this up in Draft initially before adding the steps to test this change. 

### Issues Resolved

Resolves https://github.com/opensearch-project/opensearch-k8s-operator/issues/736

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
