### PR TITLE
added flag to apply ism policy to existing indices

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -15,9 +15,9 @@ Follow the instructions in this video to install the Operator:
 
 A few notes on operator releases:
 
-* Please see the project README for a compatibility matrix which operator release is compatible with which OpenSearch release.
-* The userguide in the repository corresponds to the current development state of the code. To view the documentation for a specific released version switch to that tag in the Github menu.
-* We track feature requests as Github Issues. If you are missing a feature and find an issue for it, please be aware that an issue ticket closed as completed only means that feature has been implemented in the development version. After that it might still take some for the feature to be contained in a release. If you are unsure, please check the list of releases in our Github project if your feature is mentioned in the release notes.
+- Please see the project README for a compatibility matrix which operator release is compatible with which OpenSearch release.
+- The userguide in the repository corresponds to the current development state of the code. To view the documentation for a specific released version switch to that tag in the Github menu.
+- We track feature requests as Github Issues. If you are missing a feature and find an issue for it, please be aware that an issue ticket closed as completed only means that feature has been implemented in the development version. After that it might still take some for the feature to be contained in a release. If you are unsure, please check the list of releases in our Github project if your feature is mentioned in the release notes.
 
 ## Quickstart
 
@@ -47,23 +47,23 @@ spec:
     replicas: 1
     resources:
       requests:
-         memory: "512Mi"
-         cpu: "200m"
+        memory: "512Mi"
+        cpu: "200m"
       limits:
-         memory: "512Mi"
-         cpu: "200m"
+        memory: "512Mi"
+        cpu: "200m"
   nodePools:
     - component: nodes
       replicas: 3
       diskSize: "5Gi"
       nodeSelector:
       resources:
-         requests:
-            memory: "2Gi"
-            cpu: "500m"
-         limits:
-            memory: "2Gi"
-            cpu: "500m"
+        requests:
+          memory: "2Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"
       roles:
         - "cluster_manager"
         - "data"
@@ -121,33 +121,33 @@ OpenSearch clusters are composed of one or more node pools, with each representi
 
 ```yaml
 spec:
-    nodePools:
-      - component: masters
-        replicas: 3  # The number of replicas
-        diskSize: "30Gi" # The disk size to use
-        resources: # The resource requests and limits for that nodepool
-          requests:
-            memory: "2Gi"
-            cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "500m"
-        roles: # The roles the nodes should have
-          - "cluster_manager"
-          - "data"
-      - component: nodes
-        replicas: 3
-        diskSize: "10Gi"
-        nodeSelector:
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "500m"
-        roles:
-          - "data"
+  nodePools:
+    - component: masters
+      replicas: 3 # The number of replicas
+      diskSize: "30Gi" # The disk size to use
+      resources: # The resource requests and limits for that nodepool
+        requests:
+          memory: "2Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"
+      roles: # The roles the nodes should have
+        - "cluster_manager"
+        - "data"
+    - component: nodes
+      replicas: 3
+      diskSize: "10Gi"
+      nodeSelector:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"
+      roles:
+        - "data"
 ```
 
 Additional configuration options are available for node pools and are documented in this guide in later sections.
@@ -164,10 +164,10 @@ spec:
       some.config.option: somevalue
   # ...
 nodePools:
-- component: masters
-  # ...
-  additionalConfig:
-    some.other.config: foobar
+  - component: masters
+    # ...
+    additionalConfig:
+      some.other.config: foobar
 ```
 
 Using `spec.general.additionalConfig` you can add settings to all nodes, using `nodePools[].additionalConfig` you can add settings to only a pool of nodes. The settings must be provided as a map of strings, so use the flat form of any setting. If the value you want to provide is not a string, put it in quotes (for example `"true"` or `"1234"`). The Operator merges its own generated settings with whatever extra settings you provide. Note that basic settings like `node.name`, `node.roles`, `cluster.name` and settings related to network and discovery are set by the Operator and cannot be overwritten using `additionalConfig`. The value of `spec.general.additionalConfig` is also used for configuring the bootstrap pod. To overwrite the values of the bootstrap pod, set the field `spec.bootstrap.additionalConfig`.
@@ -194,16 +194,16 @@ To configure node transport security you can use the following fields in the `Op
 # ...
 spec:
   security:
-    tls:  # Everything related to TLS configuration
-      transport:  # Configuration of the transport endpoint
-        generate: true  # Have the operator generate and sign certificates
-        perNode: true  # Separate certificate per node
+    tls: # Everything related to TLS configuration
+      transport: # Configuration of the transport endpoint
+        generate: true # Have the operator generate and sign certificates
+        perNode: true # Separate certificate per node
         secret:
-          name:  # Name of the secret that contains the provided certificate
+          name: # Name of the secret that contains the provided certificate
         caSecret:
-          name:  # Name of the secret that contains a CA the operator should use
-        nodesDn: []  # List of certificate DNs allowed to connect
-        adminDn: []  # List of certificate DNs that should get admin access
+          name: # Name of the secret that contains a CA the operator should use
+        nodesDn: [] # List of certificate DNs allowed to connect
+        adminDn: [] # List of certificate DNs that should get admin access
 # ...
 ```
 
@@ -237,13 +237,13 @@ To configure HTTP API security, the following fields in the `OpenSearchCluster` 
 # ...
 spec:
   security:
-    tls:  # Everything related to TLS configuration
-      http:  # Configuration of the HTTP endpoint
-        generate: true  # Have the Operator generate and sign certificates
+    tls: # Everything related to TLS configuration
+      http: # Configuration of the HTTP endpoint
+        generate: true # Have the Operator generate and sign certificates
         secret:
-          name:  # Name of the secret that contains the provided certificate
+          name: # Name of the secret that contains the provided certificate
         caSecret:
-          name:  # Name of the secret that contains a CA the Operator should use
+          name: # Name of the secret that contains a CA the Operator should use
 # ...
 ```
 
