### PR TITLE
Added reconcile worker count configuration to OpenSearchClusterReconciler#1334

### DIFF
--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -48,6 +48,10 @@ The following table lists the configurable parameters of the Helm chart.
 | `tolerations` | list | `[]` |  |
 | `securityContext.runAsNonRoot` | bool | `true` |  |
 | `priorityClassName` | string | `""` |  |
+| `manager.maxConcurrentReconciles` | int | `1` | Global default max concurrent reconciles for all controllers |
+| `manager.maxConcurrentReconcilesPerController.opensearchcluster` | int | `1` | Max concurrent reconciles for opensearchcluster controller |
+| `manager.maxConcurrentReconcilesPerController.opensearchuser` | int | `2` | Max concurrent reconciles for opensearchuser controller |
+| `manager.maxConcurrentReconcilesPerController.opensearchrole` | int | `2` | Max concurrent reconciles for opensearchrole controller |
 | `manager.workerCount` | int | `1` |  |
 | `manager.securityContext.allowPrivilegeEscalation` | bool | `false` |  |
 | `manager.extraEnv` | list | `[]` |  |

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Helm chart.
 | `tolerations` | list | `[]` |  |
 | `securityContext.runAsNonRoot` | bool | `true` |  |
 | `priorityClassName` | string | `""` |  |
+| `manager.workerCount` | int | `1` |  |
 | `manager.securityContext.allowPrivilegeEscalation` | bool | `false` |  |
 | `manager.extraEnv` | list | `[]` |  |
 | `manager.resources.limits.cpu` | string | `"1000m"` |  |

