### PR TITLE
Fix MergeConfigs() to work with multiple node pools

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -150,13 +150,14 @@ func GetByComponent(left opsterv1.ComponentStatus, right opsterv1.ComponentStatu
 }
 
 func MergeConfigs(left map[string]string, right map[string]string) map[string]string {
-	if left == nil {
-		return right
+	result := make(map[string]string)
+	for k, v := range left {
+		result[k] = v
 	}
 	for k, v := range right {
-		left[k] = v
+		result[k] = v
 	}
-	return left
+	return result
 }
 
 // Return the keys of the input map in sorted order

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MergeConfigs mutation behavior", func() {
+	It("should merge the maps such that right is higher priority than left, and not mutate either argument when merging", func() {
+		generalConfig := map[string]string{"http.compression": "true"}
+		poolConfig := map[string]string{"node.data": "false"}
+
+		// Save a copy of the original
+		original := map[string]string{"http.compression": "true"}
+
+		// Merge and check result
+		merged := MergeConfigs(generalConfig, poolConfig)
+		expected := map[string]string{"http.compression": "true", "node.data": "false"}
+		Expect(merged).To(Equal(expected))
+
+		// Check that longLived was not mutated
+		Expect(generalConfig).To(Equal(original))
+
+		// Merge again with a new config
+		poolConfig2 := map[string]string{"node.master": "false", "http.compression": "false"}
+		expected2 := map[string]string{"http.compression": "false", "node.master": "false"}
+		merged2 := MergeConfigs(generalConfig, poolConfig2)
+		Expect(merged2).To(Equal(expected2))
+
+		// Still not mutated
+		Expect(generalConfig).To(Equal(original))
+	})
+})


### PR DESCRIPTION
### Description
Fix MergeConfigs() to work with multiple node pools

### Issues Resolved
Fixes #1057 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
