### PR TITLE
Add posibility to define datastreams via opensearch-cluster chart

### DIFF
--- a/charts/opensearch-cluster/templates/indextemplates.yaml
+++ b/charts/opensearch-cluster/templates/indextemplates.yaml
@@ -13,6 +13,9 @@ metadata:
 spec:
   opensearchCluster:
     name: {{ $clusterName }}
+  {{- if not (eq .dataStream nil) }}
+  dataStream: {{ .dataStream | toYaml | nindent 4 }}
+  {{- end }}
   {{- with .indexPatterns }}
   indexPatterns: {{ . | toYaml | nindent 4 }}
   {{- end }}

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -455,6 +455,7 @@ indexTemplates: []
 #  - name: example-index-template
 #    indexPatterns:
 #      - "logs-2020-01-*"
+#    dataStream: null # optional
 #    composedOf: # optional
 #      - example-component-template
 #    priority: 100 # optional


### PR DESCRIPTION
Add posibility to define datastreams  in `indextemplates.yaml` template of opensearch-cluster chart (#990)

### Description
Adding possibility to define OpenSearch index templates for data streams using the Helm chart

### Issues Resolved
#990 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
