### PR TITLE
feat: Add standard status Conditions helpers

### DIFF
--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -342,6 +342,12 @@ type ClusterStatus struct {
 	// AvailableNodes is the number of available instances.
 	AvailableNodes int32            `json:"availableNodes,omitempty"`
 	Health         OpenSearchHealth `json:"health,omitempty"`
+	// ObservedGeneration reflects the generation of the spec that has been acted upon.
+	// +kubebuilder:default=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Conditions represent the latest available observations of an object's current state.
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // +kubebuilder:object:root=true

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1
 import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -372,6 +373,13 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 	if in.ComponentsStatus != nil {
 		in, out := &in.ComponentsStatus, &out.ComponentsStatus
 		*out = make([]ComponentStatus, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/opensearch-operator/pkg/conditions/conditions.go
+++ b/opensearch-operator/pkg/conditions/conditions.go
@@ -1,0 +1,51 @@
+package conditions
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	opsterv1 "github.com/Opster/opensearch-k8s-operator/opensearch-operator/api/v1"
+)
+
+// Condition types used by the operator.
+const (
+	ConditionReady       = "Ready"
+	ConditionReconciling = "Reconciling"
+)
+
+// Set sets or updates a condition in the status slice and refreshes ObservedGeneration.
+func Set(cluster *opsterv1.OpenSearchCluster, cond metav1.Condition) {
+	cond.LastTransitionTime = metav1.Now()
+	meta.SetStatusCondition(&cluster.Status.Conditions, cond)
+	// Always update ObservedGeneration when we touch conditions so users can see
+	// the controller processed this generation.
+	cluster.Status.ObservedGeneration = cluster.GetGeneration()
+}
+
+// SetReady marks the Ready condition as True/False with a reason & message.
+func SetReady(cluster *opsterv1.OpenSearchCluster, ready bool, reason, message string) {
+	status := metav1.ConditionFalse
+	if ready {
+		status = metav1.ConditionTrue
+	}
+	Set(cluster, metav1.Condition{
+		Type:    ConditionReady,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+// SetReconciling marks the Reconciling condition.
+func SetReconciling(cluster *opsterv1.OpenSearchCluster, inProgress bool, reason, message string) {
+	status := metav1.ConditionFalse
+	if inProgress {
+		status = metav1.ConditionTrue
+	}
+	Set(cluster, metav1.Condition{
+		Type:    ConditionReconciling,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}

--- a/opensearch-operator/pkg/conditions/conditions_test.go
+++ b/opensearch-operator/pkg/conditions/conditions_test.go
@@ -1,0 +1,51 @@
+package conditions
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	opsterv1 "github.com/Opster/opensearch-k8s-operator/opensearch-operator/api/v1"
+)
+
+var _ = Describe("Conditions helper", func() {
+	var cluster *opsterv1.OpenSearchCluster
+
+	BeforeEach(func() {
+		cluster = &opsterv1.OpenSearchCluster{}
+		// pretend controller processed generation 5
+		cluster.ObjectMeta.Generation = 5
+	})
+
+	It("sets Ready condition true and observedGeneration", func() {
+		SetReady(cluster, true, "TestReason", "all good")
+
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, ConditionReady)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal("TestReason"))
+		Expect(cond.Message).To(Equal("all good"))
+		Expect(cluster.Status.ObservedGeneration).To(Equal(int64(5)))
+	})
+
+	It("sets Reconciling false", func() {
+		SetReconciling(cluster, false, "Idle", "no work")
+
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, ConditionReconciling)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	It("overwrites existing condition keeping history", func() {
+		// First set true
+		SetReady(cluster, true, "Foo", "bar")
+		// Save first transition
+		firstTransition := meta.FindStatusCondition(cluster.Status.Conditions, ConditionReady).LastTransitionTime
+		// Now set false, expect transition time to change
+		SetReady(cluster, false, "Baz", "qux")
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, ConditionReady)
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.LastTransitionTime.Time.After(firstTransition.Time)).To(BeTrue())
+	})
+})

--- a/opensearch-operator/pkg/conditions/suite_test.go
+++ b/opensearch-operator/pkg/conditions/suite_test.go
@@ -1,0 +1,13 @@
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConditions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conditions Helper Suite")
+}


### PR DESCRIPTION
### Description
New helper package pkg/conditions
Set – generic setter that also refreshes ObservedGeneration
SetReady – convenience helper
Defined condition type constants (Ready, Reconciling)

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
