### PR TITLE
feat(chart): add cluster.general.monitoring.labels field to values.yaml

### DIFF
--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for OpenSearch Cluster
 type: application
 
 ## The opensearch-cluster Helm Chart version
-version: 3.0.0
+version: 3.0.1
 
 ## The operator version
 appVersion: 2.7.0

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -50,6 +50,7 @@ A Helm chart for OpenSearch Cluster
 | cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
 | cluster.general.keystore | list | `[]` | Populate opensearch keystore before startup |
 | cluster.general.monitoring.enable | bool | `false` | Enable cluster monitoring |
+| cluster.general.monitoring.labels | object | `{}` | Additional labels to apply to the generated ServiceMonitor |
 | cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
 | cluster.general.monitoring.pluginUrl | string | `""` | Custom URL for the monitoring plugin |
 | cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -68,6 +68,9 @@ cluster:
       # -- Enable cluster monitoring
       enable: false
 
+      # -- Additional labels to apply to the generated ServiceMonitor
+      labels: {}
+
       # -- Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it.
       monitoringUserSecret: ""
 


### PR DESCRIPTION
### Description

This PR introduces missing `cluster.general.monitoring.labels` field in the Helm chart’s values.yaml and README documentation. The operator already supports this field. This change simply adds it in the chart so users can configure custom labels on the generated ServiceMonitor.

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
