### PR TITLE
Fix logic error regarding ISM action shrink

### DIFF
--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -430,27 +430,27 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 							r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
 							return nil, errors.New(reason)
 						}
-						if action.Shrink.NumNewShards != nil {
-							if action.Shrink.MaxShardSize == nil && action.Shrink.PercentageOfSourceShards == nil {
-								shrink.NumNewShards = action.Shrink.NumNewShards
-							} else {
-								reason := "numNewShards can't exist with MaxShardSize or PercentageOfSourceShards. Keep one of these"
-								r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
-								return nil, errors.New(reason)
-							}
+					}
+					if action.Shrink.NumNewShards != nil {
+						if action.Shrink.MaxShardSize == nil && action.Shrink.PercentageOfSourceShards == nil {
+							shrink.NumNewShards = action.Shrink.NumNewShards
+						} else {
+							reason := "numNewShards can't exist with MaxShardSize or PercentageOfSourceShards. Keep one of these"
+							r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
+							return nil, errors.New(reason)
 						}
-						if action.Shrink.PercentageOfSourceShards != nil {
-							if action.Shrink.NumNewShards == nil && action.Shrink.MaxShardSize == nil {
-								shrink.PercentageOfSourceShards = action.Shrink.PercentageOfSourceShards
-							} else {
-								reason := "percentageOfSourceShards can't exist with MaxShardSize or NumNewShards. Keep one of these"
-								r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
-								return nil, errors.New(reason)
-							}
+					}
+					if action.Shrink.PercentageOfSourceShards != nil {
+						if action.Shrink.NumNewShards == nil && action.Shrink.MaxShardSize == nil {
+							shrink.PercentageOfSourceShards = action.Shrink.PercentageOfSourceShards
+						} else {
+							reason := "percentageOfSourceShards can't exist with MaxShardSize or NumNewShards. Keep one of these"
+							r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
+							return nil, errors.New(reason)
 						}
-						if action.Shrink.TargetIndexNameTemplate != nil {
-							shrink.TargetIndexNameTemplate = action.Shrink.TargetIndexNameTemplate
-						}
+					}
+					if action.Shrink.TargetIndexNameTemplate != nil {
+						shrink.TargetIndexNameTemplate = action.Shrink.TargetIndexNameTemplate
 					}
 				}
 


### PR DESCRIPTION
### Description
This PR fixes a logic error that exists in ismpolicy regarding the "shrink" action.

**Component**: Index State Management (ISM) Policy Reconciler
**Related Files**: pkg/reconcilers/ismpolicy.go

Previously, when configuring an ISM policy with a shrink action, maxShardSize was effectively required to be set because of the existing conditional.

```
if action.Shrink.MaxShardSize != nil {
  if action.Shrink.NumNewShards == nil && action.Shrink.PercentageOfSourceShards == nil {
	  shrink.MaxShardSize = action.Shrink.MaxShardSize
  } else {
	  reason := "maxShardSize can't exist with NumNewShards or PercentageOfSourceShards. Keep one of these"
	  r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
	  return nil, errors.New(reason)
  }
   <---- Bracket missing here to exit the if conditional for maxShardSize
  if action.Shrink.NumNewShards != nil {
	  if action.Shrink.MaxShardSize == nil && action.Shrink.PercentageOfSourceShards == nil {
		  shrink.NumNewShards = action.Shrink.NumNewShards
	  } else {
		  reason := "numNewShards can't exist with MaxShardSize or PercentageOfSourceShards. Keep one of these"
		  r.recorder.Event(r.instance, "Error", opensearchCustomResourceError, reason)
		  return nil, errors.New(reason)
	  }
  } 
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/1030

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
