### PR TITLE
Add support for bootstrap pod annotations

### DIFF
--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -121,6 +121,9 @@ cluster:
     # -- bootstrap pod affinity rules
     affinity: {}
 
+    # -- bootstrap pod annotations
+    annotations: {}
+
     # -- bootstrap pod jvm options. If jvm is not provided then the java heap size will be set to half of resources.requests.memory which is the recommend value for data nodes.
     # If jvm is not provided and resources.requests.memory does not exist then value will be -Xmx512M -Xms512M
     jvm: ""
@@ -243,6 +246,8 @@ cluster:
   # -- Opensearch nodes configuration
   nodePools:
     - component: masters
+      # -- node pool pod annotations
+      annotations: {}
       diskSize: "30Gi"
       replicas: 3
       roles:

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -987,6 +987,10 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                     type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                   jvm:
                     type: string
                   keystore:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -173,6 +173,7 @@ type BootstrapConfig struct {
 	Jvm          string                      `json:"jvm,omitempty"`
 	// Extra items to add to the opensearch.yml, defaults to General.AdditionalConfig
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
+	Annotations      map[string]string `json:"annotations,omitempty"`
 	PluginsList      []string          `json:"pluginsList,omitempty"`
 	Keystore         []KeystoreValue   `json:"keystore,omitempty"`
 }

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -295,6 +295,13 @@ func (in *BootstrapConfig) DeepCopyInto(out *BootstrapConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PluginsList != nil {
 		in, out := &in.PluginsList, &out.PluginsList
 		*out = make([]string, len(*in))

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -987,6 +987,10 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                     type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                   jvm:
                     type: string
                   keystore:

--- a/opensearch-operator/opensearch-gateway/services/os_client.go
+++ b/opensearch-operator/opensearch-gateway/services/os_client.go
@@ -100,6 +100,8 @@ func NewOsClusterClientFromConfig(config opensearch.Config) (*OsClusterClient, e
 	client, err := opensearch.NewClient(config)
 	if err == nil {
 		service.client = client
+	} else {
+		return nil, err
 	}
 	pingReq := opensearchapi.PingRequest{}
 	pingRes, err := pingReq.Do(context.Background(), client)

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -990,9 +990,10 @@ func NewBootstrapPod(
 	mainCommand := helpers.BuildMainCommand("./bin/opensearch-plugin", pluginslist, true, startUpCommand)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BootstrapPodName(cr),
-			Namespace: cr.Namespace,
-			Labels:    labels,
+			Name:        BootstrapPodName(cr),
+			Namespace:   cr.Namespace,
+			Labels:      labels,
+			Annotations: cr.Spec.Bootstrap.Annotations,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -466,6 +466,19 @@ var _ = Describe("Builders", func() {
 			}))
 		})
 
+		It("should apply bootstrap pod annotations", func() {
+			clusterObject := ClusterDescWithVersion("2.2.1")
+			expectedAnnotations := map[string]string{
+				"custom-annotation":  "custom-value",
+				"another-annotation": "another-value",
+			}
+			clusterObject.Spec.Bootstrap.Annotations = expectedAnnotations
+
+			result := NewBootstrapPod(&clusterObject, nil, nil)
+
+			Expect(result.ObjectMeta.Annotations).To(Equal(expectedAnnotations))
+		})
+
 		It("should overwrite the General.AdditionalConfig with Bootstrap.AdditionalConfig when set", func() {
 			mockKey1 := "server.basePath"
 			mockKey2 := "server.rewriteBasePath"


### PR DESCRIPTION
### Description
Currently, bootstrap pod spec doesn't support adding annotations. This change adds the support.

Annotations were supported for node pools but was missing in helm charts, so added that as well.

### Issues Resolved
#1098 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
