### PR TITLE
fix: backfill pvc labels to new api group during migration

### DIFF
--- a/opensearch-operator/controllers/migration_controller.go
+++ b/opensearch-operator/controllers/migration_controller.go
@@ -55,6 +55,11 @@ const (
 	// Old finalizers that need to be removed during deletion
 	OldClusterFinalizer  = "Opster"                    // Old cluster finalizer corresponding myFinalizerName
 	OldResourceFinalizer = "opster.io/opensearch-data" // Old resource finalizer (User, Role, etc.) coresponding to OpensearchFinalizer)
+
+	oldClusterLabel  = "opster.io/opensearch-cluster"
+	oldNodePoolLabel = "opster.io/opensearch-nodepool"
+	newClusterLabel  = "opensearch.org/opensearch-cluster"
+	newNodePoolLabel = "opensearch.org/opensearch-nodepool"
 )
 
 // ClusterMigrationReconciler reconciles OpenSearchCluster resources between old and new API groups
@@ -69,6 +74,7 @@ type ClusterMigrationReconciler struct {
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchclusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;patch
 
 func (r *ClusterMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -279,6 +285,10 @@ func (r *ClusterMigrationReconciler) createNewFromOld(ctx context.Context, oldCl
 		// Don't fail the migration, just requeue to retry the transfer
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
+	if err := r.backfillPVCLegacyLabels(ctx, oldCluster); err != nil {
+		logger.Error(err, "Failed to backfill PVC labels during migration, will retry")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
 
 	logger.Info("Created new API group resource with status", "name", newCluster.Name, "namespace", newCluster.Namespace)
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -291,6 +301,10 @@ func (r *ClusterMigrationReconciler) syncOldToNew(ctx context.Context, oldCluste
 	// This handles cases where migration happened before this fix, or where transfer previously failed
 	if err := r.transferCertificateSecretOwnership(ctx, oldCluster, newCluster); err != nil {
 		logger.Error(err, "Failed to transfer certificate secret ownership during sync, will retry")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	if err := r.backfillPVCLegacyLabels(ctx, oldCluster); err != nil {
+		logger.Error(err, "Failed to backfill PVC labels during sync, will retry")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	// Only sync status from new back to old
@@ -1051,6 +1065,44 @@ func clearManagedClusterField(obj client.Object) {
 		// Set ManagedCluster to nil
 		managedClusterField.Set(reflect.Zero(managedClusterField.Type()))
 	}
+}
+
+// backfillPVCLegacyLabels migrates legacy PVC labels from opster.io/* to opensearch.org/*.
+func (r *ClusterMigrationReconciler) backfillPVCLegacyLabels(ctx context.Context, oldCluster *opsterv1.OpenSearchCluster) error {
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(ctx, pvcList, &client.ListOptions{
+		Namespace: oldCluster.Namespace,
+	}, client.MatchingLabels{
+		oldClusterLabel: oldCluster.Name,
+	}); err != nil {
+		return fmt.Errorf("failed to list PVCs for label migration: %w", err)
+	}
+
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if pvc.Labels == nil {
+			pvc.Labels = map[string]string{}
+		}
+
+		updated := false
+		if pvc.Labels[newClusterLabel] == "" {
+			pvc.Labels[newClusterLabel] = oldCluster.Name
+			updated = true
+		}
+		if pvc.Labels[newNodePoolLabel] == "" {
+			if oldNodePool, ok := pvc.Labels[oldNodePoolLabel]; ok && oldNodePool != "" {
+				pvc.Labels[newNodePoolLabel] = oldNodePool
+				updated = true
+			}
+		}
+
+		if updated {
+			if err := r.Update(ctx, pvc); err != nil {
+				return fmt.Errorf("failed to update PVC %s/%s labels: %w", pvc.Namespace, pvc.Name, err)
+			}
+		}
+	}
+	return nil
 }
 
 // transferCertificateSecretOwnership transfers owner references on certificate secrets

--- a/opensearch-operator/controllers/migration_controller.go
+++ b/opensearch-operator/controllers/migration_controller.go
@@ -37,6 +37,7 @@ import (
 
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	opsterv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/v1"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	k8s "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 )
 
@@ -55,11 +56,6 @@ const (
 	// Old finalizers that need to be removed during deletion
 	OldClusterFinalizer  = "Opster"                    // Old cluster finalizer corresponding myFinalizerName
 	OldResourceFinalizer = "opster.io/opensearch-data" // Old resource finalizer (User, Role, etc.) coresponding to OpensearchFinalizer)
-
-	oldClusterLabel  = "opster.io/opensearch-cluster"
-	oldNodePoolLabel = "opster.io/opensearch-nodepool"
-	newClusterLabel  = "opensearch.org/opensearch-cluster"
-	newNodePoolLabel = "opensearch.org/opensearch-nodepool"
 )
 
 // ClusterMigrationReconciler reconciles OpenSearchCluster resources between old and new API groups
@@ -285,10 +281,6 @@ func (r *ClusterMigrationReconciler) createNewFromOld(ctx context.Context, oldCl
 		// Don't fail the migration, just requeue to retry the transfer
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
-	if err := r.backfillPVCLegacyLabels(ctx, oldCluster); err != nil {
-		logger.Error(err, "Failed to backfill PVC labels during migration, will retry")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
 
 	logger.Info("Created new API group resource with status", "name", newCluster.Name, "namespace", newCluster.Namespace)
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -303,9 +295,15 @@ func (r *ClusterMigrationReconciler) syncOldToNew(ctx context.Context, oldCluste
 		logger.Error(err, "Failed to transfer certificate secret ownership during sync, will retry")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
-	if err := r.backfillPVCLegacyLabels(ctx, oldCluster); err != nil {
-		logger.Error(err, "Failed to backfill PVC labels during sync, will retry")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	// Only backfill PVC labels once the new cluster is initialized. Doing this earlier
+	// can make legacy PVCs visible to parallel recovery while the migrated CR is still
+	// settling (e.g. Status.Initialized not yet true), which recreates STS in Parallel
+	// mode and can break a healthy cluster mid-migration.
+	if newCluster.Status.Initialized {
+		if err := r.backfillPVCLegacyLabels(ctx, oldCluster); err != nil {
+			logger.Error(err, "Failed to backfill PVC labels during sync, will retry")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 	}
 	// Only sync status from new back to old
 	// Spec sync is intentionally disabled - the new CR is the source of truth after migration
@@ -1073,32 +1071,33 @@ func (r *ClusterMigrationReconciler) backfillPVCLegacyLabels(ctx context.Context
 	if err := r.List(ctx, pvcList, &client.ListOptions{
 		Namespace: oldCluster.Namespace,
 	}, client.MatchingLabels{
-		oldClusterLabel: oldCluster.Name,
+		helpers.OldClusterLabel: oldCluster.Name,
 	}); err != nil {
 		return fmt.Errorf("failed to list PVCs for label migration: %w", err)
 	}
 
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
+		original := pvc.DeepCopy()
 		if pvc.Labels == nil {
 			pvc.Labels = map[string]string{}
 		}
 
 		updated := false
-		if pvc.Labels[newClusterLabel] == "" {
-			pvc.Labels[newClusterLabel] = oldCluster.Name
+		if pvc.Labels[helpers.ClusterLabel] == "" {
+			pvc.Labels[helpers.ClusterLabel] = oldCluster.Name
 			updated = true
 		}
-		if pvc.Labels[newNodePoolLabel] == "" {
-			if oldNodePool, ok := pvc.Labels[oldNodePoolLabel]; ok && oldNodePool != "" {
-				pvc.Labels[newNodePoolLabel] = oldNodePool
+		if pvc.Labels[helpers.NodePoolLabel] == "" {
+			if oldNodePool, ok := pvc.Labels[helpers.OldNodePoolLabel]; ok && oldNodePool != "" {
+				pvc.Labels[helpers.NodePoolLabel] = oldNodePool
 				updated = true
 			}
 		}
 
 		if updated {
-			if err := r.Update(ctx, pvc); err != nil {
-				return fmt.Errorf("failed to update PVC %s/%s labels: %w", pvc.Namespace, pvc.Name, err)
+			if err := r.Patch(ctx, pvc, client.MergeFrom(original)); err != nil {
+				return fmt.Errorf("failed to patch PVC %s/%s labels: %w", pvc.Namespace, pvc.Name, err)
 			}
 		}
 	}

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -46,6 +46,7 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		scheme = runtime.NewScheme()
+		_ = corev1.AddToScheme(scheme)
 		_ = opensearchv1.AddToScheme(scheme)
 		_ = opsterv1.AddToScheme(scheme)
 		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	opsterv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -387,6 +388,68 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			result, err := reconciler.handleNewClusterDeletion(ctx, newCluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
+		})
+	})
+
+	Describe("backfillPVCLegacyLabels", func() {
+		It("should backfill new PVC labels from legacy labels", func() {
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldCluster)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "data-test-cluster-master-0",
+					Namespace: "default",
+					Labels: map[string]string{
+						oldClusterLabel:  "test-cluster",
+						oldNodePoolLabel: "master",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			Expect(reconciler.backfillPVCLegacyLabels(ctx, oldCluster)).To(Succeed())
+
+			updatedPVC := &corev1.PersistentVolumeClaim{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)).To(Succeed())
+			Expect(updatedPVC.Labels[newClusterLabel]).To(Equal("test-cluster"))
+			Expect(updatedPVC.Labels[newNodePoolLabel]).To(Equal("master"))
+		})
+
+		It("should not overwrite existing new labels", func() {
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldCluster)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "data-test-cluster-master-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						oldClusterLabel:  "test-cluster",
+						oldNodePoolLabel: "master",
+						newClusterLabel:  "already-set-cluster",
+						newNodePoolLabel: "already-set-nodepool",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			Expect(reconciler.backfillPVCLegacyLabels(ctx, oldCluster)).To(Succeed())
+
+			updatedPVC := &corev1.PersistentVolumeClaim{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)).To(Succeed())
+			Expect(updatedPVC.Labels[newClusterLabel]).To(Equal("already-set-cluster"))
+			Expect(updatedPVC.Labels[newNodePoolLabel]).To(Equal("already-set-nodepool"))
 		})
 	})
 

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	opsterv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/v1"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -407,8 +408,8 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 					Name:      "data-test-cluster-master-0",
 					Namespace: "default",
 					Labels: map[string]string{
-						oldClusterLabel:  "test-cluster",
-						oldNodePoolLabel: "master",
+						helpers.OldClusterLabel:  "test-cluster",
+						helpers.OldNodePoolLabel: "master",
 					},
 				},
 			}
@@ -418,8 +419,8 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 
 			updatedPVC := &corev1.PersistentVolumeClaim{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)).To(Succeed())
-			Expect(updatedPVC.Labels[newClusterLabel]).To(Equal("test-cluster"))
-			Expect(updatedPVC.Labels[newNodePoolLabel]).To(Equal("master"))
+			Expect(updatedPVC.Labels[helpers.ClusterLabel]).To(Equal("test-cluster"))
+			Expect(updatedPVC.Labels[helpers.NodePoolLabel]).To(Equal("master"))
 		})
 
 		It("should not overwrite existing new labels", func() {
@@ -436,10 +437,10 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 					Name:      "data-test-cluster-master-1",
 					Namespace: "default",
 					Labels: map[string]string{
-						oldClusterLabel:  "test-cluster",
-						oldNodePoolLabel: "master",
-						newClusterLabel:  "already-set-cluster",
-						newNodePoolLabel: "already-set-nodepool",
+						helpers.OldClusterLabel:  "test-cluster",
+						helpers.OldNodePoolLabel: "master",
+						helpers.ClusterLabel:     "already-set-cluster",
+						helpers.NodePoolLabel:    "already-set-nodepool",
 					},
 				},
 			}
@@ -449,8 +450,110 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 
 			updatedPVC := &corev1.PersistentVolumeClaim{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)).To(Succeed())
-			Expect(updatedPVC.Labels[newClusterLabel]).To(Equal("already-set-cluster"))
-			Expect(updatedPVC.Labels[newNodePoolLabel]).To(Equal("already-set-nodepool"))
+			Expect(updatedPVC.Labels[helpers.ClusterLabel]).To(Equal("already-set-cluster"))
+			Expect(updatedPVC.Labels[helpers.NodePoolLabel]).To(Equal("already-set-nodepool"))
+		})
+	})
+
+	Describe("syncOldToNew PVC label backfill gating", func() {
+		var statusClient client.Client
+		var statusReconciler *ClusterMigrationReconciler
+
+		BeforeEach(func() {
+			statusClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&opensearchv1.OpenSearchCluster{}, &opsterv1.OpenSearchCluster{}).
+				Build()
+			statusReconciler = &ClusterMigrationReconciler{
+				Client: statusClient,
+				Scheme: scheme,
+			}
+		})
+
+		It("should not backfill PVC labels before the new cluster is initialized", func() {
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(statusClient.Create(ctx, oldCluster)).To(Succeed())
+
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					Annotations: map[string]string{
+						CertOwnershipTransferredAnnotation: "true",
+					},
+				},
+			}
+			Expect(statusClient.Create(ctx, newCluster)).To(Succeed())
+			newCluster.Status = opensearchv1.ClusterStatus{Initialized: false}
+			Expect(statusClient.Status().Update(ctx, newCluster)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "data-test-cluster-master-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						helpers.OldClusterLabel:  "test-cluster",
+						helpers.OldNodePoolLabel: "master",
+					},
+				},
+			}
+			Expect(statusClient.Create(ctx, pvc)).To(Succeed())
+
+			_, err := statusReconciler.syncOldToNew(ctx, oldCluster, newCluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedPVC := &corev1.PersistentVolumeClaim{}
+			Expect(statusClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)).To(Succeed())
+			Expect(updatedPVC.Labels).NotTo(HaveKey(helpers.ClusterLabel))
+			Expect(updatedPVC.Labels).NotTo(HaveKey(helpers.NodePoolLabel))
+		})
+
+		It("should backfill PVC labels once the new cluster is initialized", func() {
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(statusClient.Create(ctx, oldCluster)).To(Succeed())
+
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					Annotations: map[string]string{
+						CertOwnershipTransferredAnnotation: "true",
+					},
+				},
+			}
+			Expect(statusClient.Create(ctx, newCluster)).To(Succeed())
+			newCluster.Status = opensearchv1.ClusterStatus{Initialized: true}
+			Expect(statusClient.Status().Update(ctx, newCluster)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "data-test-cluster-master-3",
+					Namespace: "default",
+					Labels: map[string]string{
+						helpers.OldClusterLabel:  "test-cluster",
+						helpers.OldNodePoolLabel: "master",
+					},
+				},
+			}
+			Expect(statusClient.Create(ctx, pvc)).To(Succeed())
+
+			_, err := statusReconciler.syncOldToNew(ctx, oldCluster, newCluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedPVC := &corev1.PersistentVolumeClaim{}
+			Expect(statusClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, updatedPVC)).To(Succeed())
+			Expect(updatedPVC.Labels[helpers.ClusterLabel]).To(Equal("test-cluster"))
+			Expect(updatedPVC.Labels[helpers.NodePoolLabel]).To(Equal("master"))
 		})
 	})
 

