### PR TITLE
Using 2 for the tag

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -40,10 +40,10 @@ metadata:
 spec:
   general:
     serviceName: my-first-cluster
-    version: 2.3.0
+    version: 2
   dashboards:
     enable: true
-    version: 2.3.0
+    version: 2
     replicas: 1
     resources:
       requests:

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -40,10 +40,10 @@ metadata:
 spec:
   general:
     serviceName: my-first-cluster
-    version: 2
+    version: 3
   dashboards:
     enable: true
-    version: 2
+    version: 3
     replicas: 1
     resources:
       requests:


### PR DESCRIPTION
### Description
I had issues running the tag 2.3.0 which the user guide has in it.  I think altering this to the rolling release `2` makes sense, or perhaps even 3 as 3.0.0 just released. 

### Issues Resolved
Closes #1026  

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

- [x] Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
