### PR TITLE
feat: use parallel podManagementPolicy for sts

### DIFF
--- a/charts/opensearch-operator/CHANGELOG.md
+++ b/charts/opensearch-operator/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for custom image used by `kubeRbacProxy`.
 ### Changed
 - `enableHotReload` is now a tri-state pointer. Omitting it enables TLS certificate hot reload on OpenSearch 3.x+ (and leaves it off on older versions). Existing 3.x clusters that never set the field take one rolling restart on operator upgrade because `plugins.security.ssl.certificates_hot_reload.enabled` is added to `opensearch.yml`.
+- StatefulSets now use `Parallel` `podManagementPolicy` (was `OrderedReady`). On operator upgrade, existing STS objects are recreated once with orphan propagation; pods are retained and re-adopted. Scaling and rolling operations remain sequenced by the operator.
 ### Deprecated
 ### Removed
+- Experimental parallel recovery mode and related Helm/env config (`manager.parallelRecoveryEnabled` / `PARALLEL_RECOVERY_ENABLED`).
 ### Fixed
 - Generated TLS certificates are now rotated 30 days before expiry by default, and expired or unparseable certificates are always regenerated. TLS certificate hot reload is enabled by default on OpenSearch 3.x and above so nodes load renewed certificates without a restart; when hot reload is off (`enableHotReload: false` or OpenSearch < 2.19.1) renewals trigger a rolling restart instead.
   Existing CRs keep a stored `rotateDaysBeforeExpiry: -1` until the spec is re-applied — set `30` (or re-apply) to rotate before expiry rather than recovering after it. Replacing the generated CA secret in place is not a supported rotation procedure; leaf reissue cannot keep dual-CA trust during the swap.

--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.3
+version: 3.0.4
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.8
+version: 3.0.9
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -68,7 +68,6 @@ The following table lists the configurable parameters of the Helm chart.
 | `manager.readinessProbe.successThreshold` | int | `1` |  |
 | `manager.readinessProbe.timeoutSeconds` | int | `3` |  |
 | `manager.readinessProbe.initialDelaySeconds` | int | `10` |  |
-| `manager.parallelRecoveryEnabled` | bool | `true` |  |
 | `manager.pprofEndpointsEnabled` | bool | `false` |  |
 | `manager.image.repository` | string | `"opensearchproject/opensearch-operator"` |  |
 | `manager.image.tag` | string | `""` |  |

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -134,4 +134,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `3.0.3`
+Opensearch-operator Helm Chart version: `3.0.4`

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -156,4 +156,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `3.0.8`
+Opensearch-operator Helm Chart version: `3.0.9`

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -89,7 +89,6 @@ The following table lists the configurable parameters of the Helm chart.
 | `manager.readinessProbe.successThreshold` | int | `1` |  |
 | `manager.readinessProbe.timeoutSeconds` | int | `3` |  |
 | `manager.readinessProbe.initialDelaySeconds` | int | `10` |  |
-| `manager.parallelRecoveryEnabled` | bool | `true` |  |
 | `manager.pprofEndpointsEnabled` | bool | `false` |  |
 | `manager.image.repository` | string | `"opensearchproject/opensearch-operator"` |  |
 | `manager.image.tag` | string | `""` |  |

--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
         env:
         - name: DNS_BASE
           value: {{ .Values.manager.dnsBase }}
-        - name: PARALLEL_RECOVERY_ENABLED
-          value: "{{ .Values.manager.parallelRecoveryEnabled }}"
         - name: PPROF_ENDPOINTS_ENABLED
           value: "{{ .Values.manager.pprofEndpointsEnabled }}"
         {{- if .Values.manager.extraEnv }}

--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
         env:
         - name: DNS_BASE
           value: {{ .Values.manager.dnsBase }}
