### PR TITLE
Fix: combine image and version field for initHelper of chart in opensearch-cluster (>=3.0.0)

### DIFF
--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -73,6 +73,7 @@ A Helm chart for OpenSearch Cluster
 | cluster.ingress.opensearch.enabled | bool | `false` | Enable ingress for Opensearch service |
 | cluster.ingress.opensearch.hosts | list | `[]` | Opensearch Ingress hostnames |
 | cluster.ingress.opensearch.tls | list | `[]` | Opensearch tls configuration |
+| cluster.initHelper.image | string | `"docker.io/busybox"` | initHelper image |
 | cluster.initHelper.imagePullPolicy | string | `"IfNotPresent"` | initHelper image pull policy |
 | cluster.initHelper.imagePullSecrets | list | `[]` | initHelper image pull secret |
 | cluster.initHelper.resources | object | `{}` | initHelper pod cpu and memory resources |

--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -27,7 +27,9 @@ spec:
     serviceName: {{ .serviceName | default $clusterName }}
   {{- end }}
   {{- with .Values.cluster.initHelper }}
-  initHelper: {{ . | toYaml | nindent 4 }}
+  initHelper:
+    {{- omit . "image" | toYaml | nindent 4 }}
+    image: {{ .image }}:{{ .version }}
   {{- end }}
   {{- with .Values.cluster.nodePools }}
   nodePools: {{ . | toYaml | nindent 4 }}

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -226,7 +226,7 @@ cluster:
   # initHelper configuration
   initHelper:
     # -- initHelper image
-    image: busybox
+    image: docker.io/busybox
     
     # -- initHelper image pull policy
     imagePullPolicy: "IfNotPresent"

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -225,6 +225,9 @@ cluster:
 
   # initHelper configuration
   initHelper:
+    # -- initHelper image
+    image: busybox
+    
     # -- initHelper image pull policy
     imagePullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
### Description
- For a quick fix to this issue (without any change in templates), I used an `image` field in the opensearch-cluster chart and deployed it. I would recommend this stopgap for the current release version.
```
# initHelper configuration
initHelper:
  image: "harbor.abc.com/nexus/docker-mig/library/busybox:1.31.1"
  imagePullPolicy: IfNotPresent
```

- However, if **opensearch-k8s-operator** follows the principle of specifying the **version** of image separately like `spec.dashboards` or `spec.general`, I suggest to fix it by:
```
  {{- with .Values.cluster.dashboards }}
  dashboards:
    {{- omit . "image" | toYaml | nindent 4 }}
    image: {{ .image }}:{{ .version }}
  {{- end }}
  {{- with .Values.cluster.general }}
  general:
    {{- omit . "image" "serviceName" | toYaml | nindent 4 }}
    image: {{ .image }}:{{ .version }}
    serviceName: {{ .serviceName | default $clusterName }}
  {{- end }}
  {{- with .Values.cluster.initHelper }}
    {{- omit . "image" | toYaml | nindent 4 }}
    image: {{ .image }}:{{ .version }}
  {{- end }}
```

### Issues Resolved
- https://github.com/opensearch-project/opensearch-k8s-operator/issues/1039

### Check List
- [X] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [X] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
