### PR TITLE
Add hostAliases to opensearch and dashboards pods

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -2754,6 +2754,25 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostAliases:
+                    items:
+                      description: |-
+                        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                        pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
                   image:
                     type: string
                   imagePullPolicy:
@@ -3993,6 +4012,25 @@ spec:
                     description: Drain data nodes controls whether to drain data notes
                       on rolling restart operations
                     type: boolean
+                  hostAliases:
+                    items:
+                      description: |-
+                        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                        pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
                   httpPort:
                     default: 9200
                     format: int32

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -235,6 +235,12 @@ GeneralConfig defines global Opensearch cluster configuration
         <td>List of additional volume mounts</td>
         <td>false</td>
         <td>-</td>
+      </tr><tr>
+        <td><b>hostAliases</b></td>
+        <td>[]corev1.HostAlias</td>
+        <td>Set the host aliases for the cluster pods.</td>
+        <td>false</td>
+        <td> - </td>
       </tr>
 </table>
 
@@ -433,6 +439,12 @@ Dashboards defines Opensearch-Dashboard configuration and deployment
         <td><b>securityContext</b></td>
         <td>*corev1.SecurityContext</td>
         <td>Set the security context for the dashboards pods' containers.</td>
+        <td>false</td>
+        <td> - </td>
+      </tr><tr>
+        <td><b>hostAliases</b></td>
+        <td>[]corev1.HostAlias</td>
+        <td>Set the host aliases for the dashboards pods.</td>
         <td>false</td>
         <td> - </td>
       </tr>

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -655,6 +655,26 @@ The Opensearch pods by default launch an init container to configure the volume.
 
 Note that the bootstrap pod started during initial cluster setup uses the same (pod)securityContext as the Opensearch pods (with the same limitations for the init containers).
 
+### Host Aliases for pods and containers
+
+You can add entries to Opensearch and Dashboard pods /etc/hosts files using [HostAliases](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/).
+
+The structure is the same for both Opensearch pods (in `spec.general`) and the Dashboard pod (in `spec.dashboards`):
+
+```yaml
+spec:
+  general:
+    hostAliases:
+    - hostnames:
+      - example.com
+      ip: 127.0.0.1
+  dashboards:
+    hostAliases:
+    - hostnames:
+      - example.com
+      ip: 127.0.0.1
+```
+
 ### Labels or Annotations on OpenSearch nodes
 
 You can add additional labels or annotations on the nodepool configuration. This is useful for integration with other applications such as a service mesh, or configuring a prometheus scrape endpoint:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -70,6 +70,7 @@ type GeneralConfig struct {
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// Set security context for the cluster pods' container
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+	HostAliases     []corev1.HostAlias      `json:"hostAliases,omitempty"`
 }
 
 type PdbConfig struct {
@@ -205,6 +206,7 @@ type DashboardsConfig struct {
 	Annotations                 map[string]string           `json:"annotations,omitempty"`
 	Service                     DashboardsServiceSpec       `json:"service,omitempty"`
 	PluginsList                 []string                    `json:"pluginsList,omitempty"`
+	HostAliases                 []corev1.HostAlias          `json:"hostAliases,omitempty"`
 	// Set security context for the dashboards pods
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// Set security context for the dashboards pods' container

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -604,6 +604,13 @@ func (in *DashboardsConfig) DeepCopyInto(out *DashboardsConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]corev1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(corev1.PodSecurityContext)
@@ -837,6 +844,13 @@ func (in *GeneralConfig) DeepCopyInto(out *GeneralConfig) {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(corev1.SecurityContext)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]corev1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -2754,6 +2754,25 @@ spec:
                       - name
                       type: object
                     type: array
+                  hostAliases:
+                    items:
+                      description: |-
+                        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                        pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
                   image:
                     type: string
                   imagePullPolicy:
@@ -3993,6 +4012,25 @@ spec:
                     description: Drain data nodes controls whether to drain data notes
                       on rolling restart operations
                     type: boolean
+                  hostAliases:
+                    items:
+                      description: |-
+                        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                        pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
                   httpPort:
                     default: 9200
                     format: int32

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -537,6 +537,7 @@ func NewSTSForNodePool(
 					ImagePullSecrets:          image.ImagePullSecrets,
 					PriorityClassName:         node.PriorityClassName,
 					SecurityContext:           podSecurityContext,
+					HostAliases:               cr.Spec.General.HostAliases,
 				},
 			},
 			VolumeClaimTemplates: func() []corev1.PersistentVolumeClaim {

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -958,4 +958,27 @@ var _ = Describe("Builders", func() {
 			Expect(job.Spec.Template.Spec.Containers[0].Resources).To(Equal(clusterObject.Spec.Security.Config.UpdateJob.Resources))
 		})
 	})
+
+	When("configuring a host alias for the cluster", func() {
+		It("should configure the host alias for the statefulset pods", func() {
+			hostNames := []string{"dummy.com"}
+			hostAlias := corev1.HostAlias{
+				IP:        "3.5.7.9",
+				Hostnames: hostNames,
+			}
+			clusterObject := ClusterDescWithVersion("2.2.1")
+			clusterObject.Namespace = "foobar"
+			clusterObject.Name = "foobar"
+			clusterObject.Spec.General.HostAliases = []corev1.HostAlias{hostAlias}
+			nodePool := opsterv1.NodePool{
+				Replicas:  3,
+				Component: "masters",
+				Roles:     []string{"cluster_manager", "data"},
+			}
+			clusterObject.Spec.NodePools = append(clusterObject.Spec.NodePools, nodePool)
+
+			sts := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(sts.Spec.Template.Spec.HostAliases).To(Equal([]corev1.HostAlias{hostAlias}))
+		})
+	})
 })

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -169,6 +169,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 					Tolerations:        cr.Spec.Dashboards.Tolerations,
 					Affinity:           cr.Spec.Dashboards.Affinity,
 					SecurityContext:    podSecurityContext,
+					HostAliases:        cr.Spec.Dashboards.HostAliases,
 				},
 			},
 		},

--- a/opensearch-operator/pkg/builders/dashboards_test.go
+++ b/opensearch-operator/pkg/builders/dashboards_test.go
@@ -234,4 +234,28 @@ var _ = Describe("Builders", func() {
 			Expect(result.Spec.Selector).To(HaveKeyWithValue("opensearch.cluster.dashboards", clusterName))
 		})
 	})
+
+	When("configuring a host alias for the dashboards", func() {
+		It("should configure the host alias for the dashboard pods", func() {
+			hostNames := []string{"dummy.com"}
+			hostAlias := corev1.HostAlias{
+				IP:        "3.5.7.9",
+				Hostnames: hostNames,
+			}
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-name", Namespace: "some-namespace", UID: "dummyuid"},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{
+						ServiceName: "some-name",
+					},
+					Dashboards: opsterv1.DashboardsConfig{
+						Enable:      true,
+						HostAliases: []corev1.HostAlias{hostAlias},
+					},
+				},
+			}
+			result := NewDashboardsDeploymentForCR(&spec, nil, nil, nil)
+			Expect(result.Spec.Template.Spec.HostAliases).To(Equal([]corev1.HostAlias{hostAlias}))
+		})
+	})
 })


### PR DESCRIPTION
Implements #1077

Changes:
- `hostAliases` fields for cluster and dashboards pods
- docs for crds and userguide
- unit tests