### PR TITLE
Warm role support

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -60,6 +60,7 @@ func NewSTSForNodePool(
 		"transform",
 		"cluster_manager",
 		"search",
+		"warm",
 	}
 	var selectedRoles []string
 	for _, role := range node.Roles {

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -134,6 +134,30 @@ var _ = Describe("Builders", func() {
 				Value: "master",
 			}))
 		})
+		It("should accept the warm role", func() {
+			clusterObject := ClusterDescWithVersion("3.0.0")
+			nodePool := opsterv1.NodePool{
+				Component: "masters",
+				Roles:     []string{"warm"},
+			}
+			result := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "warm",
+			}))
+		})
+		It("should convert the warm role", func() {
+			clusterObject := ClusterDescWithVersion("2.0.0")
+			nodePool := opsterv1.NodePool{
+				Component: "masters",
+				Roles:     []string{"warm"},
+			}
+			result := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "search",
+			}))
+		})
 		It("should have annotations added to node", func() {
 			clusterObject := ClusterDescWithVersion("1.3.0")
 			nodePool := opsterv1.NodePool{

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -212,7 +212,6 @@ func MapClusterRole(role string, ver string) string {
 			"warm":   "search",
 		},
 		3: {
-			"search": "warm",
 			"master": "cluster_manager",
 		},
 	}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -201,15 +201,27 @@ func MapClusterRole(role string, ver string) string {
 	if err != nil {
 		return role
 	}
-	clusterManagerVer, _ := version.NewVersion("2.0.0")
-	is2XVersion := osVer.GreaterThanOrEqual(clusterManagerVer)
-	if role == "master" && is2XVersion {
-		return "cluster_manager"
-	} else if role == "cluster_manager" && !is2XVersion {
-		return "master"
-	} else {
-		return role
+
+	majorVersion := osVer.Segments()[0]
+	roleMap := map[int]map[string]string{
+		1: {
+			"cluster_manager": "master",
+		},
+		2: {
+			"master": "cluster_manager",
+			"warm":   "search",
+		},
+		3: {
+			"search": "warm",
+			"master": "cluster_manager",
+		},
 	}
+
+	if mappedRole, ok := roleMap[majorVersion][role]; ok {
+		return mappedRole
+	}
+
+	return role
 }
 
 func MapClusterRoles(roles []string, version string) []string {


### PR DESCRIPTION
### Description
With the release of OpenSearch 3.0 the search role has been renamed to warm. This PR allows the warm role to be specified and add some compatibility mapping for other versions.

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
