### PR TITLE
added flag to apply ism policy to existing indices

### DIFF
--- a/opensearch-operator/api/v1/opensearchism_types.go
+++ b/opensearch-operator/api/v1/opensearchism_types.go
@@ -43,8 +43,10 @@ type OpenSearchISMPolicySpec struct {
 	// The default starting state for each index that uses this policy.
 	DefaultState string `json:"defaultState"`
 	// A human-readable description of the policy.
-	Description       string             `json:"description"`
-	ErrorNotification *ErrorNotification `json:"errorNotification,omitempty"`
+	Description string `json:"description"`
+	// If true, apply the policy to existing indices that match the index patterns in the ISM template.
+	ApplyToExistingIndices *bool              `json:"applyToExistingIndices,omitempty"`
+	ErrorNotification      *ErrorNotification `json:"errorNotification,omitempty"`
 	// Specify an ISM template pattern that matches the index to apply the policy.
 	ISMTemplate *ISMTemplate `json:"ismTemplate,omitempty"`
 	PolicyID    string       `json:"policyId,omitempty"`

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -1261,6 +1261,11 @@ func (in *OpenSearchISMPolicyList) DeepCopyObject() runtime.Object {
 func (in *OpenSearchISMPolicySpec) DeepCopyInto(out *OpenSearchISMPolicySpec) {
 	*out = *in
 	out.OpensearchRef = in.OpensearchRef
+	if in.ApplyToExistingIndices != nil {
+		in, out := &in.ApplyToExistingIndices, &out.ApplyToExistingIndices
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ErrorNotification != nil {
 		in, out := &in.ErrorNotification, &out.ErrorNotification
 		*out = new(ErrorNotification)

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
@@ -42,6 +42,10 @@ spec:
             description: ISMPolicySpec is the specification for the ISM policy for
               OS.
             properties:
+              applyToExistingIndices:
+                description: If true, apply the policy to existing indices that match
+                  the index patterns in the ISM template.
+                type: boolean
               defaultState:
                 description: The default starting state for each index that uses this
                   policy.

--- a/opensearch-operator/examples/2.x/opensearch-ismpolicy-apply.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-ismpolicy-apply.yaml
@@ -1,0 +1,26 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchISMPolicy
+metadata:
+  name: test-policy-apply
+spec:
+  opensearchCluster:
+    name: opensearch-cluster
+  applyToExistingIndices: true
+  description: "Test ISM policy - Apply to existing indices is true"
+  defaultState: "hot"
+  ismTemplate:
+    indexPatterns:
+      - "test-*"
+  states:
+    - name: hot
+      actions:
+        - replicaCount:
+            numberOfReplicas: 2
+      transitions:
+        - stateName: warm
+          conditions:
+            minIndexAge: "1d"
+    - name: warm
+      actions:
+        - replicaCount:
+            numberOfReplicas: 1

--- a/opensearch-operator/examples/2.x/opensearch-ismpolicy-noApply.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-ismpolicy-noApply.yaml
@@ -1,0 +1,26 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchISMPolicy
+metadata:
+  name: test-policy-no-apply
+spec:
+  opensearchCluster:
+    name: opensearch-cluster
+  applyToExistingIndices: false
+  description: "Test ISM policy 2 - Apply to existing indices is false"
+  defaultState: "hot"
+  ismTemplate:
+    indexPatterns:
+      - "test-*"
+  states:
+    - name: hot
+      actions:
+        - replicaCount:
+            numberOfReplicas: 2
+      transitions:
+        - stateName: warm
+          conditions:
+            minIndexAge: "1d"
+    - name: warm
+      actions:
+        - replicaCount:
+            numberOfReplicas: 1

--- a/opensearch-operator/opensearch-gateway/services/http_request.go
+++ b/opensearch-operator/opensearch-gateway/services/http_request.go
@@ -29,6 +29,26 @@ func doHTTPGet(ctx context.Context, client *opensearch.Client, path strings.Buil
 	return &opensearchapi.Response{StatusCode: res.StatusCode, Body: res.Body, Header: res.Header}, nil
 }
 
+// doHTTPPost performs a HTTP POST request
+func doHTTPPost(ctx context.Context, client *opensearch.Client, path strings.Builder, body io.Reader) (*opensearchapi.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, path.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	req.Header.Add(headerContentType, jsonContentHeader)
+
+	res, err := client.Perform(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &opensearchapi.Response{StatusCode: res.StatusCode, Body: res.Body, Header: res.Header}, nil
+}
+
 // doHTTPHead performs a HTTP HEAD request
 func doHTTPHead(ctx context.Context, client *opensearch.Client, path strings.Builder) (*opensearchapi.Response, error) {
 	req, err := http.NewRequest(http.MethodHead, path.String(), nil)

--- a/opensearch-operator/opensearch-gateway/services/os_ism_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_ism_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/requests"
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
@@ -90,5 +91,77 @@ func DeleteISMPolicy(ctx context.Context, service *OsClusterClient, policyName s
 	if resp.IsError() {
 		return fmt.Errorf("failed to delete ism policy: %s", resp.String())
 	}
+	return nil
+}
+
+// IndexInfo represents the response from OpenSearch for indices
+type IndexInfo struct {
+	Index string `json:"index"`
+}
+
+// GetIndices retrieves indices matching the given pattern from OpenSearch
+func GetIndices(ctx context.Context, service *OsClusterClient, pattern string) ([]string, error) {
+	resp, err := service.GetIndices(ctx, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call GetIndices: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check for OpenSearch error response
+	if resp.IsError() {
+		return nil, fmt.Errorf("OpenSearch API error: %s", resp.String())
+	}
+
+	// Parse response
+	var indices []IndexInfo
+	if err := json.Unmarshal(bodyBytes, &indices); err != nil {
+		// Log the raw response for debugging
+		log.FromContext(ctx).V(1).Info(fmt.Sprintf("Raw response: %s", string(bodyBytes)))
+		return nil, fmt.Errorf("failed to parse indices response: %w", err)
+	}
+
+	// Handle empty result
+	if len(indices) == 0 {
+		log.FromContext(ctx).V(1).Info(fmt.Sprintf("No indices found matching pattern: %s", pattern))
+		return []string{}, nil
+	}
+
+	// Extract index names
+	indexNames := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		indexNames = append(indexNames, idx.Index)
+	}
+
+	// Log the found indices
+	log.FromContext(ctx).V(1).Info(fmt.Sprintf("Found indices matching pattern '%s': %v", pattern, indexNames))
+
+	return indexNames, nil
+}
+
+// AddISMPolicyRequest is the request body for adding an ISM policy to an index
+type AddISMPolicyRequest struct {
+	PolicyID string `json:"policy_id"`
+}
+
+// AddPolicyToIndex applies an ISM policy to the specified index
+func AddPolicyToIndex(ctx context.Context, service *OsClusterClient, indexName string, policyId string) error {
+	body := opensearchutil.NewJSONReader(AddISMPolicyRequest{PolicyID: policyId})
+
+	resp, err := service.AddPolicyToIndex(ctx, indexName, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.IsError() {
+		return fmt.Errorf("failed to add policy to index: %s", resp.String())
+	}
+
 	return nil
 }

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -197,6 +197,16 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 				RequeueAfter: defaultRequeueAfter,
 			}, retErr
 		}
+		// Apply to existing indices
+		if err := r.applyPolicyToExistingIndices(policyId); err != nil {
+			reason = "failed to apply policy to existing indices"
+			r.logger.Error(err, reason)
+			r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, err
+		}
 		// Mark the ISM Policy as not pre-existing (created by the operator)
 		retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 			object.(*opsterv1.OpenSearchISMPolicy).Status.ExistingISMPolicy = pointer.Bool(false)
@@ -546,6 +556,41 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 	}
 
 	return &policy, nil
+}
+
+func (r *IsmPolicyReconciler) applyPolicyToExistingIndices(policyId string) error {
+	if r.instance.Spec.ApplyToExistingIndices == nil || !*r.instance.Spec.ApplyToExistingIndices {
+		return nil
+	}
+
+	if r.instance.Spec.ISMTemplate == nil || len(r.instance.Spec.ISMTemplate.IndexPatterns) == 0 {
+		return nil
+	}
+
+	for _, pattern := range r.instance.Spec.ISMTemplate.IndexPatterns {
+
+		// Get existing indices matching the pattern
+		indices, err := services.GetIndices(r.ctx, r.osClient, pattern)
+
+		if err != nil {
+			reason := fmt.Sprintf("failed to get indices matching pattern %s", pattern)
+			r.logger.Error(err, reason)
+			return fmt.Errorf("%s: %w", reason, err)
+		}
+
+		// Apply policy to each index
+		for _, index := range indices {
+			if err := services.AddPolicyToIndex(r.ctx, r.osClient, index, policyId); err != nil {
+				reason := fmt.Sprintf("failed to apply policy to index %s", index)
+				return fmt.Errorf("%s: %w", reason, err)
+			}
+			r.logger.V(1).Info(fmt.Sprintf("Applied ISM Policy '%s' to existing index '%s'", policyId, index))
+		}
+	}
+
+	r.recorder.Event(r.instance, "Normal", opensearchAPIUpdated, "ISM policy applied to existing indices")
+
+	return nil
 }
 
 // Delete ISM policy from the OS cluster


### PR DESCRIPTION
### Description
This change introduces an ism policy flag called "applyToExistingIndices", which, when true, will apply the created ism policy to all existing indices, which have no ism policy and which pattern matches the ism policy pattern in question.

### Issues Resolved
Closes #828 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
