### PR TITLE
Update the CI tests to latest released OpenSearch versions (2.19 and 3.0.0)

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -48,8 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-            - 2.13.0
-            - 1.3.16
+            - 3.0.0
+            - 2.19.0
+            - 1.3.20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Update the CI tests to latest released OpenSearch versions (2.19 and 3.0.0)

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-k8s-operator/issues/1009

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