@@ -260,38 +260,41 @@ You can extend the functionality of OpenSearch via [plugins](https://opensearch.
 To install a plugin for opensearch add it to the list under `general.pluginsList`:
 
 ```yaml
-  general:
-    version: 2.3.0
-    httpPort: 9200
-    vendor: opensearch
-    serviceName: my-cluster
-    pluginsList: ["repository-s3","https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/1.3.0.0/prometheus-exporter-1.3.0.0.zip"]
+general:
+  version: 2.3.0
+  httpPort: 9200
+  vendor: opensearch
+  serviceName: my-cluster
+  pluginsList:
+    [
+      "repository-s3",
+      "https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/1.3.0.0/prometheus-exporter-1.3.0.0.zip",
+    ]
 ```
 
 To install a plugin for opensearch dashboards add it to the list under `dashboards.pluginsList`:
 
 ```yaml
-  dashboards:
-    enable: true
-    version: 2.4.1
-    pluginsList:
-      - sample-plugin-name
+dashboards:
+  enable: true
+  version: 2.4.1
+  pluginsList:
+    - sample-plugin-name
 ```
 
 To install a plugin for the bootstrap pod add it to the list under `bootstrap.pluginsList`:
 
 ```yaml
-  bootstrap:
-    pluginsList: ["repository-s3"]
+bootstrap:
+  pluginsList: ["repository-s3"]
 ```
-
 
 Please note:
 
-* [Bundled plugins](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/plugins/#bundled-plugins) do not have to be added to the list, they are installed automatically
-* You can provide either a plugin name or a complete to the plugin zip. The items you provide are passed to the `bin/opensearch-plugin install <plugin-name>` command.
-* Updating the list for an already installed cluster will lead to a rolling restart of all opensearch nodes to install the new plugin.
-* If your plugin requires additional configuration you must provide that either through `additionalConfig` (see section [Configuring opensearch.yml](#configuring-opensearchyml)) or as secrets in the opensearch keystore (see section [Add secrets to keystore](#add-secrets-to-keystore)).
+- [Bundled plugins](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/plugins/#bundled-plugins) do not have to be added to the list, they are installed automatically
+- You can provide either a plugin name or a complete to the plugin zip. The items you provide are passed to the `bin/opensearch-plugin install <plugin-name>` command.
+- Updating the list for an already installed cluster will lead to a rolling restart of all opensearch nodes to install the new plugin.
+- If your plugin requires additional configuration you must provide that either through `additionalConfig` (see section [Configuring opensearch.yml](#configuring-opensearchyml)) or as secrets in the opensearch keystore (see section [Add secrets to keystore](#add-secrets-to-keystore)).
 
 ### Add secrets to keystore
 
@@ -299,9 +302,9 @@ Some OpenSearch features (e.g. snapshot repository plugins) require sensitive co
 To do so add the secrets under the `general.keystore` section:
 
 ```yaml
-  general:
-    # ...
-    keystore:
+general:
+  # ...
+  keystore:
     - secret:
         name: credentials
     - secret:
@@ -313,9 +316,9 @@ With this configuration all keys of the secrets will become keys in the keystore
 If you only want to load some keys from a secret or rename the existing keys, you can add key mappings as a map:
 
 ```yaml
-  general:
-    # ...
-    keystore:
+general:
+  # ...
+  keystore:
     - secret:
         name: many-secret-values
       keyMappings:
@@ -334,9 +337,9 @@ Note that only provided keys will be loaded from the secret! Any keys not specif
 To populate the keystore of the boostrap pod add the secrets under the `bootstrap.keystore` section:
 
 ```yaml
-  bootstrap:
-    # ...
-    keystore:
+bootstrap:
+  # ...
+  keystore:
     - secret:
         name: credentials
     - secret:
@@ -359,20 +362,20 @@ Recommendation: Set to half of memory request
 
 ```yaml
 spec:
-    nodePools:
-      - component: nodes
-        replicas: 3
-        diskSize: "10Gi"
-        jvm: -Xmx1024M -Xms1024M
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "500m"
-        roles:
-          - "data"
+  nodePools:
+    - component: nodes
+      replicas: 3
+      diskSize: "10Gi"
+      jvm: -Xmx1024M -Xms1024M
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"
+      roles:
+        - "data"
 ```
 
 If `jvm` is not provided then the java heap size will be set to half of
@@ -403,18 +406,18 @@ You can configure the snapshot repositories for the OpenSearch cluster through t
 spec:
   general:
     snapshotRepositories:
-        - name: my_s3_repository_1
-          type: s3
-          settings:
-            bucket: opensearch-s3-snapshot
-            region: us-east-1
-            base_path: os-snapshot
-        - name: my_s3_repository_3
-          type: s3
-          settings:
-            bucket: opensearch-s3-snapshot
-            region: us-east-1
-            base_path: os-snapshot_1
+      - name: my_s3_repository_1
+        type: s3
+        settings:
+          bucket: opensearch-s3-snapshot
+          region: us-east-1
+          base_path: os-snapshot
+      - name: my_s3_repository_3
+        type: s3
+        settings:
+          bucket: opensearch-s3-snapshot
+          region: us-east-1
+          base_path: os-snapshot_1
 ```
 
 #### Prerequisites for Configuring Snapshot Repo
@@ -423,46 +426,42 @@ Before configuring `snapshotRepositories` for a cluster, please ensure the follo
 
 1. The right cloud provider native plugins are installed. For example:
 
-    ```yaml
-    spec:
-      general:
-        pluginsList: ["repository-s3"]
-    ```
+   ```yaml
+   spec:
+     general:
+       pluginsList: ["repository-s3"]
+   ```
 
 2. The required roles/permissions for the backend cloud are pre-created. An example AWS IAM role added for kubernetes nodes so that snapshots can be published to the `opensearch-s3-snapshot` s3 bucket:
 
-    ```json
-    {
-        "Statement": [
-            {
-                "Action": [
-                    "s3:ListBucket",
-                    "s3:GetBucketLocation",
-                    "s3:ListBucketMultipartUploads",
-                    "s3:ListBucketVersions"
-                ],
-                "Effect": "Allow",
-                "Resource": [
-                    "arn:aws:s3:::opensearch-s3-snapshot"
-                ]
-            },
-            {
-                "Action": [
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:DeleteObject",
-                    "s3:AbortMultipartUpload",
-                    "s3:ListMultipartUploadParts"
-                ],
-                "Effect": "Allow",
-                "Resource": [
-                    "arn:aws:s3:::opensearch-s3-snapshot/*"
-                ]
-            }
-        ],
-        "Version": "2012-10-17"
-    }
-    ```
+   ```json
+   {
+     "Statement": [
+       {
+         "Action": [
+           "s3:ListBucket",
+           "s3:GetBucketLocation",
+           "s3:ListBucketMultipartUploads",
+           "s3:ListBucketVersions"
+         ],
+         "Effect": "Allow",
+         "Resource": ["arn:aws:s3:::opensearch-s3-snapshot"]
+       },
+       {
+         "Action": [
+           "s3:GetObject",
+           "s3:PutObject",
+           "s3:DeleteObject",
+           "s3:AbortMultipartUpload",
+           "s3:ListMultipartUploadParts"
+         ],
+         "Effect": "Allow",
+         "Resource": ["arn:aws:s3:::opensearch-s3-snapshot/*"]
+       }
+     ],
+     "Version": "2012-10-17"
+   }
+   ```
 
 ## Configuring Dashboards
 
@@ -472,9 +471,9 @@ The operator can automatically deploy and manage a OpenSearch Dashboards instanc
 # ...
 spec:
   dashboards:
-    enable: true  # Set this to true to enable the Dashboards deployment
-    version: 2.3.0  # The Dashboards version to deploy. This should match the configured opensearch version
-    replicas: 1  # The number of replicas to deploy
+    enable: true # Set this to true to enable the Dashboards deployment
+    version: 2.3.0 # The Dashboards version to deploy. This should match the configured opensearch version
+    replicas: 1 # The number of replicas to deploy
 ```
 
 ### Configuring opensearch_dashboards.yml
@@ -528,7 +527,7 @@ When using OpenSearch behind a reverse proxy on a subpath (e.g. `/logs`) you hav
 ```yaml
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
-...
+---
 spec:
   dashboards:
     enable: true
@@ -545,14 +544,14 @@ OpenSearch Dashboards can expose its API/UI via HTTP or HTTPS. It is unencrypted
 # ...
 spec:
   dashboards:
-    enable: true  # Deploy Dashboards component
+    enable: true # Deploy Dashboards component
     tls:
-      enable: true  # Configure TLS
-      generate: true  # Have the Operator generate and sign a certificate
+      enable: true # Configure TLS
+      generate: true # Have the Operator generate and sign a certificate
       secret:
-        name:  # Name of the secret that contains the provided certificate
+        name: # Name of the secret that contains the provided certificate
       caSecret:
-       name:  # Name of the secret that contains a CA the Operator should use
+        name: # Name of the secret that contains a CA the Operator should use
 # ...
 ```
 
@@ -577,17 +576,17 @@ The default option is persistent storage via PVCs. You can explicity define the 
 
 ```yaml
 nodePools:
-- component: masters
-  replicas: 3
-  diskSize: 30
-  roles:
-    - "data"
-    - "master"
-  persistence:
-    pvc:
-      storageClass: mystorageclass  # Set the name of the storage class to be used
-      accessModes: # You can change the accessMode
-      - ReadWriteOnce
+  - component: masters
+    replicas: 3
+    diskSize: 30
+    roles:
+      - "data"
+      - "master"
+    persistence:
+      pvc:
+        storageClass: mystorageclass # Set the name of the storage class to be used
+        accessModes: # You can change the accessMode
+          - ReadWriteOnce
 ```
 
 #### EmptyDir
@@ -596,14 +595,14 @@ If you do not want to use persistent storage you can use the `emptyDir` option. 
 
 ```yaml
 nodePools:
-- component: masters
-  replicas: 3
-  diskSize: 30
-  roles:
-    - "data"
-    - "master"
-  persistence:
-    emptyDir: {}  # This configures emptyDir
+  - component: masters
+    replicas: 3
+    diskSize: 30
+    roles:
+      - "data"
+      - "master"
+    persistence:
+      emptyDir: {} # This configures emptyDir
 ```
 
 If you are using emptyDir, it is recommended that you set `spec.general.drainDataNodes` to be `true`. This will ensure that shards are drained from the pods before rolling upgrades or restart operations are performed.
@@ -614,15 +613,15 @@ As a last option you can hose a `hostPath`. Please note that hostPath is strongl
 
 ```yaml
 nodePools:
-- component: masters
-  replicas: 3
-  diskSize: 30
-  roles:
-    - "data"
-    - "master"
-  persistence:
-    hostPath:
-      path: "/var/opensearch"  # Define the path on the host here
+  - component: masters
+    replicas: 3
+    diskSize: 30
+    roles:
+      - "data"
+      - "master"
+    persistence:
+      hostPath:
+        path: "/var/opensearch" # Define the path on the host here
 ```
 
 ### Security Context for pods and containers
@@ -648,7 +647,7 @@ spec:
     securityContext:
       capabilities:
         drop:
-        - ALL
+          - ALL
       privileged: false
 ```
 
@@ -668,18 +667,18 @@ spec:
     - component: masters
       replicas: 3
       diskSize: "5Gi"
-      labels:  # Add any extra labels as key-value pairs here
+      labels: # Add any extra labels as key-value pairs here
         someLabelKey: someLabelValue
-      annotations:  # Add any extra annotations as key-value pairs here
+      annotations: # Add any extra annotations as key-value pairs here
         someAnnotationKey: someAnnotationValue
       nodeSelector:
       resources:
-         requests:
-            memory: "2Gi"
-            cpu: "500m"
-         limits:
-            memory: "2Gi"
-            cpu: "500m"
+        requests:
+          memory: "2Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"
       roles:
         - "data"
         - "master"
@@ -697,9 +696,9 @@ spec:
     enable: true
     version: 1.3.1
     replicas: 1
-    labels:  # Add any extra labels as key-value pairs here
+    labels: # Add any extra labels as key-value pairs here
       someLabelKey: someLabelValue
-    annotations:  # Add any extra annotations as key-value pairs here
+    annotations: # Add any extra annotations as key-value pairs here
       someAnnotationKey: someAnnotationValue
 ```
 
@@ -717,53 +716,53 @@ spec:
       diskSize: "5Gi"
       priorityClassName: somePriorityClassName
       resources:
-         requests:
-            memory: "2Gi"
-            cpu: "500m"
-         limits:
-            memory: "2Gi"
-            cpu: "500m"
+        requests:
+          memory: "2Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"
       roles:
         - "master"
 ```
 
 ### Additional Volumes
 
-Sometimes it is neccessary to mount ConfigMaps, Secrets, emptyDir, projected volumes, or CSI volumes into the Opensearch pods as volumes to provide additional configuration (e.g. plugin config files).  This can be achieved by providing an array of additional volumes to mount to the custom resource. This option is located in either `spec.general.additionalVolumes` or `spec.dashboards.additionalVolumes`. The format is as follows:
+Sometimes it is neccessary to mount ConfigMaps, Secrets, emptyDir, projected volumes, or CSI volumes into the Opensearch pods as volumes to provide additional configuration (e.g. plugin config files). This can be achieved by providing an array of additional volumes to mount to the custom resource. This option is located in either `spec.general.additionalVolumes` or `spec.dashboards.additionalVolumes`. The format is as follows:
 
 ```yaml
 spec:
   general:
     additionalVolumes:
-    - name: example-configmap
-      path: /path/to/mount/volume
-      #subPath: mykey # Add this to mount only a specific key of the configmap/secret
-      configMap:
-        name: config-map-name
-      restartPods: true #set this to true to restart the pods when the content of the configMap changes
-    - name: temp
-      path: /tmp
-      emptyDir: {}
-    - name: example-csi-volume
-      path: /path/to/mount/volume
-      #subPath: "subpath" # Add this to mount the CSI volume at a specific subpath
-      csi:
-        driver: csi-driver-name
-        readOnly: true
-        volumeAttributes:
-          secretProviderClass: example-secret-provider-class
-    - name: example-projected-volume
-      path: /path/to/mount/volume
-      projected:
-        sources:
-        - serviceAccountToken:
-            path: "token"
+      - name: example-configmap
+        path: /path/to/mount/volume
+        #subPath: mykey # Add this to mount only a specific key of the configmap/secret
+        configMap:
+          name: config-map-name
+        restartPods: true #set this to true to restart the pods when the content of the configMap changes
+      - name: temp
+        path: /tmp
+        emptyDir: {}
+      - name: example-csi-volume
+        path: /path/to/mount/volume
+        #subPath: "subpath" # Add this to mount the CSI volume at a specific subpath
+        csi:
+          driver: csi-driver-name
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: example-secret-provider-class
+      - name: example-projected-volume
+        path: /path/to/mount/volume
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: "token"
   dashboards:
     additionalVolumes:
-    - name: example-secret
-      path: /path/to/mount/volume
-      secret:
-        secretName: secret-name
+      - name: example-secret
+        path: /path/to/mount/volume
+        secret:
+          secretName: secret-name
 ```
 
 The defined volumes are added to all pods of the opensearch cluster. It is currently not possible to define them per nodepool.
@@ -813,17 +812,17 @@ manager:
 During cluster initialization the operator uses init containers as helpers. For these containers a busybox image is used ( specifically `docker.io/busybox:latest`). In case you are working in an offline environment and the cluster cannot access the registry or you want to customize the image, you can override the image used by specifying the `initHelper` image in your cluster spec:
 
 ```yaml
-  spec:
-    initHelper:
-      # You can either only specify the version
-      version: "1.27.2-buildcustom"
-      # or specify a totally different image
-      image: "mycustomrepo.cr/mycustombusybox:myversion"
-      # Additionally you can define the imagePullPolicy
-      imagePullPolicy: IfNotPresent
-      # and imagePullSecrets if needed
-      imagePullSecrets:
-        - name: docker-pull-secret
+spec:
+  initHelper:
+    # You can either only specify the version
+    version: "1.27.2-buildcustom"
+    # or specify a totally different image
+    image: "mycustomrepo.cr/mycustombusybox:myversion"
+    # Additionally you can define the imagePullPolicy
+    imagePullPolicy: IfNotPresent
+    # and imagePullSecrets if needed
+    imagePullSecrets:
+      - name: docker-pull-secret
 ```
 
 ### Edit init container resources
@@ -831,16 +830,16 @@ During cluster initialization the operator uses init containers as helpers. For 
 Init container run without any resource constraints, but it's possible to specify resource requests and limits by adding a resources section to the YAML definition. This allows you to control the amount of CPU and memory allocated to the init container, it's helps to ensure that it doesn't starve other containers, by setting appropriate resource limits.
 
 ```yaml
-  spec:
-    initHelper:
-      resources:
-        requests:
-          memory: "128Mi"
-          cpu: "250m"
-        limits:
-          memory: "512Mi"
-          cpu: "500m"
- ```
+spec:
+  initHelper:
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "250m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+```
 
 ### Disabling the init helper
 
@@ -864,7 +863,7 @@ You must provide either `minAvailable` or `maxUnavailable` to configure PDB, but
 ```yaml
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
-...
+---
 spec:
   nodePools:
     - component: masters
@@ -895,19 +894,19 @@ metadata:
   namespace: default
 spec:
   tls:
-  - hosts:
-    - dashboards.my.company
+    - hosts:
+        - dashboards.my.company
   rules:
-  - host: dashboards.my.company
-    http:
-      paths:
-      - backend:
-          service:
-            name: my-cluster-dashboards
-            port:
-              number: 5601
-        path: "/(.*)"
-        pathType: ImplementationSpecific
+    - host: dashboards.my.company
+      http:
+        paths:
+          - backend:
+              service:
+                name: my-cluster-dashboards
+                port:
+                  number: 5601
+            path: "/(.*)"
+            pathType: ImplementationSpecific
 ```
 
 Note: If you have enabled HTTPS for dashboards you need to instruct your ingress-controller to use a HTTPS connection internally. This is specific for the controller you are using (e.g. nginx-ingress, traefik, ...).
@@ -918,21 +917,21 @@ You can customize the Kubernetes Service object that the operator generates for 
 
 Supported Service Types
 
-* ClusterIP (default)
-* NodePort
-* LoadBalancer
+- ClusterIP (default)
+- NodePort
+- LoadBalancer
 
 When using type LoadBalancer you can optionally set the load balancer source ranges.
 
 ```yaml
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
-...
+---
 spec:
   dashboards:
     service:
-      type: LoadBalancer  # Set one of the supported types
-      loadBalancerSourceRanges: "10.0.0.0/24, 192.168.0.0/24"  # Optional, add source ranges for a loadbalancer
+      type: LoadBalancer # Set one of the supported types
+      loadBalancerSourceRanges: "10.0.0.0/24, 192.168.0.0/24" # Optional, add source ranges for a loadbalancer
 ```
 
 ### Exposing the OpenSearch cluster REST API
@@ -947,7 +946,7 @@ If the cluster nodes do not spins up before the threshold reaches and the pod re
 ```yaml
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
-...
+---
 spec:
   nodePools:
     - component: masters
@@ -982,7 +981,7 @@ The operator generates many pods via resources such as jobs, stateful sets, repl
 ```yaml
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
-...
+---
 spec:
   initHelper:
     resources:
@@ -999,7 +998,7 @@ You can also configure the resources for the security update job as shown below.
 ```yaml
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
-...
+---
 spec:
   security:
     config:
@@ -1058,12 +1057,12 @@ To increase the disk volume size set the `diskSize` of a nodepool to the desired
 
 The following considerations should be taken into account in order to increase the PVC size.
 
-* This only works for PVC-based persistence
-* Before considering the expansion of the the cluster disk, make sure the volumes/data is backed up in desired format, so that any failure can be tolerated by restoring from the backup.
-* Make sure the cluster storage class has `allowVolumeExpansion: true` before applying the new `diskSize`. For more details checkout the [kubernetes storage classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) document.
-* Once the above step is done, the cluster yaml can be applied with new `diskSize` value, to all decalared nodepool components or to single component.
-* It is best recommended not to apply any new changes to the cluster along with volume expansion.
-* Make sure the declared size definitions are proper and consistent, example if the `diskSize` is in `G` or `Gi`, make sure the same size definitions are followed for expansion.
+- This only works for PVC-based persistence
+- Before considering the expansion of the the cluster disk, make sure the volumes/data is backed up in desired format, so that any failure can be tolerated by restoring from the backup.
+- Make sure the cluster storage class has `allowVolumeExpansion: true` before applying the new `diskSize`. For more details checkout the [kubernetes storage classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) document.
+- Once the above step is done, the cluster yaml can be applied with new `diskSize` value, to all decalared nodepool components or to single component.
+- It is best recommended not to apply any new changes to the cluster along with volume expansion.
+- Make sure the declared size definitions are proper and consistent, example if the `diskSize` is in `G` or `Gi`, make sure the same size definitions are followed for expansion.
 
 Note: To change the `diskSize` from `G` to `Gi` or vice-versa, first make sure data is backed up and make sure the right conversion number is identified, so that the underlying volume has the same value and then re-apply the cluster yaml. This will make sure the statefulset is re-created with right value in VolueClaimTemplates, this operation is expected to have no downtime.
 
@@ -1072,8 +1071,8 @@ Note: To change the `diskSize` from `G` to `Gi` or vice-versa, first make sure d
 An important part of any OpenSearch cluster is the user and role management to give users access to the cluster (via the opensearch-security plugin). By default the operator will use the included demo securityconfig with default users (see [internal_users.yml](https://github.com/opensearch-project/security/blob/main/config/internal_users.yml) for a list of users). For any production installation you should swap that out with your own configuration.
 There are two ways to do that with the operator:
 
-* Defining your own securityconfig
-* Managing users and roles via kubernetes resources
+- Defining your own securityconfig
+- Managing users and roles via kubernetes resources
 
 Note that currently a combination of both approaches is not possible. Once you use the CRDs you cannot provide your own securityconfig as those would overwrite each other. We are working on a feature to merge these options.
 
@@ -1087,13 +1086,13 @@ The Operator can be controlled using the following fields in the `OpenSearchClus
 # ...
 spec:
   security:
-    config:  # Everything related to the securityconfig
+    config: # Everything related to the securityconfig
       securityConfigSecret:
-        name:  # Name of the secret that contains the securityconfig files
+        name: # Name of the secret that contains the securityconfig files
       adminSecret:
-        name:  # Name of a secret that contains the admin client certificate
+        name: # Name of a secret that contains the admin client certificate
       adminCredentialsSecret:
-        name:  # Name of a secret that contains username/password for admin access
+        name: # Name of a secret that contains username/password for admin access
 # ...
 ```
 
@@ -1139,7 +1138,7 @@ spec:
     name: sample-user-password
     key: password
   backendRoles:
-  - kibanauser
+    - kibanauser
 ```
 
 The namespace of the `OpenSearchUser` must be the namespace the OpenSearch cluster itself is deployed in.
@@ -1164,14 +1163,14 @@ spec:
   opensearchCluster:
     name: my-first-cluster
   clusterPermissions:
-  - cluster_composite_ops
-  - cluster_monitor
+    - cluster_composite_ops
+    - cluster_monitor
   indexPermissions:
-  - indexPatterns:
-    - logs*
-    allowedActions:
-    - index
-    - read
+    - indexPatterns:
+        - logs*
+      allowedActions:
+        - index
+        - read
 ```
 
 #### Linking Opensearch Users and Roles
@@ -1188,11 +1187,11 @@ spec:
   opensearchCluster:
     name: my-first-cluster
   users:
-  - sample-user
+    - sample-user
   backendRoles:
-  - sample-backend-role
+    - sample-backend-role
   roles:
-  - sample-role
+    - sample-role
 ```
 
 #### Opensearch Action Groups
@@ -1255,32 +1254,32 @@ Make sure that the password hash of the admin user corresponds to the password y
 Notice that inside `securityconfig-secret` You must edit the `hash` of the admin user before creating the secret. if you have python 3.x installed on your machine you can use the following command to hash your password: `python -c 'import bcrypt; print(bcrypt.hashpw("admin123".encode("utf-8"), bcrypt.gensalt(12, prefix=b"2a")).decode("utf-8"))'`
 
 ```yaml
-  internal_users.yml: |-
-    _meta:
-      type: "internalusers"
-      config_version: 2
-    admin:
-      hash: "$2y$12$lJsHWchewGVcGlYgE3js/O4bkTZynETyXChAITarCHLz8cuaueIyq"   <------- change that hash to your new password hash
-      reserved: true
-      backend_roles:
-      - "admin"
-      description: "Demo admin user"
-  ```
+internal_users.yml: |-
+  _meta:
+    type: "internalusers"
+    config_version: 2
+  admin:
+    hash: "$2y$12$lJsHWchewGVcGlYgE3js/O4bkTZynETyXChAITarCHLz8cuaueIyq"   <------- change that hash to your new password hash
+    reserved: true
+    backend_roles:
+    - "admin"
+    description: "Demo admin user"
+```
 
 The last thing that you have to do is to add that security configuration to your cluster spec:
 
 ```yaml
-  security:
-    config:
-      adminCredentialsSecret:
-        name: admin-credentials-secret  # The secret with the admin credentials for the operator to use
-      securityConfigSecret:
-       name: securityconfig-secret  # The secret containing your customized securityconfig
-    tls:
-      transport:
-        generate: true
-      http:
-        generate: true
+security:
+  config:
+    adminCredentialsSecret:
+      name: admin-credentials-secret # The secret with the admin credentials for the operator to use
+    securityConfigSecret:
+      name: securityconfig-secret # The secret containing your customized securityconfig
+  tls:
+    transport:
+      generate: true
+    http:
+      generate: true
 ```
 
 Changing the admin password after the cluster has been created is possible via the same way. You must update your securityconfig (in the `securityconfig-secret`) and the content of the `admin-credentials-secret` to both reflect the new password. Note that currently the operator cannot make changes in the securityconfig itself. As such you must always update the securityconfig in the secret with the new password and in addition provide it via the credentials secret so that the operator can still access the cluster.
@@ -1293,7 +1292,7 @@ Dashboards requires an opensearch user to connect to the cluster. By default Das
 spec:
   dashboards:
     opensearchCredentialsSecret:
-      name: dashboards-credentials  # This is the name of your secret that contains the credentials for Dashboards to use
+      name: dashboards-credentials # This is the name of your secret that contains the credentials for Dashboards to use
 ```
 
 ## Adding Opensearch Monitoring to your cluster
@@ -1340,33 +1339,33 @@ It is possible to manage OpenSearch ISM policies in Kubernetes with the operator
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchISMPolicy
 metadata:
-   name: sample-policy
+  name: sample-policy
 spec:
-   opensearchCluster:
-      name: my-first-cluster
-   description: Sample policy
-   policyId: sample-policy
-   defaultState: hot
-   states:
-      - name: hot
-        actions:
-           - replicaCount:
-                numberOfReplicas: 4
-        transitions:
-           - stateName: warm
-             conditions:
-                minIndexAge: "10d"
-      - name: warm
-        actions:
-           - replicaCount:
-                numberOfReplicas: 2
-        transitions:
-           - stateName: delete
-             conditions:
-                minIndexAge: "30d"
-      - name: delete
-        actions:
-           - delete: {}
+  opensearchCluster:
+    name: my-first-cluster
+  description: Sample policy
+  policyId: sample-policy
+  defaultState: hot
+  states:
+    - name: hot
+      actions:
+        - replicaCount:
+            numberOfReplicas: 4
+      transitions:
+        - stateName: warm
+          conditions:
+            minIndexAge: "10d"
+    - name: warm
+      actions:
+        - replicaCount:
+            numberOfReplicas: 2
+      transitions:
+        - stateName: delete
+          conditions:
+            minIndexAge: "30d"
+    - name: delete
+      actions:
+        - delete: {}
 ```
 
 The namespace of the `OpenSearchISMPolicy` must be the namespace the OpenSearch cluster itself is deployed in. `policyId` is an optional field, and if not provided `metadata.name` is used as the default.
@@ -1432,3 +1431,41 @@ spec:
 ```
 
 Note: the `.spec.name` is immutable, meaning that it cannot be changed after the resources have been deployed to a Kubernetes cluster
+
+## Apply ism policies to existing indices
+
+The operator provides a flag to apply ism policies to already existing indices in the opensearch cluster.
+This is done by setting the `applyToExistingIndices` flag to true in the `OpenSearchISMPolicy` CRD. An example of this can be seen below:
+
+```yaml
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchISMPolicy
+metadata:
+  name: test-policy-apply
+spec:
+  opensearchCluster:
+    name: opensearch-cluster
+  applyToExistingIndices: true
+  description: "Test ISM policy - Apply to existing indices is true"
+  defaultState: "hot"
+  ismTemplate:
+    indexPatterns:
+      - "test-*"
+  states:
+    - name: hot
+      actions:
+        - replicaCount:
+            numberOfReplicas: 2
+      transitions:
+        - stateName: warm
+          conditions:
+            minIndexAge: "1d"
+    - name: warm
+      actions:
+        - replicaCount:
+            numberOfReplicas: 1
+```
+
+Note that the default setting of `applyToExistingIndices` is false and it will be false if the flag is omitted in the manifest.
+
+When the flag is true, any existing indices in the opensearch cluster with the specified index pattern will have this ism policy applied to it. If multiple ism policies use this with the same index pattern, the priority has to be different between the ism policies.

--- a/opensearch-operator/api/v1/opensearchism_types.go
+++ b/opensearch-operator/api/v1/opensearchism_types.go
@@ -43,8 +43,10 @@ type OpenSearchISMPolicySpec struct {
 	// The default starting state for each index that uses this policy.
 	DefaultState string `json:"defaultState"`
 	// A human-readable description of the policy.
-	Description       string             `json:"description"`
-	ErrorNotification *ErrorNotification `json:"errorNotification,omitempty"`
+	Description string `json:"description"`
+	// If true, apply the policy to existing indices that match the index patterns in the ISM template.
+	ApplyToExistingIndices *bool              `json:"applyToExistingIndices,omitempty"`
+	ErrorNotification      *ErrorNotification `json:"errorNotification,omitempty"`
 	// Specify an ISM template pattern that matches the index to apply the policy.
 	ISMTemplate *ISMTemplate `json:"ismTemplate,omitempty"`
 	PolicyID    string       `json:"policyId,omitempty"`

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -1261,6 +1261,11 @@ func (in *OpenSearchISMPolicyList) DeepCopyObject() runtime.Object {
 func (in *OpenSearchISMPolicySpec) DeepCopyInto(out *OpenSearchISMPolicySpec) {
 	*out = *in
 	out.OpensearchRef = in.OpensearchRef
+	if in.ApplyToExistingIndices != nil {
+		in, out := &in.ApplyToExistingIndices, &out.ApplyToExistingIndices
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ErrorNotification != nil {
 		in, out := &in.ErrorNotification, &out.ErrorNotification
 		*out = new(ErrorNotification)

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
@@ -42,6 +42,10 @@ spec:
             description: ISMPolicySpec is the specification for the ISM policy for
               OS.
             properties:
+              applyToExistingIndices:
+                description: If true, apply the policy to existing indices that match
+                  the index patterns in the ISM template.
+                type: boolean
               defaultState:
                 description: The default starting state for each index that uses this
                   policy.

--- a/opensearch-operator/examples/2.x/opensearch-ismpolicy-apply.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-ismpolicy-apply.yaml
@@ -1,0 +1,26 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchISMPolicy
+metadata:
+  name: test-policy-apply
+spec:
+  opensearchCluster:
+    name: opensearch-cluster
+  applyToExistingIndices: true
+  description: "Test ISM policy - Apply to existing indices is true"
+  defaultState: "hot"
+  ismTemplate:
+    indexPatterns:
+      - "test-*"
+  states:
+    - name: hot
+      actions:
+        - replicaCount:
+            numberOfReplicas: 2
+      transitions:
+        - stateName: warm
+          conditions:
+            minIndexAge: "1d"
+    - name: warm
+      actions:
+        - replicaCount:
+            numberOfReplicas: 1

--- a/opensearch-operator/examples/2.x/opensearch-ismpolicy-noApply.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-ismpolicy-noApply.yaml
@@ -1,0 +1,26 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchISMPolicy
+metadata:
+  name: test-policy-no-apply
+spec:
+  opensearchCluster:
+    name: opensearch-cluster
+  applyToExistingIndices: false
+  description: "Test ISM policy 2 - Apply to existing indices is false"
+  defaultState: "hot"
+  ismTemplate:
+    indexPatterns:
+      - "test-*"
+  states:
+    - name: hot
+      actions:
+        - replicaCount:
+            numberOfReplicas: 2
+      transitions:
+        - stateName: warm
+          conditions:
+            minIndexAge: "1d"
+    - name: warm
+      actions:
+        - replicaCount:
+            numberOfReplicas: 1

--- a/opensearch-operator/opensearch-gateway/services/http_request.go
+++ b/opensearch-operator/opensearch-gateway/services/http_request.go
@@ -29,6 +29,26 @@ func doHTTPGet(ctx context.Context, client *opensearch.Client, path strings.Buil
 	return &opensearchapi.Response{StatusCode: res.StatusCode, Body: res.Body, Header: res.Header}, nil
 }
 
+// doHTTPPost performs a HTTP POST request
+func doHTTPPost(ctx context.Context, client *opensearch.Client, path strings.Builder, body io.Reader) (*opensearchapi.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, path.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	req.Header.Add(headerContentType, jsonContentHeader)
+
+	res, err := client.Perform(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &opensearchapi.Response{StatusCode: res.StatusCode, Body: res.Body, Header: res.Header}, nil
+}
+
 // doHTTPHead performs a HTTP HEAD request
 func doHTTPHead(ctx context.Context, client *opensearch.Client, path strings.Builder) (*opensearchapi.Response, error) {
 	req, err := http.NewRequest(http.MethodHead, path.String(), nil)

--- a/opensearch-operator/opensearch-gateway/services/os_ism_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_ism_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/requests"
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
@@ -90,5 +91,77 @@ func DeleteISMPolicy(ctx context.Context, service *OsClusterClient, policyName s
 	if resp.IsError() {
 		return fmt.Errorf("failed to delete ism policy: %s", resp.String())
 	}
+	return nil
+}
+
+// IndexInfo represents the response from OpenSearch for indices
+type IndexInfo struct {
+	Index string `json:"index"`
+}
+
+// GetIndices retrieves indices matching the given pattern from OpenSearch
+func GetIndices(ctx context.Context, service *OsClusterClient, pattern string) ([]string, error) {
+	resp, err := service.GetIndices(ctx, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call GetIndices: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check for OpenSearch error response
+	if resp.IsError() {
+		return nil, fmt.Errorf("OpenSearch API error: %s", resp.String())
+	}
+
+	// Parse response
+	var indices []IndexInfo
+	if err := json.Unmarshal(bodyBytes, &indices); err != nil {
+		// Log the raw response for debugging
+		log.FromContext(ctx).V(1).Info(fmt.Sprintf("Raw response: %s", string(bodyBytes)))
+		return nil, fmt.Errorf("failed to parse indices response: %w", err)
+	}
+
+	// Handle empty result
+	if len(indices) == 0 {
+		log.FromContext(ctx).V(1).Info(fmt.Sprintf("No indices found matching pattern: %s", pattern))
+		return []string{}, nil
+	}
+
+	// Extract index names
+	indexNames := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		indexNames = append(indexNames, idx.Index)
+	}
+
+	// Log the found indices
+	log.FromContext(ctx).V(1).Info(fmt.Sprintf("Found indices matching pattern '%s': %v", pattern, indexNames))
+
+	return indexNames, nil
+}
+
+// AddISMPolicyRequest is the request body for adding an ISM policy to an index
+type AddISMPolicyRequest struct {
+	PolicyID string `json:"policy_id"`
+}
+
+// AddPolicyToIndex applies an ISM policy to the specified index
+func AddPolicyToIndex(ctx context.Context, service *OsClusterClient, indexName string, policyId string) error {
+	body := opensearchutil.NewJSONReader(AddISMPolicyRequest{PolicyID: policyId})
+
+	resp, err := service.AddPolicyToIndex(ctx, indexName, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.IsError() {
+		return fmt.Errorf("failed to add policy to index: %s", resp.String())
+	}
+
 	return nil
 }

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -197,6 +197,16 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 				RequeueAfter: defaultRequeueAfter,
 			}, retErr
 		}
+		// Apply to existing indices
+		if err := r.applyPolicyToExistingIndices(policyId); err != nil {
+			reason = "failed to apply policy to existing indices"
+			r.logger.Error(err, reason)
+			r.recorder.Event(r.instance, "Warning", opensearchAPIError, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, err
+		}
 		// Mark the ISM Policy as not pre-existing (created by the operator)
 		retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 			object.(*opsterv1.OpenSearchISMPolicy).Status.ExistingISMPolicy = pointer.Bool(false)
@@ -546,6 +556,41 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 	}
 
 	return &policy, nil
+}
+
+func (r *IsmPolicyReconciler) applyPolicyToExistingIndices(policyId string) error {
+	if r.instance.Spec.ApplyToExistingIndices == nil || !*r.instance.Spec.ApplyToExistingIndices {
+		return nil
+	}
+
+	if r.instance.Spec.ISMTemplate == nil || len(r.instance.Spec.ISMTemplate.IndexPatterns) == 0 {
+		return nil
+	}
+
+	for _, pattern := range r.instance.Spec.ISMTemplate.IndexPatterns {
+
+		// Get existing indices matching the pattern
+		indices, err := services.GetIndices(r.ctx, r.osClient, pattern)
+
+		if err != nil {
+			reason := fmt.Sprintf("failed to get indices matching pattern %s", pattern)
+			r.logger.Error(err, reason)
+			return fmt.Errorf("%s: %w", reason, err)
+		}
+
+		// Apply policy to each index
+		for _, index := range indices {
+			if err := services.AddPolicyToIndex(r.ctx, r.osClient, index, policyId); err != nil {
+				reason := fmt.Sprintf("failed to apply policy to index %s", index)
+				return fmt.Errorf("%s: %w", reason, err)
+			}
+			r.logger.V(1).Info(fmt.Sprintf("Applied ISM Policy '%s' to existing index '%s'", policyId, index))
+		}
+	}
+
+	r.recorder.Event(r.instance, "Normal", opensearchAPIUpdated, "ISM policy applied to existing indices")
+
+	return nil
 }
 
 // Delete ISM policy from the OS cluster


### PR DESCRIPTION
### Description
This change introduces an ism policy boolean called "applyToExistingIndices", which, when true, will apply the created ism policy to all existing indices, which have no ism policy and which pattern matches the ism policy pattern in question.

### Issues Resolved
Closes #828 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
