### PR TITLE
feat(helm): add Gateway API HTTPRoute support to opensearch-cluster chart

### DIFF
--- a/charts/opensearch-cluster/CHANGELOG.md
+++ b/charts/opensearch-cluster/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Opt-in Gateway API `HTTPRoute` support for the Opensearch, Dashboards, and per-nodePool services as an alternative to the existing Ingress resources
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for OpenSearch Cluster
 type: application
 
 ## The opensearch-cluster Helm Chart version
-version: 3.3.4
+version: 3.4.0
 
 ## The operator version
 appVersion: 2.8.0

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -81,10 +81,11 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.initHelper.imagePullSecrets` | list | `[]` | initHelper image pull secret |
 | `cluster.initHelper.resources` | object | `{}` | initHelper pod cpu and memory resources |
 | `cluster.initHelper.version` | string | `"1.36"` | initHelper version |
-| `cluster.nodePools` | list | `[{"additionalConfig":{},"annotations":{},"component":"masters","diskSize":"30Gi","ingress":{"enabled":false},"replicas":3,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"roles":["master","data"],"sidecarContainers":[]}]` | Opensearch nodes configuration |
+| `cluster.nodePools` | list | `[{"additionalConfig":{},"annotations":{},"component":"masters","diskSize":"30Gi","httproute":{"enabled":false},"ingress":{"enabled":false},"replicas":3,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"roles":["master","data"],"sidecarContainers":[]}]` | Opensearch nodes configuration |
 | `cluster.nodePools[0].annotations` | object | `{}` | node pool pod annotations |
 | `cluster.nodePools[0].additionalConfig` | object | `{}` | Extra items to add to opensearch.yml for this specific nodepool (merged with general.additionalConfig) |
 | `cluster.nodePools[0].ingress` | object | `{"enabled":false}` | Per-nodePool ingress configuration. Creates a separate Ingress targeting this nodePool's service. |
+| `cluster.nodePools[0].httproute` | object | `{"enabled":false}` | Per-nodePool Gateway API HTTPRoute configuration. Creates a separate HTTPRoute targeting this nodePool's service. |
 | `cluster.nodePools[0].sidecarContainers` | list | `[]` | These containers will be deployed as sidecars in the same pod as the OpenSearch container |
 | `cluster.security.config.adminCredentialsSecret` | object | `{}` | Secret that contains fields username and password to be used by the operator to access the opensearch cluster for node draining. Must be set if custom securityconfig is provided. |
 | `cluster.security.config.adminSecret` | object | `{}` | TLS Secret that contains a client certificate (tls.key, tls.crt, ca.crt) with admin rights in the opensearch cluster. Must be set if http certificates are provided by user and not generated |
@@ -116,6 +117,18 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.ingress.dashboards.className` | string | `""` | Ingress class name |
 | `cluster.ingress.dashboards.hosts` | list | `[]` | Ingress hostnames |
 | `cluster.ingress.dashboards.tls` | list | `[]` | Ingress tls configuration |