--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -12,6 +12,7 @@ const (
 	OldClusterLabel              = "opster.io/opensearch-cluster"
 	JobLabel                     = "opensearch.org/opensearch-job"
 	NodePoolLabel                = "opensearch.org/opensearch-nodepool"
+	OldNodePoolLabel             = "opster.io/opensearch-nodepool"
 	OsUserNameAnnotation         = "opensearchuser/name"
 	OsUserNamespaceAnnotation    = "opensearchuser/namespace"
 	DnsBaseEnvVariable           = "DNS_BASE"

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -247,7 +247,11 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opensearchv1.NodeP
 	}
 
 	// Detect cluster failure and initiate parallel recovery
+	// Skip until the cluster has initialized ΓÇö a never-initialized CR does not need
+	// parallel recovery, and this also prevents misfires during API-group migration
+	// when Status.Initialized has not landed yet on the new CR.
 	if helpers.ParallelRecoveryMode() &&
+		r.instance.Status.Initialized &&
 		(nodePool.Persistence == nil || nodePool.Persistence.PVC != nil) {
 		// This logic only works if the STS uses PVCs
 		// First check if the STS already has a readable status (CurrentRevision == "" indicates the STS is newly created and the controller has not yet updated the status properly)


### PR DESCRIPTION
### Description
fix #1393

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
