### PR TITLE
feat(makefile): add helm-docs target

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -84,7 +84,7 @@ jobs:
 
           ## Install helm chart
           helm install opensearch-operator ../charts/opensearch-operator --set manager.image.repository=controller --set manager.image.tag=latest --set manager.image.pullPolicy=IfNotPresent --namespace default --wait
-          helm install opensearch-cluster ../charts/opensearch-cluster --set  opensearchCluster.general.version=${{ matrix.version }} --set opensearchCluster.dashboards.version=${{ matrix.version }} --wait
+          helm install opensearch-cluster ../charts/opensearch-cluster --set  cluster.general.version=${{ matrix.version }} --set cluster.dashboards.version=${{ matrix.version }} --wait
           cd functionaltests
 
           ## Run tests

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -1,0 +1,20 @@
+name: Helm Docs
+on:
+  pull_request:
+    paths: 
+        - 'charts/**'
+
+jobs: 
+  helm-docs:
+    name: helm docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: helm docs
+        working-directory: ./opensearch-operator
+        run: |
+          make helm-docs
+          if ! git diff --exit-code --quiet; then
+            echo "Helm docs are out of date. Please run 'make helm-docs' and commit the changes."
+            exit 1
+          fi

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -8,8 +8,35 @@ A Helm chart for OpenSearch Cluster
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| actionGroups | list | `[]` | List of OpensearchActionGroup. Check values.yaml file for examples. |
-| cluster.annotations | object | `{}` | OpenSearchCluster annotations |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| serviceAccount.create | bool | `false` | Create Service Account |
+| serviceAccount.name | string | `""` | Service Account name. Set `general.serviceAccount` to use this Service Account for the Opensearch cluster |
+| serviceAccount.annotations | object | `{}` | Service Account annotations |
+| cluster.name | string | `""` | cluster name, by default release name is used |
+| cluster.annotations | object | `{}` | cluster annotations |
+| cluster.labels | object | `{}` | cluster labels |
+| cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
+| cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
+| cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
+| cluster.general.httpPort | int | `9200` | Opensearch service http port |
+| cluster.general.image | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
+| cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
+| cluster.general.keystore | list | `[]` | Populate opensearch keystore before startup |
+| cluster.general.monitoring.enable | bool | `false` | Enable cluster monitoring |
+| cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
+| cluster.general.monitoring.pluginUrl | string | `""` | Custom URL for the monitoring plugin |
+| cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |
+| cluster.general.monitoring.tlsConfig | object | `{}` | Override the tlsConfig of the generated ServiceMonitor |
+| cluster.general.pluginsList | list | `[]` | List of Opensearch plugins to install |
+| cluster.general.podSecurityContext | object | `{}` | Opensearch pod security context configuration |
+| cluster.general.securityContext | object | `{}` | Opensearch securityContext |
+| cluster.general.serviceAccount | string | `""` | Opensearch serviceAccount name. If Service Account doesn't exist it could be created by setting `serviceAccount.create` and `serviceAccount.name` |
+| cluster.general.serviceName | string | `""` | Opensearch service name |
+| cluster.general.setVMMaxMapCount | bool | `true` | Enable setVMMaxMapCount. OpenSearch requires the Linux kernel vm.max_map_count option to be set to at least 262144 |
+| cluster.general.snapshotRepositories | list | `[]` | Opensearch snapshot repositories configuration |
+| cluster.general.vendor | string | `"Opensearch"` |  |
+| cluster.general.version | string | `"2.3.0"` | Opensearch version |
 | cluster.bootstrap.additionalConfig | object | `{}` | bootstrap additional configuration, key-value pairs that will be added to the opensearch.yml configuration |
 | cluster.bootstrap.affinity | object | `{}` | bootstrap pod affinity rules |
 | cluster.bootstrap.jvm | string | `""` | bootstrap pod jvm options. If jvm is not provided then the java heap size will be set to half of resources.requests.memory which is the recommend value for data nodes. If jvm is not provided and resources.requests.memory does not exist then value will be -Xmx512M -Xms512M |
@@ -42,43 +69,10 @@ A Helm chart for OpenSearch Cluster
 | cluster.dashboards.tls.secret | string | `nil` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.dashboards.tolerations | list | `[]` | dashboards pod tolerations |
 | cluster.dashboards.version | string | `"2.3.0"` | dashboards version |
-| cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
-| cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
-| cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
-| cluster.general.httpPort | int | `9200` | Opensearch service http port |
-| cluster.general.image | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
-| cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
-| cluster.general.keystore | list | `[]` | Populate opensearch keystore before startup |
-| cluster.general.monitoring.enable | bool | `false` | Enable cluster monitoring |
-| cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
-| cluster.general.monitoring.pluginUrl | string | `""` | Custom URL for the monitoring plugin |
-| cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |
-| cluster.general.monitoring.tlsConfig | object | `{}` | Override the tlsConfig of the generated ServiceMonitor |
-| cluster.general.pluginsList | list | `[]` | List of Opensearch plugins to install |
-| cluster.general.podSecurityContext | object | `{}` | Opensearch pod security context configuration |
-| cluster.general.securityContext | object | `{}` | Opensearch securityContext |
-| cluster.general.serviceAccount | string | `""` | Opensearch serviceAccount name. If Service Account doesn't exist it could be created by setting `serviceAccount.create` and `serviceAccount.name` |
-| cluster.general.serviceName | string | `""` | Opensearch service name |
-| cluster.general.setVMMaxMapCount | bool | `true` | Enable setVMMaxMapCount. OpenSearch requires the Linux kernel vm.max_map_count option to be set to at least 262144 |
-| cluster.general.snapshotRepositories | list | `[]` | Opensearch snapshot repositories configuration |
-| cluster.general.vendor | string | `"Opensearch"` |  |
-| cluster.general.version | string | `"2.3.0"` | Opensearch version |
-| cluster.ingress.dashboards.annotations | object | `{}` | dashboards ingress annotations |
-| cluster.ingress.dashboards.className | string | `""` | Ingress class name |
-| cluster.ingress.dashboards.enabled | bool | `false` | Enable ingress for dashboards service |
-| cluster.ingress.dashboards.hosts | list | `[]` | Ingress hostnames |
-| cluster.ingress.dashboards.tls | list | `[]` | Ingress tls configuration |
-| cluster.ingress.opensearch.annotations | object | `{}` | Opensearch ingress annotations |
-| cluster.ingress.opensearch.className | string | `""` | Opensearch Ingress class name |
-| cluster.ingress.opensearch.enabled | bool | `false` | Enable ingress for Opensearch service |
-| cluster.ingress.opensearch.hosts | list | `[]` | Opensearch Ingress hostnames |
-| cluster.ingress.opensearch.tls | list | `[]` | Opensearch tls configuration |
 | cluster.initHelper.imagePullPolicy | string | `"IfNotPresent"` | initHelper image pull policy |
 | cluster.initHelper.imagePullSecrets | list | `[]` | initHelper image pull secret |
 | cluster.initHelper.resources | object | `{}` | initHelper pod cpu and memory resources |
 | cluster.initHelper.version | string | `"1.36"` | initHelper version |
-| cluster.labels | object | `{}` | OpenSearchCluster labels |
-| cluster.name | string | `""` | OpenSearchCluster name, by default release name is used |
 | cluster.nodePools | list | `[{"component":"masters","diskSize":"30Gi","replicas":3,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"roles":["master","data"]}]` | Opensearch nodes configuration |
 | cluster.security.config.adminCredentialsSecret | object | `{}` | Secret that contains fields username and password to be used by the operator to access the opensearch cluster for node draining. Must be set if custom securityconfig is provided. |
 | cluster.security.config.adminSecret | object | `{}` | TLS Secret that contains a client certificate (tls.key, tls.crt, ca.crt) with admin rights in the opensearch cluster. Must be set if transport certificates are provided by user and not generated |
@@ -92,18 +86,24 @@ A Helm chart for OpenSearch Cluster
 | cluster.security.tls.transport.nodesDn | list | `[]` | Allowed Certificate DNs for nodes, only used when existing certificates are provided |
 | cluster.security.tls.transport.perNode | bool | `true` | Separate certificate per node |
 | cluster.security.tls.transport.secret | object | `{}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
-| componentTemplates | list | `[]` | List of OpensearchComponentTemplate. Check values.yaml file for examples. |
-| fullnameOverride | string | `""` |  |
-| indexTemplates | list | `[]` | List of OpensearchIndexTemplate. Check values.yaml file for examples. |
-| ismPolicies | list | `[]` | List of OpenSearchISMPolicy. Check values.yaml file for examples. |
-| nameOverride | string | `""` |  |
+| cluster.ingress.opensearch.enabled | bool | `false` | Enable ingress for Opensearch service |
+| cluster.ingress.opensearch.annotations | object | `{}` | Opensearch ingress annotations |
+| cluster.ingress.opensearch.className | string | `""` | Opensearch Ingress class name |
+| cluster.ingress.opensearch.hosts | list | `[]` | Opensearch Ingress hostnames |
+| cluster.ingress.opensearch.tls | list | `[]` | Opensearch tls configuration |
+| cluster.ingress.dashboards.enabled | bool | `false` | Enable ingress for dashboards service |
+| cluster.ingress.dashboards.annotations | object | `{}` | dashboards ingress annotations |
+| cluster.ingress.dashboards.className | string | `""` | Ingress class name |
+| cluster.ingress.dashboards.hosts | list | `[]` | Ingress hostnames |
+| cluster.ingress.dashboards.tls | list | `[]` | Ingress tls configuration |
 | roles | list | `[]` | List of OpensearchRole. Check values.yaml file for examples. |
-| serviceAccount.annotations | object | `{}` | Service Account annotations |
-| serviceAccount.create | bool | `false` | Create Service Account |
-| serviceAccount.name | string | `""` | Service Account name. Set `general.serviceAccount` to use this Service Account for the Opensearch cluster |
-| tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
 | users | list | `[]` | List of OpensearchUser. Check values.yaml file for examples. |
 | usersRoleBinding | list | `[]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
+| tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
+| actionGroups | list | `[]` | List of OpensearchActionGroup. Check values.yaml file for examples. |
+| componentTemplates | list | `[]` | List of OpensearchComponentTemplate. Check values.yaml file for examples. |
+| indexTemplates | list | `[]` | List of OpensearchIndexTemplate. Check values.yaml file for examples. |
+| ismPolicies | list | `[]` | List of OpenSearchISMPolicy. Check values.yaml file for examples. |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -15,18 +15,18 @@ serviceAccount:
   # -- Service Account annotations
   annotations: {}
 
-# OpenSearchCluster configuration
+# cluster configuration
 cluster:
-  # -- OpenSearchCluster name, by default release name is used
+  # -- cluster name, by default release name is used
   name: ""
 
-  # -- OpenSearchCluster annotations
+  # -- cluster annotations
   annotations: {}
 
-  # -- OpenSearchCluster labels
+  # -- cluster labels
   labels: {}
 
-  # OpenSearchCluster general configuration
+  # cluster general configuration
   general:
     # -- Extra items to add to the opensearch.yml
     additionalConfig: {}
@@ -113,7 +113,7 @@ cluster:
     # -- Opensearch version
     version: 2.3.0
 
-  # OpenSearchCluster boostrap pod configuration
+  # cluster boostrap pod configuration
   bootstrap:
     # -- bootstrap additional configuration, key-value pairs that will be added to the opensearch.yml configuration
     additionalConfig: {}
@@ -134,12 +134,12 @@ cluster:
     # -- bootstrap pod tolerations
     tolerations: []
 
-  # OpenSearchCluster additional services
+  # cluster additional services
   confMgmt:
     # -- Enable nodes to be safely removed from the cluster
     smartScaler: false
 
-  # OpenSearchCluster dashboards configuration
+  # cluster dashboards configuration
   dashboards:
     # -- Additional properties for opensearch_dashboards.yaml
     additionalConfig: {}

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -1,29 +1,80 @@
-# OpenSearch-k8s-operator
+# opensearch-operator
 