-        - name: PARALLEL_RECOVERY_ENABLED
-          value: "{{ .Values.manager.parallelRecoveryEnabled }}"
         - name: PPROF_ENDPOINTS_ENABLED
           value: "{{ .Values.manager.pprofEndpointsEnabled }}"
         {{- if .Values.manager.extraEnv }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -40,8 +40,6 @@ manager:
     timeoutSeconds: 3
     initialDelaySeconds: 10
 
-  # Set this to false to disable the experimental parallel recovery in case you are experiencing problems
-  parallelRecoveryEnabled: true
   # Set this to true to enable the standard go pprof endpoints on port 6060 (https://pkg.go.dev/net/http/pprof)
   # Should only be used for debugging purposes
   pprofEndpointsEnabled: false

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1318,17 +1318,9 @@ The operator contains several features that automate management tasks that might
 
 ### Cluster recovery
 
-This operator automatically handles common failure scenarios and restarts crashed pods, normally this is done in a one-by-one fashion to maintain quorum and cluster stability.
-In case the operator detects several crashed or missing pods (for a nodepool) at the same time it will switch into a special recovery mode and start all pods at once and allow the cluster to form a new quorum. This parallel recovery mode is currently experimental and only works with PVC-backed storage as it uses the number of existing PVCs to determine the number of missing pods. The recovery is done by temporarily changing the statefulset underlying each nodepool and setting the `podManagementPolicy` to `Parallel`. If you encounter problems with it, you can disable it by redeploying the operator and adding `manager.parallelRecoveryEnabled: false` to your `values.yaml`. Please also report any problems by opening an issue in the operator github project.
+The operator uses `Parallel` pod management for StatefulSets by default, so pods are started in parallel. This allows the cluster to form quorum and recover when multiple pods are missing or crashed, without a separate recovery mode.
 
-The recovery mode also kicks in if you deleted your cluster but kept the PVCs around and are then reinstalling the cluster.
-
-If the cluster is using emptyDir i.e. every node pool is using emptyDir, the operator starts recovery in case of these failure scenarios:
-
-1. More than half the master nodes are missing or crashed and thus, the quorum is broken.
-2. All data nodes are missing or crashed and thus, no data node is available.
-
-But since the cluster is using emptyDir, data is lost and not recoverable. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
+If the cluster is using emptyDir i.e. every node pool is using emptyDir, data is lost and not recoverable in failure scenarios. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
 
 ### Rolling Upgrades
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1429,17 +1429,9 @@ The operator contains several features that automate management tasks that might
 
 ### Cluster recovery
 
-This operator automatically handles common failure scenarios and restarts crashed pods, normally this is done in a one-by-one fashion to maintain quorum and cluster stability.
-In case the operator detects several crashed or missing pods (for a nodepool) at the same time it will switch into a special recovery mode and start all pods at once and allow the cluster to form a new quorum. This parallel recovery mode is currently experimental and only works with PVC-backed storage as it uses the number of existing PVCs to determine the number of missing pods. The recovery is done by temporarily changing the statefulset underlying each nodepool and setting the `podManagementPolicy` to `Parallel`. If you encounter problems with it, you can disable it by redeploying the operator and adding `manager.parallelRecoveryEnabled: false` to your `values.yaml`. Please also report any problems by opening an issue in the operator github project.
+The operator uses `Parallel` pod management for StatefulSets by default, so pods are started in parallel. This allows the cluster to form quorum and recover when multiple pods are missing or crashed, without a separate recovery mode.
 
-The recovery mode also kicks in if you deleted your cluster but kept the PVCs around and are then reinstalling the cluster.
-
-If the cluster is using emptyDir i.e. every node pool is using emptyDir, the operator starts recovery in case of these failure scenarios:
-
-1. More than half the master nodes are missing or crashed and thus, the quorum is broken.
-2. All data nodes are missing or crashed and thus, no data node is available.
-
-But since the cluster is using emptyDir, data is lost and not recoverable. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
+If the cluster is using emptyDir i.e. every node pool is using emptyDir, data is lost and not recoverable in failure scenarios. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
 
 ### Rolling Upgrades
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1431,7 +1431,16 @@ The operator contains several features that automate management tasks that might
 
 The operator uses `Parallel` pod management for StatefulSets by default, so pods are started in parallel. This allows the cluster to form quorum and recover when multiple pods are missing or crashed, without a separate recovery mode.
 
-If the cluster is using emptyDir i.e. every node pool is using emptyDir, data is lost and not recoverable in failure scenarios. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
+Scaling, rolling restarts, and version upgrades remain sequenced by the operator (one replica / one node at a time). `Parallel` only removes the StatefulSet controller's readiness gate on pod creation and recreation.
+
+`podManagementPolicy` is immutable on StatefulSets. After upgrading to an operator version that sets `Parallel`, existing node-pool StatefulSets are recreated once via orphan delete (pods are retained and re-adopted). This is a one-time, fleet-wide STS recreate that normally converges within one or two reconciles.
+
+If the cluster is using emptyDir i.e. every node pool is using emptyDir, the operator starts recovery in case of these failure scenarios:
+
+1. More than half the master nodes are missing or crashed and thus, the quorum is broken.
+2. All data nodes are missing or crashed and thus, no data node is available.
+
+But since the cluster is using emptyDir, data is lost and not recoverable. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
 
 ### Rolling Upgrades
 

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -24,6 +24,8 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/builders"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -251,13 +253,20 @@ func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context)
 }
 
 func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context) (ctrl.Result, error) {
-	// Update initialized status first
+	// Update initialized status first. Only set Initialized when all master pods are ready
+	// and the OpenSearch cluster API is reachable (cluster has formed). This prevents
+	// deleting the bootstrap pod before the cluster has actually bootstrapped, which
+	// can happen with parallel pod management when pods report ready before quorum is formed.
 	if !r.Instance.Status.Initialized {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
 				return err
 			}
-			r.Instance.Status.Initialized = builders.AllMastersReady(ctx, r.Client, r.Instance)
+			allMastersReady := builders.AllMastersReady(ctx, r.Client, r.Instance)
+			k8sClient := k8s.NewK8sClient(r.Client, ctx)
+			health, _ := util.GetClusterHealth(k8sClient, ctx, r.Instance, r.Logger)
+			clusterReachable := health != opensearchv1.OpenSearchUnknownHealth
+			r.Instance.Status.Initialized = allMastersReady && clusterReachable
 			return r.Status().Update(ctx, r.Instance)
 		}); err != nil {
 			return ctrl.Result{}, err

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -24,6 +24,8 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/builders"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -260,13 +262,20 @@ func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context)
 }
 
 func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context) (ctrl.Result, error) {
-	// Update initialized status first
+	// Update initialized status first. Only set Initialized when all master pods are ready
+	// and the OpenSearch cluster API is reachable (cluster has formed). This prevents
+	// deleting the bootstrap pod before the cluster has actually bootstrapped, which
+	// can happen with parallel pod management when pods report ready before quorum is formed.
 	if !r.Instance.Status.Initialized {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
 				return err
 			}
-			r.Instance.Status.Initialized = builders.AllMastersReady(ctx, r.Client, r.Instance)
+			allMastersReady := builders.AllMastersReady(ctx, r.Client, r.Instance)
+			k8sClient := k8s.NewK8sClient(r.Client, ctx)
+			health, _ := util.GetClusterHealth(k8sClient, ctx, r.Instance, r.Logger)
+			clusterReachable := health != opensearchv1.OpenSearchUnknownHealth
+			r.Instance.Status.Initialized = allMastersReady && clusterReachable
 			return r.Status().Update(ctx, r.Instance)
 		}); err != nil {
 			return ctrl.Result{}, err

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -533,7 +533,7 @@ func NewSTSForNodePool(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: matchLabels,
 			},
-			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -735,7 +735,7 @@ func NewSTSForNodePool(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: matchLabels,
 			},
-			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -12,6 +12,7 @@ import (
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,6 +77,11 @@ func ClusterDescWithAdditionalConfigs(addtitionalConfig map[string]string, boots
 
 var _ = Describe("Builders", func() {
 	When("Constructing a STS for a NodePool", func() {
+		It("should use Parallel podManagementPolicy", func() {
+			clusterObject := ClusterDescWithVersion("2.2.1")
+			result := NewSTSForNodePool("foobar", &clusterObject, opensearchv1.NodePool{}, "foobar", nil, nil)
+			Expect(result.Spec.PodManagementPolicy).To(Equal(appsv1.ParallelPodManagement))
+		})
 		It("should include the init containers as SKIP_INIT_CONTAINER is not set", func() {
 			clusterObject := ClusterDescWithVersion("2.2.1")
 			result := NewSTSForNodePool("foobar", &clusterObject, opensearchv1.NodePool{}, "foobar", nil, nil)

--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -15,7 +15,6 @@ const (
 	OsUserNameAnnotation         = "opensearchuser/name"
 	OsUserNamespaceAnnotation    = "opensearchuser/namespace"
 	DnsBaseEnvVariable           = "DNS_BASE"
-	ParallelRecoveryEnabled      = "PARALLEL_RECOVERY_ENABLED"
 	SkipInitContainerEnvVariable = "SKIP_INIT_CONTAINER"
 )
 
@@ -40,18 +39,4 @@ func ClusterDnsBase() string {
 	}
 
 	return env
-}
-
-func ParallelRecoveryMode() bool {
-	env, found := os.LookupEnv(ParallelRecoveryEnabled)
-
-	if !found || len(env) == 0 {
-		env = "true"
-	}
-
-	result, err := strconv.ParseBool(env)
-	if err != nil {
-		return true
-	}
-	return result
 }

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -742,25 +742,6 @@ func ReadyReplicasForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSear
 	return int32(numReadyPods), nil
 }
 
-// Count the number of PVCs created for the given NodePool
-func CountPVCsForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSearchCluster, nodePool *opensearchv1.NodePool) (int, error) {
-	clusterReq, err := labels.NewRequirement(ClusterLabel, selection.Equals, []string{cr.Name})
-	if err != nil {
-		return 0, err
-	}
-	componentReq, err := labels.NewRequirement(NodePoolLabel, selection.Equals, []string{nodePool.Component})
-	if err != nil {
-		return 0, err
-	}
-	selector := labels.NewSelector()
-	selector = selector.Add(*clusterReq, *componentReq)
-	list, err := k8sClient.ListPVCs(&client.ListOptions{Namespace: cr.Namespace, LabelSelector: selector})
-	if err != nil {
-		return 0, err
-	}
-	return len(list.Items), nil
-}
-
 // Delete a STS with cascade=orphan and wait until it is actually deleted from the kubernetes API
 func WaitForSTSDelete(ctx context.Context, k8sClient k8s.K8sClient, obj *appsv1.StatefulSet) error {
 	cond := func(ctx context.Context) (bool, error) {
@@ -774,44 +755,6 @@ func WaitForSTSDelete(ctx context.Context, k8sClient k8s.K8sClient, obj *appsv1.
 		return err
 	}
 	return wait.PollUntilContextTimeout(ctx, time.Second*updateStepTime, time.Second*stsUpdateWaitTime, true, cond)
-}
-
-// Wait for max 30s until a STS has at least the given number of replicas
-func WaitForSTSReplicas(ctx context.Context, k8sClient k8s.K8sClient, obj *appsv1.StatefulSet, replicas int32) error {
-	cond := func(ctx context.Context) (bool, error) {
-		existing, err := k8sClient.GetStatefulSet(obj.Name, obj.Namespace)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		if existing.Status.Replicas >= replicas {
-			return true, nil
-		}
-		return false, nil
-	}
-	return wait.PollUntilContextTimeout(ctx, time.Second*updateStepTime, time.Second*stsUpdateWaitTime, true, cond)
-}
-
-func WaitForSTSStatus(ctx context.Context, k8sClient k8s.K8sClient, obj *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
-	var result appsv1.StatefulSet
-	cond := func(ctx context.Context) (bool, error) {
-		existing, err := k8sClient.GetStatefulSet(obj.Name, obj.Namespace)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		result = existing
-		if existing.Status.CurrentRevision != "" {
-			return true, nil
-		}
-		return false, nil
-	}
-	err := wait.PollUntilContextTimeout(ctx, time.Second*updateStepTime, time.Second*stsUpdateWaitTime, true, cond)
-	return &result, err
 }
 
 // GetSTSForNodePool returns the corresponding sts for a given nodePool and cluster name

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -245,66 +245,6 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opensearchv1.NodeP
 		}
 	}
 
-	// Detect cluster failure and initiate parallel recovery
-	if helpers.ParallelRecoveryMode() &&
-		(nodePool.Persistence == nil || nodePool.Persistence.PVC != nil) {
-		// This logic only works if the STS uses PVCs
-		// First check if the STS already has a readable status (CurrentRevision == "" indicates the STS is newly created and the controller has not yet updated the status properly)
-		if existing.Status.CurrentRevision == "" {
-			new, err := helpers.WaitForSTSStatus(r.ctx, r.client, &existing)
-			if err != nil {
-				return &ctrl.Result{Requeue: true}, err
-			}
-			existing = *new
-		}
-		readyReplicas, err := helpers.ReadyReplicasForNodePool(r.client, r.instance, &nodePool)
-		if err != nil {
-			return result, err
-		}
-		existing.Status.ReadyReplicas = readyReplicas
-		// Check number of PVCs for nodepool
-		pvcCount, err := helpers.CountPVCsForNodePool(r.client, r.instance, &nodePool)
-		if err != nil {
-			r.logger.Error(err, "Failed to determine PVC count. Continuing on normally")
-		} else {
-			// A failure is assumed if n PVCs exist but less than n-1 pods (one missing pod is allowed for rolling restart purposes)
-			// We can assume the cluster is in a failure state and cannot recover on its own
-			if !helpers.IsUpgradeInProgress(r.instance.Status) &&
-				pvcCount >= int(nodePool.Replicas) && existing.Status.ReadyReplicas < nodePool.Replicas-1 {
-				r.logger.Info(fmt.Sprintf("Detected recovery situation for nodepool %s: PVC count: %d, replicas: %d. Recreating STS with parallel mode", nodePool.Component, pvcCount, existing.Status.Replicas))
-				if existing.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
-					// Switch to Parallel to jumpstart the cluster
-					// First delete existing STS
-					if err := helpers.WaitForSTSDelete(r.ctx, r.client, &existing); err != nil {
-						r.logger.Error(err, "Failed to delete STS")
-						return result, err
-					}
-					// Recreate with PodManagementPolicy=Parallel
-					sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
-					sts.ResourceVersion = ""
-					sts.UID = ""
-					result, err = r.client.ReconcileResource(sts, reconciler.StatePresent)
-					if err != nil {
-						r.logger.Error(err, "Failed to create STS")
-						return result, err
-					}
-					// Wait for pods to appear
-					err := helpers.WaitForSTSReplicas(r.ctx, r.client, &existing, nodePool.Replicas)
-					// Abort normal logic and requeue
-					return &ctrl.Result{Requeue: true}, err
-				}
-			} else if existing.Spec.PodManagementPolicy == appsv1.ParallelPodManagement {
-				// We are in Parallel mode but appear to not have a failure situation any longer. Switch back to normal mode
-				r.logger.Info(fmt.Sprintf("Ending recovery mode for nodepool %s", nodePool.Component))
-				if err := helpers.WaitForSTSDelete(r.ctx, r.client, &existing); err != nil {
-					r.logger.Error(err, "Failed to delete STS")
-					return result, err
-				}
-				// STS will be recreated by the normal code below
-			}
-		}
-	}
-
 	// Handle PodDisruptionBudget
 	result, err = r.handlePDB(&nodePool)
 	if err != nil {

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -302,66 +302,6 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opensearchv1.NodeP
 		}
 	}
 
-	// Detect cluster failure and initiate parallel recovery
-	if helpers.ParallelRecoveryMode() &&
-		(nodePool.Persistence == nil || nodePool.Persistence.PVC != nil) {
-		// This logic only works if the STS uses PVCs
-		// First check if the STS already has a readable status (CurrentRevision == "" indicates the STS is newly created and the controller has not yet updated the status properly)
-		if existing.Status.CurrentRevision == "" {
-			new, err := helpers.WaitForSTSStatus(r.ctx, r.client, &existing)
-			if err != nil {
-				return &ctrl.Result{Requeue: true}, err
-			}
-			existing = *new
-		}
-		readyReplicas, err := helpers.ReadyReplicasForNodePool(r.client, r.instance, &nodePool)
-		if err != nil {
-			return result, err
-		}
-		existing.Status.ReadyReplicas = readyReplicas
-		// Check number of PVCs for nodepool
-		pvcCount, err := helpers.CountPVCsForNodePool(r.client, r.instance, &nodePool)
-		if err != nil {
-			r.logger.Error(err, "Failed to determine PVC count. Continuing on normally")
-		} else {
-			// A failure is assumed if n PVCs exist but less than n-1 pods (one missing pod is allowed for rolling restart purposes)
-			// We can assume the cluster is in a failure state and cannot recover on its own
-			if !helpers.IsUpgradeInProgress(r.instance.Status) &&
-				pvcCount >= int(nodePool.Replicas) && existing.Status.ReadyReplicas < nodePool.Replicas-1 {
-				r.logger.Info(fmt.Sprintf("Detected recovery situation for nodepool %s: PVC count: %d, replicas: %d. Recreating STS with parallel mode", nodePool.Component, pvcCount, existing.Status.Replicas))
-				if existing.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
-					// Switch to Parallel to jumpstart the cluster
-					// First delete existing STS
-					if err := helpers.WaitForSTSDelete(r.ctx, r.client, &existing); err != nil {
-						r.logger.Error(err, "Failed to delete STS")
-						return result, err
-					}
-					// Recreate with PodManagementPolicy=Parallel
-					sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
-					sts.ResourceVersion = ""
-					sts.UID = ""
-					result, err = r.client.ReconcileResource(sts, reconciler.StatePresent)
-					if err != nil {
-						r.logger.Error(err, "Failed to create STS")
-						return result, err
-					}
-					// Wait for pods to appear
-					err := helpers.WaitForSTSReplicas(r.ctx, r.client, &existing, nodePool.Replicas)
-					// Abort normal logic and requeue
-					return &ctrl.Result{Requeue: true}, err
-				}
-			} else if existing.Spec.PodManagementPolicy == appsv1.ParallelPodManagement {
-				// We are in Parallel mode but appear to not have a failure situation any longer. Switch back to normal mode
-				r.logger.Info(fmt.Sprintf("Ending recovery mode for nodepool %s", nodePool.Component))
-				if err := helpers.WaitForSTSDelete(r.ctx, r.client, &existing); err != nil {
-					r.logger.Error(err, "Failed to delete STS")
-					return result, err
-				}
-				// STS will be recreated by the normal code below
-			}
-		}
-	}
-
 	// Handle PodDisruptionBudget
 	result, err = r.handlePDB(&nodePool)
 	if err != nil {


### PR DESCRIPTION
### Description
this commit sets StatefulSet podManagementPolicy to Parallel (was OrderedReady) so pods are created and scaled in parallel, improving startup and scale performance.
- remove parallel recovery mode
- set cluster status as initialized when all master pods are ready and opensearch api is reachable


### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1182

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
