### PR TITLE
Fix opensearch-cluster.cluster-name definition

### DIFF
--- a/charts/opensearch-cluster/templates/_helpers.tpl
+++ b/charts/opensearch-cluster/templates/_helpers.tpl
@@ -6,7 +6,7 @@ Expand the name of the chart.
 {{- end }}
 
 {{- define "opensearch-cluster.cluster-name" -}}
-{{- default .Values.cluster.name .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- default .Release.Name .Values.cluster.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### Description

 The default function **"opensearch-cluster.cluster-name"** in the _helpers.tpl file was incorrectly prioritizing the release name (.Release.Name) over the value specified in Values.cluster.name. This meant that even if a user explicitly set cluster.name in their values.yaml file, it would be ignored, and the cluster would always be named after the release.

This change reverses the order of arguments in the default function call. Now, the Values.cluster.name is used as the primary value, and the release name is only used as a fallback if Values.cluster.name is not defined.

Helm Documentation: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [X] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