+| `cluster.httproute.opensearch.enabled` | bool | `false` | Enable a Gateway API HTTPRoute for the Opensearch service |
+| `cluster.httproute.opensearch.parentRefs` | list | `[]` | Opensearch HTTPRoute parentRefs (the Gateway(s) the route attaches to) |
+| `cluster.httproute.opensearch.hostnames` | list | `[]` | Opensearch HTTPRoute hostnames |
+| `cluster.httproute.opensearch.labels` | object | `{}` | Opensearch HTTPRoute extra labels |
+| `cluster.httproute.opensearch.annotations` | object | `{}` | Opensearch HTTPRoute annotations |
+| `cluster.httproute.opensearch.matches` | list | `[]` | Opensearch HTTPRoute rule matches. Defaults to a single PathPrefix `/` match when empty. |
+| `cluster.httproute.dashboards.enabled` | bool | `false` | Enable a Gateway API HTTPRoute for the dashboards service |
+| `cluster.httproute.dashboards.parentRefs` | list | `[]` | dashboards HTTPRoute parentRefs (the Gateway(s) the route attaches to) |
+| `cluster.httproute.dashboards.hostnames` | list | `[]` | dashboards HTTPRoute hostnames |
+| `cluster.httproute.dashboards.labels` | object | `{}` | dashboards HTTPRoute extra labels |
+| `cluster.httproute.dashboards.annotations` | object | `{}` | dashboards HTTPRoute annotations |
+| `cluster.httproute.dashboards.matches` | list | `[]` | dashboards HTTPRoute rule matches. Defaults to a single PathPrefix `/` match when empty. |
 | `roles` | list | `[]` | List of OpensearchRole. Check values.yaml file for examples. |
 | `users` | list | `[]` | List of OpensearchUser. Check values.yaml file for examples. |
 | `usersRoleBinding` | list | `[]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
@@ -127,4 +140,4 @@ The following table lists the configurable parameters of the Helm chart.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Opensearch-cluster Helm Chart version: `3.3.4`
+Opensearch-cluster Helm Chart version: `3.4.0`

--- a/charts/opensearch-cluster/templates/httproute.yaml
+++ b/charts/opensearch-cluster/templates/httproute.yaml
@@ -1,0 +1,128 @@
+{{- $clusterName := include "opensearch-cluster.cluster-name" . }}
+{{- $svcPort := .Values.cluster.general.httpPort -}}
+{{- $svcName := .Values.cluster.general.serviceName | default $clusterName }}
+
+{{- range $pool := .Values.cluster.nodePools }}
+{{- if and $pool.httproute $pool.httproute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $clusterName }}-{{ $pool.component }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "opensearch-cluster.labels" $ | nindent 4 }}
+    {{- with $pool.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $pool.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $pool.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $pool.httproute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- if $pool.httproute.matches }}
+        {{- toYaml $pool.httproute.matches | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      backendRefs:
+        - name: {{ $svcName }}-{{ $pool.component }}
+          port: {{ $svcPort }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.cluster.httproute.opensearch.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $clusterName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch-cluster.labels" . | nindent 4 }}
+    {{- with .Values.cluster.httproute.opensearch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.cluster.httproute.opensearch.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.cluster.httproute.opensearch.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.httproute.opensearch.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- if .Values.cluster.httproute.opensearch.matches }}
+        {{- toYaml .Values.cluster.httproute.opensearch.matches | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      backendRefs:
+        - name: {{ $svcName }}
+          port: {{ $svcPort }}
+{{- end }}
+
+{{- if .Values.cluster.httproute.dashboards.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $clusterName }}-dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch-cluster.labels" . | nindent 4 }}
+    {{- with .Values.cluster.httproute.dashboards.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.cluster.httproute.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.cluster.httproute.dashboards.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.httproute.dashboards.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- if .Values.cluster.httproute.dashboards.matches }}
+        {{- toYaml .Values.cluster.httproute.dashboards.matches | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      backendRefs:
+        - name: {{ $svcName }}-dashboards
+          port: 5601
+{{- end }}

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -313,6 +313,22 @@ cluster:
       #         - opensearch-data.example.com
       #       secretName: tls-secret
 
+      # -- Per-nodePool Gateway API HTTPRoute configuration. Creates a separate HTTPRoute targeting this nodePool's service.
+      httproute:
+        enabled: false
+      #   parentRefs:
+      #     - name: example-gateway
+      #       namespace: default
+      #       sectionName: https
+      #   hostnames:
+      #     - opensearch-data.example.com
+      #   labels: {}
+      #   annotations: {}
+      #   matches:
+      #     - path:
+      #         type: PathPrefix
+      #         value: /
+
       # -- These containers will be deployed as sidecars in the same pod as the OpenSearch container
       sidecarContainers: []
       # Example configurations:
@@ -493,6 +509,62 @@ cluster:
       #  - hosts:
       #      - example.com
       #    secretName: tls-secret
+
+  # Gateway API HTTPRoute configuration. Opt-in alternative to the Ingress
+  # resources above for clusters that expose services through the Gateway API.
+  httproute:
+    opensearch:
+      # -- Enable a Gateway API HTTPRoute for the Opensearch service
+      enabled: false
+
+      # -- Opensearch HTTPRoute parentRefs (the Gateway(s) the route attaches to)
+      parentRefs: []
+      #  - name: example-gateway
+      #    namespace: default
+      #    sectionName: https
+
+      # -- Opensearch HTTPRoute hostnames
+      hostnames: []
+      #  - opensearch.example.com
+
+      # -- Opensearch HTTPRoute extra labels
+      labels: {}
+
+      # -- Opensearch HTTPRoute annotations
+      annotations: {}
+
+      # -- Opensearch HTTPRoute rule matches. Defaults to a single PathPrefix `/` match when empty.
+      matches: []
+      #  - path:
+      #      type: PathPrefix
+      #      value: /
+
+    # Dashboards HTTPRoute configuration
+    dashboards:
+      # -- Enable a Gateway API HTTPRoute for the dashboards service
+      enabled: false
+
+      # -- dashboards HTTPRoute parentRefs (the Gateway(s) the route attaches to)
+      parentRefs: []
+      #  - name: example-gateway
+      #    namespace: default
+      #    sectionName: https
+
+      # -- dashboards HTTPRoute hostnames
+      hostnames: []
+      #  - dashboards.example.com
+
+      # -- dashboards HTTPRoute extra labels
+      labels: {}
+
+      # -- dashboards HTTPRoute annotations
+      annotations: {}
+
+      # -- dashboards HTTPRoute rule matches. Defaults to a single PathPrefix `/` match when empty.
+      matches: []
+      #  - path:
+      #      type: PathPrefix
+      #      value: /
 
 # -- List of OpensearchRole. Check values.yaml file for examples.
 roles: []


### PR DESCRIPTION
### Description
Add an opt-in Gateway API HTTPRoute template to the opensearch-cluster chart as an alternative to the existing Ingress resources, for the Opensearch, Dashboards, and per-nodePool services. Each route is disabled by default and exposes parentRefs, hostnames, labels, annotations, and rule matches, with backendRefs wired to the matching service (Opensearch 9200, Dashboards 5601, per-nodePool 9200). Mirrors the structure of the existing `ingress.yaml`.

### Issues Resolved
Closes #1434

### Check List
- [x] Commits are signed per the DCO using --signoff
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

Validation (run locally):
- `helm template` rendered in 3 scenarios: disabled (no output), opensearch+dashboards enabled, and per-nodePool enabled with parentRefs / hostnames / annotations / labels / custom path matches.
- `helm lint` and `ct lint --target-branch main` pass (chart version bumped 3.3.1 -> 3.4.0).
- `make helm-docs` regenerated `charts/opensearch-cluster/README.md` (committed).

The opensearch-cluster chart has no helm-unittest harness, so the Unittest box is left unchecked; `ct lint` render is the chart validation gate.