-The Kubernetes [OpenSearch Operator](https://github.com/opensearch-project/opensearch-k8s-operator) is used for automating the deployment, provisioning, management, and orchestration of OpenSearch clusters and OpenSearch dashboards.
+![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
-## Getting started
+The OpenSearch Operator Helm chart for Kubernetes
 
-The Operator can be easily installed using helm on any CNCF-certified Kubernetes cluster. Please refer to the [User Guide](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/userguide/main.md) for more information.
+## Values
 
-### Installation Using Helm
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| nodeSelector | object | `{}` |  |
+| tolerations | list | `[]` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| priorityClassName | string | `""` |  |
+| manager.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| manager.extraEnv | list | `[]` |  |
+| manager.resources.limits.cpu | string | `"200m"` |  |
+| manager.resources.limits.memory | string | `"500Mi"` |  |
+| manager.resources.requests.cpu | string | `"100m"` |  |
+| manager.resources.requests.memory | string | `"350Mi"` |  |
+| manager.livenessProbe.failureThreshold | int | `3` |  |
+| manager.livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| manager.livenessProbe.httpGet.port | int | `8081` |  |
+| manager.livenessProbe.periodSeconds | int | `15` |  |
+| manager.livenessProbe.successThreshold | int | `1` |  |
+| manager.livenessProbe.timeoutSeconds | int | `3` |  |
+| manager.livenessProbe.initialDelaySeconds | int | `10` |  |
+| manager.readinessProbe.failureThreshold | int | `3` |  |
+| manager.readinessProbe.httpGet.path | string | `"/readyz"` |  |
+| manager.readinessProbe.httpGet.port | int | `8081` |  |
+| manager.readinessProbe.periodSeconds | int | `15` |  |
+| manager.readinessProbe.successThreshold | int | `1` |  |
+| manager.readinessProbe.timeoutSeconds | int | `3` |  |
+| manager.readinessProbe.initialDelaySeconds | int | `10` |  |
+| manager.parallelRecoveryEnabled | bool | `true` |  |
+| manager.pprofEndpointsEnabled | bool | `false` |  |
+| manager.image.repository | string | `"opensearchproject/opensearch-operator"` |  |
+| manager.image.tag | string | `""` |  |
+| manager.image.pullPolicy | string | `"Always"` |  |
+| manager.imagePullSecrets | list | `[]` |  |
+| manager.dnsBase | string | `"cluster.local"` |  |
+| manager.loglevel | string | `"info"` |  |
+| manager.watchNamespace | string | `nil` |  |
+| installCRDs | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| kubeRbacProxy.enable | bool | `true` |  |
+| kubeRbacProxy.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| kubeRbacProxy.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| kubeRbacProxy.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| kubeRbacProxy.resources.limits.cpu | string | `"50m"` |  |
+| kubeRbacProxy.resources.limits.memory | string | `"50Mi"` |  |
+| kubeRbacProxy.resources.requests.cpu | string | `"25m"` |  |
+| kubeRbacProxy.resources.requests.memory | string | `"25Mi"` |  |
+| kubeRbacProxy.livenessProbe.failureThreshold | int | `3` |  |
+| kubeRbacProxy.livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| kubeRbacProxy.livenessProbe.httpGet.port | int | `10443` |  |
+| kubeRbacProxy.livenessProbe.httpGet.scheme | string | `"HTTPS"` |  |
+| kubeRbacProxy.livenessProbe.periodSeconds | int | `15` |  |
+| kubeRbacProxy.livenessProbe.successThreshold | int | `1` |  |
+| kubeRbacProxy.livenessProbe.timeoutSeconds | int | `3` |  |
+| kubeRbacProxy.livenessProbe.initialDelaySeconds | int | `10` |  |
+| kubeRbacProxy.readinessProbe.failureThreshold | int | `3` |  |
+| kubeRbacProxy.readinessProbe.httpGet.path | string | `"/healthz"` |  |
+| kubeRbacProxy.readinessProbe.httpGet.port | int | `10443` |  |
+| kubeRbacProxy.readinessProbe.httpGet.scheme | string | `"HTTPS"` |  |
+| kubeRbacProxy.readinessProbe.periodSeconds | int | `15` |  |
+| kubeRbacProxy.readinessProbe.successThreshold | int | `1` |  |
+| kubeRbacProxy.readinessProbe.timeoutSeconds | int | `3` |  |
+| kubeRbacProxy.readinessProbe.initialDelaySeconds | int | `10` |  |
+| kubeRbacProxy.image.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |  |
+| kubeRbacProxy.image.tag | string | `"v0.15.0"` |  |
+| useRoleBindings | bool | `false` |  |
 
-#### Get Repo Info
-```
-helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
-helm repo update
-```
-#### Install Chart
-```
-helm install [RELEASE_NAME] opensearch-operator/opensearch-operator
-```
-#### Uninstall Chart
-```
-helm uninstall [RELEASE_NAME]
-```
-#### Upgrade Chart
-```
-helm repo update
-helm upgrade [RELEASE_NAME] opensearch-operator/opensearch-operator
-```
-
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -43,8 +43,13 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: controller-gen helm-docs ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and helm-docs.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+.PHONY: helm-docs
+helm-docs: ${HELM_DOCS}
+	${HELM_DOCS} -s file -c ../charts/opensearch-operator
+	${HELM_DOCS} -s file -c ../charts/opensearch-cluster
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -114,11 +119,13 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 MOCKERY ?= $(LOCALBIN)/mockery
+HELM_DOCS := $(LOCALBIN)/helm-docs
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 MOCKERY_VERSION ?= v2.42.1
+HELM_DOCS_VERSION ?= 1.14.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -140,3 +147,9 @@ $(MOCKERY): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: helm-docs
+helm-docs: $(HELM_DOCS) ## Download helm-docs locally if necessary.
+$(HELM_DOCS): $(LOCALBIN)
+	@curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v$(HELM_DOCS_VERSION)/helm-docs_$(HELM_DOCS_VERSION)_$$(uname -s)_x86_64.tar.gz" | tar -xz -C $(LOCALBIN) helm-docs
+	@chmod +x $(HELM_DOCS)


### PR DESCRIPTION
### Description

- Adds helm-docs to the makefile.
- Enforces up to date helm-docs via a new CI job.
- Fixes invalid `--set` param arguments in functional tests.

### Issues Resolved

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