--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         - --enable-webhooks={{ .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
         - --opensearch-controller-worker={{ .Values.manager.workerCount }}
+        - --max-concurrent-reconciles={{ .Values.manager.maxConcurrentReconciles }}
+        {{- if .Values.manager.maxConcurrentReconcilesPerController }}
+        - --max-concurrent-reconciles-per-controller={{- range $controller, $count := .Values.manager.maxConcurrentReconcilesPerController }}{{ $controller }}={{ $count }},{{- end }}
+        {{- end }}
         {{- if .Values.manager.watchNamespace }}
         {{- if kindIs "slice" .Values.manager.watchNamespace }}
         - --watch-namespace={{ .Values.manager.watchNamespace | join "," }}

--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - --leader-elect
         - --enable-webhooks={{ .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        - --opensearch-controller-worker={{ .Values.manager.workerCount }}
         {{- if .Values.manager.watchNamespace }}
         {{- if kindIs "slice" .Values.manager.watchNamespace }}
         - --watch-namespace={{ .Values.manager.watchNamespace | join "," }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -9,6 +9,24 @@ securityContext:
   runAsNonRoot: true
 priorityClassName: ""
 manager:
+  # Global default max concurrent reconciles for all controllers
+  maxConcurrentReconciles: 1
+  
+  # Per-controller max concurrent reconciles overrides
+  # This allows fine-grained control over reconciliation parallelism
+  # Example configuration:
+  maxConcurrentReconcilesPerController:
+    opensearchcluster: 1    # keep cluster reconciliation serial
+    opensearchuser: 2       # allow more parallel user reconciles
+    opensearchrole: 2       # allow more parallel role reconciles
+    # opensearchtenant: 2
+    # opensearchuserrolebinding: 4
+    # opensearchactiongroup: 4
+    # opensearchismpolicy: 4
+    # opensearchindextemplate: 4
+    # opensearchcomponenttemplate: 4
+    # opensearchsnapshotpolicy: 4
+  
   workerCount: 1
   securityContext:
     allowPrivilegeEscalation: false

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -9,6 +9,7 @@ securityContext:
   runAsNonRoot: true
 priorityClassName: ""
 manager:
+  workerCount: 1
   securityContext:
     allowPrivilegeEscalation: false
   extraEnv: []

--- a/opensearch-operator/controllers/controller_settings.go
+++ b/opensearch-operator/controllers/controller_settings.go
@@ -3,3 +3,33 @@ package controllers
 const (
 	OpensearchFinalizer = "opensearch.org/opensearch-data"
 )
+
+// ControllerConcurrencyConfig holds concurrency settings for controllers
+type ControllerConcurrencyConfig struct {
+	// Global default max concurrent reconciles for all controllers
+	MaxConcurrentReconciles int
+	// Per-controller overrides (controller name -> max concurrent reconciles)
+	PerController map[string]int
+}
+
+// GetMaxConcurrentReconciles returns the max concurrent reconciles for a given controller
+func (c *ControllerConcurrencyConfig) GetMaxConcurrentReconciles(controllerName string) int {
+	if override, exists := c.PerController[controllerName]; exists {
+		return override
+	}
+	return c.MaxConcurrentReconciles
+}
+
+// Controller names for per-controller configuration
+const (
+	ControllerNameCluster           = "opensearchcluster"
+	ControllerNameUser              = "opensearchuser"
+	ControllerNameRole              = "opensearchrole"
+	ControllerNameTenant            = "opensearchtenant"
+	ControllerNameUserRoleBinding   = "opensearchuserrolebinding"
+	ControllerNameActionGroup       = "opensearchactiongroup"
+	ControllerNameISMPolicy         = "opensearchismpolicy"
+	ControllerNameIndexTemplate     = "opensearchindextemplate"
+	ControllerNameComponentTemplate = "opensearchcomponenttemplate"
+	ControllerNameSnapshotPolicy    = "opensearchsnapshotpolicy"
+)

--- a/opensearch-operator/controllers/controller_settings.go
+++ b/opensearch-operator/controllers/controller_settings.go
@@ -14,10 +14,14 @@ type ControllerConcurrencyConfig struct {
 
 // GetMaxConcurrentReconciles returns the max concurrent reconciles for a given controller
 func (c *ControllerConcurrencyConfig) GetMaxConcurrentReconciles(controllerName string) int {
+	n := c.MaxConcurrentReconciles
 	if override, exists := c.PerController[controllerName]; exists {
-		return override
+		n = override
 	}
-	return c.MaxConcurrentReconciles
+	if n < 0 {
+		return 1
+	}
+	return n
 }
 
 // Controller names for per-controller configuration

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,10 +46,9 @@ import (
 // Now reconciles opensearch.org/v1 API group (new API) instead of opensearch.opster.io/v1 (old API)
 type OpenSearchClusterReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Instance *opensearchv1.OpenSearchCluster
-	logr.Logger
+	Scheme      *runtime.Scheme
+	Recorder    record.EventRecorder
+	WorkerCount int
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchclusters,verbs=get;list;watch;create;update;patch;delete
@@ -79,13 +79,13 @@ type OpenSearchClusterReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("cluster", req.NamespacedName, "apiGroup", "opensearch.org/v1")
-	r.Info("Reconciling OpenSearchCluster (opensearch.org/v1)")
+	logger := log.FromContext(ctx).WithValues("cluster", req.NamespacedName, "apiGroup", "opensearch.org/v1")
+	logger.Info("Reconciling OpenSearchCluster (opensearch.org/v1)")
 	myFinalizerName := "Opensearch"
 
 	// Try to get new API group resource first
-	r.Instance = &opensearchv1.OpenSearchCluster{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpenSearchCluster{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// If new API group resource not found, check if old one exists (for backward compatibility during migration)
@@ -93,7 +93,7 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if err := r.Get(ctx, req.NamespacedName, oldInstance); err == nil {
 				// Old instance exists but new one doesn't - migration controller should handle this
 				// Just requeue to let migration controller create the new one
-				r.Info("Old API group resource exists, waiting for migration", "name", req.Name)
+				logger.Info("Old API group resource exists, waiting for migration", "name", req.Name)
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			}
 			return ctrl.Result{}, nil
@@ -102,24 +102,24 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	/// ------ check if CRD has been deleted ------ ///
 	///	if ns deleted, delete the associated resources ///
-	if r.Instance.DeletionTimestamp.IsZero() {
-		if !helpers.ContainsString(r.Instance.GetFinalizers(), myFinalizerName) {
+	if instance.DeletionTimestamp.IsZero() {
+		if !helpers.ContainsString(instance.GetFinalizers(), myFinalizerName) {
 			// Use RetryOnConflict to update finalizer to handle any changes to resource
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				if err := r.Get(ctx, req.NamespacedName, r.Instance); err != nil {
+				if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 					return err
 				}
-				controllerutil.AddFinalizer(r.Instance, myFinalizerName)
-				return r.Update(ctx, r.Instance)
+				controllerutil.AddFinalizer(instance, myFinalizerName)
+				return r.Update(ctx, instance)
 			})
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 		}
 	} else {
-		if helpers.ContainsString(r.Instance.GetFinalizers(), myFinalizerName) {
+		if helpers.ContainsString(instance.GetFinalizers(), myFinalizerName) {
 			// our finalizer is present, so lets handle any external dependency
-			if result, err := r.deleteExternalResources(ctx); err != nil {
+			if result, err := r.deleteExternalResources(ctx, instance, logger); err != nil {
 				// if fail to delete the external dependency here, return with error
 				// so that it can be retried
 				return result, err
@@ -127,31 +127,31 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			// remove our finalizer from the list and update it.
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				if err := r.Get(ctx, req.NamespacedName, r.Instance); err != nil {
+				if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 					return err
 				}
-				controllerutil.RemoveFinalizer(r.Instance, myFinalizerName)
-				return r.Update(ctx, r.Instance)
+				controllerutil.RemoveFinalizer(instance, myFinalizerName)
+				return r.Update(ctx, instance)
 			})
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 
-			helpers.DeleteClusterMetrics(req.Namespace, r.Instance.Name)
+			helpers.DeleteClusterMetrics(req.Namespace, instance.Name)
 		}
 		return ctrl.Result{}, nil
 	}
 
 	/// if crd not deleted started phase 1
-	if r.Instance.Status.Phase == "" {
-		r.Instance.Status.Phase = opensearchv1.PhasePending
+	if instance.Status.Phase == "" {
+		instance.Status.Phase = opensearchv1.PhasePending
 	}
 
-	switch r.Instance.Status.Phase {
+	switch instance.Status.Phase {
 	case opensearchv1.PhasePending:
-		return r.reconcilePhasePending(ctx)
+		return r.reconcilePhasePending(ctx, instance, logger)
 	case opensearchv1.PhaseRunning, opensearchv1.PhaseUpgrading:
-		return r.reconcilePhaseRunning(ctx)
+		return r.reconcilePhaseRunning(ctx, instance, logger)
 	default:
 		// NOTHING WILL HAPPEN - DEFAULT
 		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
@@ -169,48 +169,49 @@ func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.WorkerCount}).
 		Complete(r)
 }
 
 // delete associated cluster resources //
-func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Context) (ctrl.Result, error) {
-	r.Info("Deleting resources")
+func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Context, instance *opensearchv1.OpenSearchCluster, logger logr.Logger) (ctrl.Result, error) {
+	logger.Info("Deleting resources")
 	// Run through all sub controllers to delete existing objects
-	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, r.Instance, r.Instance.Spec.NodePools)
+	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, instance, instance.Spec.NodePools)
 
 	tls := reconcilers.NewTLSReconciler(
 		r.Client,
 		ctx,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	securityconfig := reconcilers.NewSecurityconfigReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	config := reconcilers.NewConfigurationReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	cluster := reconcilers.NewClusterReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	dashboards := reconcilers.NewDashboardsReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 
 	componentReconcilers := []reconcilers.NamedComponentReconciler{
@@ -230,19 +231,19 @@ func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Contex
 			return result, nil
 		}
 	}
-	r.Info("Finished deleting resources")
+	logger.Info("Finished deleting resources")
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context) (ctrl.Result, error) {
-	r.Info("Start reconcile - Phase: PENDING")
+func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context, instance *opensearchv1.OpenSearchCluster, logger logr.Logger) (ctrl.Result, error) {
+	logger.Info("Start reconcile - Phase: PENDING")
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
+		if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 			return err
 		}
-		r.Instance.Status.Phase = opensearchv1.PhaseRunning
-		r.Instance.Status.ComponentsStatus = make([]opensearchv1.ComponentStatus, 0)
-		return r.Status().Update(ctx, r.Instance)
+		instance.Status.Phase = opensearchv1.PhaseRunning
+		instance.Status.ComponentsStatus = make([]opensearchv1.ComponentStatus, 0)
+		return r.Status().Update(ctx, instance)
 	})
 	if err != nil {
 		return ctrl.Result{}, err
@@ -250,83 +251,83 @@ func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context)
 	return ctrl.Result{Requeue: true}, nil
 }
 
-func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context) (ctrl.Result, error) {
+func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context, instance *opensearchv1.OpenSearchCluster, logger logr.Logger) (ctrl.Result, error) {
 	// Update initialized status first
-	if !r.Instance.Status.Initialized {
+	if !instance.Status.Initialized {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
+			if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 				return err
 			}
-			r.Instance.Status.Initialized = builders.AllMastersReady(ctx, r.Client, r.Instance)
-			return r.Status().Update(ctx, r.Instance)
+			instance.Status.Initialized = builders.AllMastersReady(ctx, r.Client, instance)
+			return r.Status().Update(ctx, instance)
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
 	// Run through all sub controllers to create or update all needed objects
-	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, r.Instance, r.Instance.Spec.NodePools)
+	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, instance, instance.Spec.NodePools)
 
 	tls := reconcilers.NewTLSReconciler(
 		r.Client,
 		ctx,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	securityconfig := reconcilers.NewSecurityconfigReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	config := reconcilers.NewConfigurationReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	cluster := reconcilers.NewClusterReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	scaler := reconcilers.NewScalerReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	dashboards := reconcilers.NewDashboardsReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	upgrade := reconcilers.NewUpgradeReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	restart := reconcilers.NewRollingRestartReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	snapshotrepository := reconcilers.NewSnapshotRepositoryReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
 	componentReconcilers := []reconcilers.NamedComponentReconciler{

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -159,7 +159,16 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
+	// Use the provided maxConcurrentReconciles, but fall back to WorkerCount for backward compatibility
+	concurrency := maxConcurrentReconciles
+	if concurrency == 0 && r.WorkerCount > 0 {
+		concurrency = r.WorkerCount
+	}
+	if concurrency == 0 {
+		concurrency = 1
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpenSearchCluster{}). // Watch new API group
 		Owns(&corev1.Pod{}).
@@ -169,7 +178,7 @@ func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.WorkerCount}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: concurrency}).
 		Complete(r)
 }
 

--- a/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,9 +71,10 @@ func (r *OpensearchComponentTemplateReconciler) Reconcile(ctx context.Context, r
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchComponentTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchComponentTemplateReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchComponentTemplate{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearch_indextemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_indextemplate_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,9 +71,10 @@ func (r *OpensearchIndexTemplateReconciler) Reconcile(ctx context.Context, req c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchIndexTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchIndexTemplateReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchIndexTemplate{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchactiongroup_controller.go
+++ b/opensearch-operator/controllers/opensearchactiongroup_controller.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -71,9 +72,10 @@ func (r *OpensearchActionGroupReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchActionGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchActionGroupReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchActionGroup{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchism_controller.go
+++ b/opensearch-operator/controllers/opensearchism_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -67,9 +68,10 @@ func (r *OpensearchISMPolicyReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchISMPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchISMPolicyReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpenSearchISMPolicy{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchrole_controller.go
+++ b/opensearch-operator/controllers/opensearchrole_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -87,9 +88,10 @@ func (r *OpensearchRoleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchRoleReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchRole{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
+++ b/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -95,9 +96,10 @@ func (r *OpensearchSnapshotPolicyReconciler) Reconcile(ctx context.Context, req 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchSnapshotPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchSnapshotPolicyReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchSnapshotPolicy{}).
 		Owns(&opensearchv1.OpenSearchCluster{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchtenant_controller.go
+++ b/opensearch-operator/controllers/opensearchtenant_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,9 +71,10 @@ func (r *OpensearchTenantReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchTenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchTenantReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchTenant{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchuser_controller.go
+++ b/opensearch-operator/controllers/opensearchuser_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -140,7 +141,7 @@ func (r *OpensearchUserReconciler) handleSecretEvent(_ context.Context, secret c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchUserReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchUser{}).
 		// Get notified when opensearch clusters change
@@ -150,5 +151,6 @@ func (r *OpensearchUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.handleSecretEvent),
 		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
+++ b/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -87,9 +88,10 @@ func (r *OpensearchUserRoleBindingReconciler) Reconcile(ctx context.Context, req
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchUserRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchUserRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchUserRoleBinding{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -170,12 +170,20 @@ func main() {
 	perControllerConfig := make(map[string]int)
 	if maxConcurrentReconcilesPerController != "" {
 		for _, pair := range strings.Split(maxConcurrentReconcilesPerController, ",") {
-			parts := strings.Split(strings.TrimSpace(pair), "=")
-			if len(parts) == 2 {
-				if count, err := strconv.Atoi(parts[1]); err == nil {
-					perControllerConfig[strings.ToLower(parts[0])] = count
-				}
+			parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+			if len(parts) != 2 {
+				continue
 			}
+			key := strings.ToLower(strings.TrimSpace(parts[0]))
+			val := strings.TrimSpace(parts[1])
+			if key == "" || val == "" {
+				continue
+			}
+			count, err := strconv.Atoi(val)
+			if err != nil || count < 1 {
+				continue
+			}
+			perControllerConfig[key] = count
 		}
 	}
 

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -71,6 +71,7 @@ func main() {
 	var enableLeaderElection bool
 	var enableWebhooks bool
 	var webhookPort int
+	var opensearchControllerWorker int
 	var probeAddr string
 	var watchNamespace string
 	var logLevel string
@@ -81,6 +82,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable validating webhooks for OpenSearch custom resources.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port used by the validating webhook server.")
+	flag.IntVar(&opensearchControllerWorker, "opensearch-controller-worker", 2, "Total number of opensearch controller workers to initialize")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"The comma-separated list of namespaces that the controller manager is restricted to watch. If not set, default is to watch all namespaces.")
 	flag.StringVar(&logLevel, "loglevel", "info", "The log level to use for the operator logs. Possible values: debug,info,warn,error")
@@ -162,9 +164,10 @@ func main() {
 	// Controllers now watch opensearch.org/v1 (new API group)
 	// Migration controller handles creating new CRs from old ones
 	if err = (&controllers.OpenSearchClusterReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("containerset-controller"),
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		WorkerCount: opensearchControllerWorker,
+		Recorder:    mgr.GetEventRecorderFor("containerset-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenSearchCluster")
 		os.Exit(1)

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -75,6 +75,8 @@ func main() {
 	var probeAddr string
 	var watchNamespace string
 	var logLevel string
+	var maxConcurrentReconciles int
+	var maxConcurrentReconcilesPerController string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -82,7 +84,10 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable validating webhooks for OpenSearch custom resources.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port used by the validating webhook server.")
-	flag.IntVar(&opensearchControllerWorker, "opensearch-controller-worker", 2, "Total number of opensearch controller workers to initialize")
+	flag.IntVar(&opensearchControllerWorker, "opensearch-controller-worker", 2, "Total number of opensearch controller workers to initialize (deprecated: use max-concurrent-reconciles)")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Global default max concurrent reconciles for all controllers")
+	flag.StringVar(&maxConcurrentReconcilesPerController, "max-concurrent-reconciles-per-controller", "",
+		"Per-controller max concurrent reconciles overrides (format: controller1=N,controller2=M)")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"The comma-separated list of namespaces that the controller manager is restricted to watch. If not set, default is to watch all namespaces.")
 	flag.StringVar(&logLevel, "loglevel", "info", "The log level to use for the operator logs. Possible values: debug,info,warn,error")
@@ -161,6 +166,24 @@ func main() {
 
 	helpers.RegisterMetrics()
 
+	// Parse per-controller configuration
+	perControllerConfig := make(map[string]int)
+	if maxConcurrentReconcilesPerController != "" {
+		for _, pair := range strings.Split(maxConcurrentReconcilesPerController, ",") {
+			parts := strings.Split(strings.TrimSpace(pair), "=")
+			if len(parts) == 2 {
+				if count, err := strconv.Atoi(parts[1]); err == nil {
+					perControllerConfig[strings.ToLower(parts[0])] = count
+				}
+			}
+		}
+	}
+
+	concurrencyConfig := &controllers.ControllerConcurrencyConfig{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+		PerController:           perControllerConfig,
+	}
+
 	// Controllers now watch opensearch.org/v1 (new API group)
 	// Migration controller handles creating new CRs from old ones
 	if err = (&controllers.OpenSearchClusterReconciler{
@@ -168,7 +191,7 @@ func main() {
 		Scheme:      mgr.GetScheme(),
 		WorkerCount: opensearchControllerWorker,
 		Recorder:    mgr.GetEventRecorderFor("containerset-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameCluster)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenSearchCluster")
 		os.Exit(1)
 	}
@@ -177,7 +200,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("user-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameUser)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchUser")
 		os.Exit(1)
 	}
@@ -185,7 +208,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("role-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameRole)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchRole")
 		os.Exit(1)
 	}
@@ -193,7 +216,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("ism-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameISMPolicy)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchISM")
 		os.Exit(1)
 	}
@@ -201,7 +224,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("tenant-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameTenant)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchTenant")
 		os.Exit(1)
 	}
@@ -209,7 +232,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("userrolebinding-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameUserRoleBinding)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchUserRoleBinding")
 		os.Exit(1)
 	}
@@ -217,7 +240,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("actiongroup-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameActionGroup)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchActionGroup")
 		os.Exit(1)
 	}
@@ -225,7 +248,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("indextemplate-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameIndexTemplate)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchIndexTemplate")
 		os.Exit(1)
 	}
@@ -233,7 +256,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("componenttemplate-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameComponentTemplate)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchComponentTemplate")
 		os.Exit(1)
 	}
@@ -241,7 +264,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("snapshotpolicy-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameSnapshotPolicy)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchSnapshotPolicy")
 		os.Exit(1)
 	}


### PR DESCRIPTION

---------

Added reconcile worker count configuration to OpenSearchClusterReconciler and deployment manifest.


### Description
Added Reconcilation worker count configurable (default value is 1)

Code changes in detail: 
When we increased `MaxConcurrentReconciles` for OpenSearchCluster, the reconciler started running multiple Reconcile calls in parallel on the same reconciler instance.
Previously the struct stored per-request state on fields (Instance, Logger), and each Reconcile mutated those fields. With multiple workers this leads to data races and request state leaking between clusters (one reconcile overwriting r.Instance while another is still using it).
This change makes the reconciler stateless per request: instance and logger are now local variables passed down into helper methods, and the struct only holds shared dependencies (client, scheme, recorder, worker count). That makes higher `MaxConcurrentReconciles` safe, because each reconcile uses its own state instead of sharing mutable fields.

### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1333

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
