### PR TITLE
fix(helm): use serviceName for ingress backend if set, fallback to clusterName

### DIFF
--- a/charts/opensearch-cluster/templates/ingress.yaml
+++ b/charts/opensearch-cluster/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- $clusterName := include "opensearch-cluster.cluster-name" . }}
 {{- $svcPort := .Values.cluster.general.httpPort -}}
+{{- $svcName := .Values.cluster.general.serviceName | default $clusterName }}
 {{- if .Values.cluster.ingress.opensearch.enabled -}}
 ---
 {{- if and .Values.cluster.ingress.opensearch.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -50,11 +51,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $clusterName }}
+                name: {{ $svcName }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $clusterName }}
+              serviceName: {{ $svcName }}
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
@@ -111,11 +112,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $clusterName }}-dashboards
+                name: {{ $svcName }}-dashboards
                 port:
                   number: 5601
               {{- else }}
-              serviceName: {{ $clusterName }}
+              serviceName: {{ $svcName }}
               servicePort: 5601
               {{- end }}
           {{- end }}


### PR DESCRIPTION
…usterName

### Description
allow the Ingress backend to use a user-defined serviceName if specified, otherwise defaulting to the clusterName.

### Issues Resolved
#1042 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
