### PR TITLE
[Opensearch] pvc mount 기능 추가, replicas 무시하도록 설정

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -1287,6 +1287,20 @@ spec:
                           description: Path in the container to mount the volume at.
                             Required.
                           type: string
+                        persistentVolumeClaim:
+                          description: PersistentVolumeClaim object to use to populate the volume
+                          properties:
+                            claimName:
+                              description: |-
+                                The name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          type: object
                         projected:
                           description: Projected object to use to populate the volume
                           properties:
@@ -3561,6 +3575,20 @@ spec:
                           description: Path in the container to mount the volume at.
                             Required.
                           type: string
+                        persistentVolumeClaim:
+                          description: PersistentVolumeClaim object to use to populate the volume
+                          properties:
+                            claimName:
+                              description: |-
+                                The name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          type: object
                         projected:
                           description: Projected object to use to populate the volume
                           properties:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -106,8 +106,11 @@ type ReadinessProbeConfig struct {
 }
 
 type NodePool struct {
-	Component                 string                            `json:"component"`
-	Replicas                  int32                             `json:"replicas"`
+	Component string `json:"component"`
+	// Count of Elasticsearch nodes to deploy.
+	// If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
+	// +kubebuilder:validation:Optional
+	Replicas                  int32                             `json:"replicas,omitempty"`
 	DiskSize                  string                            `json:"diskSize,omitempty"`
 	Resources                 corev1.ResourceRequirements       `json:"resources,omitempty"`
 	Jvm                       string                            `json:"jvm,omitempty"`
@@ -299,6 +302,8 @@ type AdditionalVolume struct {
 	EmptyDir *corev1.EmptyDirVolumeSource `json:"emptyDir,omitempty"`
 	// CSI object to use to populate the volume
 	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`
+	// PersistentVolumeClaim object to use to populate the volume
+	PersistentVolumeClaim *corev1.PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
 	// Projected object to use to populate the volume
 	Projected *corev1.ProjectedVolumeSource `json:"projected,omitempty"`
 	// Whether to restart the pods on content change

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -151,6 +151,11 @@ func (in *AdditionalVolume) DeepCopyInto(out *AdditionalVolume) {
 		*out = new(corev1.CSIVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PersistentVolumeClaim != nil {
+		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+		*out = new(corev1.PersistentVolumeClaimVolumeSource)
+		**out = **in
+	}
 	if in.Projected != nil {
 		in, out := &in.Projected, &out.Projected
 		*out = new(corev1.ProjectedVolumeSource)

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -1287,6 +1287,23 @@ spec:
                           description: Path in the container to mount the volume at.
                             Required.
                           type: string
+                        persistentVolumeClaim:
+                          description: PersistentVolumeClaim object to use to populate
+                            the volume
+                          properties:
+                            claimName:
+                              description: |-
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
                         projected:
                           description: Projected object to use to populate the volume
                           properties:
@@ -3561,6 +3578,23 @@ spec:
                           description: Path in the container to mount the volume at.
                             Required.
                           type: string
+                        persistentVolumeClaim:
+                          description: PersistentVolumeClaim object to use to populate
+                            the volume
+                          properties:
+                            claimName:
+                              description: |-
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
                         projected:
                           description: Projected object to use to populate the volume
                           properties:
@@ -5815,6 +5849,9 @@ spec:
                           type: object
                       type: object
                     replicas:
+                      description: |-
+                        Count of Elasticsearch nodes to deploy.
+                        If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
                       format: int32
                       type: integer
                     resources:
@@ -6094,7 +6131,6 @@ spec:
                       type: array
                   required:
                   - component
-                  - replicas
                   - roles
                   type: object
                 type: array

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -138,6 +138,15 @@ func CreateAdditionalVolumes(
 				},
 			})
 		}
+		if volumeConfig.PersistentVolumeClaim != nil {
+			readOnly = volumeConfig.PersistentVolumeClaim.ReadOnly
+			retVolumes = append(retVolumes, corev1.Volume{
+				Name: volumeConfig.Name,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: volumeConfig.PersistentVolumeClaim,
+				},
+			})
+		}
 		if volumeConfig.Projected != nil {
 			retVolumes = append(retVolumes, corev1.Volume{
 				Name: volumeConfig.Name,

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -154,6 +154,20 @@ var _ = Describe("Additional volumes", func() {
 		})
 	})
 
+	When("PersistentVolumeClaim volume is added", func() {
+		It("Should have PersistentVolumeClaimVolumeSource fields", func() {
+			readOnly := true
+			volumeConfigs[0].PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "testClaim",
+				ReadOnly:  readOnly,
+			}
+
+			volume, _, _, _ := CreateAdditionalVolumes(mockClient, namespace, volumeConfigs)
+			Expect(volume[0].PersistentVolumeClaim.ClaimName).To(Equal("testClaim"))
+			Expect(volume[0].PersistentVolumeClaim.ReadOnly).Should(BeTrue())
+		})
+	})
+
 	When("Projected volume is added", func() {
 		It("Should have ProjectedVolumeSource fields", func() {
 			volumeConfigs[0].Projected = &v1.ProjectedVolumeSource{


### PR DESCRIPTION
### Description
- Opensearch 커스텀 리소스에서, PVC Mount 할 수 있도록 추가
- HPA를 활용하기 위해 replicas를 CR에서 꼭 기입하지 않아도 되도록 추가

## 코드
Local에 k3d cluster를 배포하여 테스트 진행했습니다.

[1] Nodepool 구조체에서 replicas를 기입하지 않아도 되도록 설정 추가

```
type NodePool struct {
	Component string `json:"component"`
	// Count of Elasticsearch nodes to deploy.
	// If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
	// +kubebuilder:validation:Optional
	Replicas                  int32                             `json:"replicas,omitempty"`
```

[2] PVC를 마운트할 수 있도록 추가
https://github.com/opensearch-project/opensearch-k8s-operator/pull/852/files 에 있는 내용들을 그대로 복붙

## 기능 테스트

1. **kubectl apply -f xxx.yaml** 한 뒤 Custom Resource가 제출되는지 확인

```
  nodePools:
    - component: masters
      replicas: 1
..

    - component: coord
..
      roles: []
..
```

```
❯ kubectl apply -f examples/2.x/opensearch-cluster.yaml
opensearchcluster.opensearch.opster.io/my-first-cluster created

> kubectl get sts
NAMESPACE   NAME                       READY   AGE
default     my-first-cluster-coord     0/0     42s
default     my-first-cluster-masters   0/1     42s
```

1. Custom Resource 제출 성공한 뒤, Replicas를 늘려보기

```
    - component: coord
      replicas: 1

❯ kubectl apply -f examples/2.x/opensearch-cluster.yaml
opensearchcluster.opensearch.opster.io/my-first-cluster configured

NAMESPACE     NAME                                           READY   STATUS      RESTARTS   AGE    IP           NODE                         NOMINATED NODE   READINESS GATES
default       my-first-cluster-bootstrap-0                   1/1     Running     0          2m1s   10.42.0.18   k3d-local-cluster-server-0   <none>           <none>
default       my-first-cluster-coord-0                       0/1     Pending     0          19s    <none>       <none>                       <none>           <none>
default       my-first-cluster-dashboards-8d96d9c88-pm6j5    0/1     Running     0          80s    10.42.0.20   k3d-local-cluster-server-0   <none>           <none>
default       my-first-cluster-masters-0                     0/1     Running     0          2m1s   10.42.0.19   k3d-local-cluster-server-0   <none>           <none>
default       my-first-cluster-securityconfig-update-qwrlf   1/1     Running     0          2m1s   10.42.0.17   k3d-local-cluster-server-0   <none>           <none>
```

2. PVC 테스트
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: test-pv
spec:
  capacity:
    storage: 1Gi
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Delete
  storageClassName: manual
  hostPath:
    path: /tmp/test-pv  # k3d 노드 컨테이너 내부 경로
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: manual

..

apiVersion: opensearch.opster.io/v1
kind: OpenSearchCluster
metadata:
  name: my-first-cluster
  namespace: default
spec:
  general:
    additionalVolumes:
      - name: test-mount
        path: /usr/share/opensearch/config/analysis
        persistentVolumeClaim:
          claimName: test-pvc

```


```
❯ k exec -it my-first-cluster-masters-0 -- bash
Defaulted container "opensearch" out of: opensearch, init (init)
[opensearch@my-first-cluster-masters-0 ~]$ cd config/analysis/
[opensearch@my-first-cluster-masters-0 analysis]$
[opensearch@my-first-cluster-masters-0 analysis]$
[opensearch@my-first-cluster-masters-0 analysis]$ pwd
/usr/share/opensearch/config/analysis
[opensearch@my-first-cluster-masters-0 analysis]$
```



