### PR TITLE
Fix/preserve custom users in apply user hashes

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -411,9 +411,20 @@ func BuildGeneratedSecurityConfigSecret(k8sClient k8s.K8sClient, cr *opensearchv
 }
 
 func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOverride string, dashboardsPassword []byte, dashboardsHashOverride string) ([]byte, error) {
-	var data InternalUserConfig
+	// Use a generic map to preserve all users (including custom ones).
+	// Only "admin" and "kibanaserver" are modified; all other entries
+	// (including _meta and any custom users) pass through unchanged.
+	var data map[string]interface{}
 	if err := yaml.Unmarshal(internalUserData, &data); err != nil {
 		return nil, err
+	}
+
+	// Update admin user.
+	// NOTE: yaml.v2 deserializes nested mappings as map[interface{}]interface{}.
+	// If migrating to yaml.v3, these assertions must change to map[string]interface{}.
+	adminUser, ok := data["admin"].(map[interface{}]interface{})
+	if !ok {
+		return nil, fmt.Errorf("admin user not found or has invalid format")
 	}
 
 	var adminHash string
@@ -426,28 +437,43 @@ func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOve
 		}
 		adminHash = string(hashed)
 	}
-	data.Admin.Hash = adminHash
+	adminUser["hash"] = adminHash
 
-	if !data.Admin.Reserved {
-		data.Admin.Reserved = true
+	if reserved, ok := adminUser["reserved"].(bool); !ok || !reserved {
+		adminUser["reserved"] = true
 	}
-	if len(data.Admin.BackendRoles) == 0 {
-		data.Admin.BackendRoles = []string{"admin"}
+
+	// Ensure admin has "admin" backend role
+	var backendRoles []string
+	if roles, ok := adminUser["backend_roles"].([]interface{}); ok {
+		for _, role := range roles {
+			if roleStr, ok := role.(string); ok {
+				backendRoles = append(backendRoles, roleStr)
+			}
+		}
+	}
+	if len(backendRoles) == 0 {
+		backendRoles = []string{"admin"}
 	} else {
 		found := false
-		for _, role := range data.Admin.BackendRoles {
+		for _, role := range backendRoles {
 			if role == "admin" {
 				found = true
 				break
 			}
 		}
 		if !found {
-			data.Admin.BackendRoles = append(data.Admin.BackendRoles, "admin")
+			backendRoles = append(backendRoles, "admin")
 		}
 	}
+	adminUser["backend_roles"] = backendRoles
 
-	if data.Kibanaserver == nil {
-		data.Kibanaserver = &User{}
+	// Update kibanaserver user (same yaml.v2 map type as above)
+	kibanaUser, ok := data["kibanaserver"].(map[interface{}]interface{})
+	if !ok {
+		// Create kibanaserver if it doesn't exist
+		kibanaUser = make(map[interface{}]interface{})
+		data["kibanaserver"] = kibanaUser
 	}
 
 	var dashboardsHash string
@@ -460,14 +486,17 @@ func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOve
 		}
 		dashboardsHash = string(hashed)
 	}
-	data.Kibanaserver.Hash = dashboardsHash
-	if !data.Kibanaserver.Reserved {
-		data.Kibanaserver.Reserved = true
-	}
-	if data.Kibanaserver.Description == "" {
-		data.Kibanaserver.Description = "Demo user for the OpenSearch Dashboards server"
+	kibanaUser["hash"] = dashboardsHash
+
+	if reserved, ok := kibanaUser["reserved"].(bool); !ok || !reserved {
+		kibanaUser["reserved"] = true
 	}
 
+	if description, ok := kibanaUser["description"].(string); !ok || description == "" {
+		kibanaUser["description"] = "Demo user for the OpenSearch Dashboards server"
+	}
+
+	// Marshal back to YAML, preserving all users (base + custom)
 	modifiedYaml, err := yaml.Marshal(data)
 	if err != nil {
 		return nil, err

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -341,5 +342,269 @@ var _ = Describe("TlsCASecretRef", func() {
 		}
 
 		Expect(TlsCASecretRef(cluster).Name).To(BeEmpty())
+	})
+})
+
+var _ = Describe("applyUserHashes", func() {
+	It("should preserve custom users alongside admin and kibanaserver", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "oldadminhash"
+  reserved: true
+  backend_roles:
+    - "admin"
+  description: "Admin user"
+kibanaserver:
+  hash: "oldkibanahash"
+  reserved: true
+  description: "Demo user for the OpenSearch Dashboards server"
+readall:
+  hash: "$2a$12$readallhash"
+  reserved: false
+  backend_roles:
+    - "readall"
+  description: "readall user"
+snapshotrestore:
+  hash: "$2a$12$snapshothash"
+  reserved: false
+  backend_roles:
+    - "snapshotrestore"
+  description: "snapshotrestore user"
+`
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			"",
+			[]byte("dashboardspass"),
+			"",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		// admin and kibanaserver must still exist
+		Expect(output).To(HaveKey("admin"))
+		Expect(output).To(HaveKey("kibanaserver"))
+
+		// Custom users must be preserved
+		Expect(output).To(HaveKey("readall"))
+		Expect(output).To(HaveKey("snapshotrestore"))
+
+		// Verify custom user data is intact
+		readall, ok := output["readall"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(readall["hash"]).To(Equal("$2a$12$readallhash"))
+		Expect(readall["description"]).To(Equal("readall user"))
+
+		snapshotrestore, ok := output["snapshotrestore"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(snapshotrestore["hash"]).To(Equal("$2a$12$snapshothash"))
+		Expect(snapshotrestore["description"]).To(Equal("snapshotrestore user"))
+	})
+
+	It("should update admin and kibanaserver hashes while keeping custom users", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "oldadminhash"
+  reserved: true
+  backend_roles:
+    - "admin"
+kibanaserver:
+  hash: "oldkibanahash"
+  reserved: true
+  description: "Demo user for the OpenSearch Dashboards server"
+customuser:
+  hash: "$2a$12$customhash"
+  reserved: false
+  backend_roles:
+    - "custom_role"
+  description: "A custom user"
+`
+		adminHashOverride := "$2a$12$overriddenadminhash"
+		dashboardsHashOverride := "$2a$12$overriddendashboardshash"
+
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			adminHashOverride,
+			[]byte("dashboardspass"),
+			dashboardsHashOverride,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Admin hash should be updated
+		admin, ok := output["admin"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(admin["hash"]).To(Equal(adminHashOverride))
+
+		// Kibanaserver hash should be updated
+		kibana, ok := output["kibanaserver"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(kibana["hash"]).To(Equal(dashboardsHashOverride))
+
+		// Custom user must still exist with original data
+		custom, ok := output["customuser"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(custom["hash"]).To(Equal("$2a$12$customhash"))
+		Expect(custom["description"]).To(Equal("A custom user"))
+	})
+
+	It("should preserve multiple custom users with various configurations", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "adminhash"
+  reserved: true
+  backend_roles:
+    - "admin"
+kibanaserver:
+  hash: "kibanahash"
+  reserved: true
+  description: "Demo user for the OpenSearch Dashboards server"
+logstash:
+  hash: "$2a$12$logstashhash"
+  reserved: false
+  backend_roles:
+    - "logstash"
+  description: "Logstash user"
+kibanaro:
+  hash: "$2a$12$kibanarohash"
+  reserved: false
+  backend_roles:
+    - "kibanauser"
+    - "readall"
+  attributes:
+    attribute1: "value1"
+  description: "kibanaro user"
+`
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			"$2a$12$newhash",
+			[]byte("dashboardspass"),
+			"$2a$12$newkibanahash",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		// All users must be present
+		Expect(output).To(HaveKey("_meta"))
+		Expect(output).To(HaveKey("admin"))
+		Expect(output).To(HaveKey("kibanaserver"))
+		Expect(output).To(HaveKey("logstash"))
+		Expect(output).To(HaveKey("kibanaro"))
+
+		// Verify logstash user is untouched
+		logstash, ok := output["logstash"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(logstash["hash"]).To(Equal("$2a$12$logstashhash"))
+
+		// Verify kibanaro user preserves attributes and multiple backend_roles
+		kibanaro, ok := output["kibanaro"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(kibanaro["hash"]).To(Equal("$2a$12$kibanarohash"))
+		Expect(kibanaro["description"]).To(Equal("kibanaro user"))
+	})
+
+	It("should create kibanaserver if it does not exist", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "adminhash"
+  reserved: true
+  backend_roles:
+    - "admin"
+customuser:
+  hash: "$2a$12$customhash"
+  reserved: false
+  description: "custom"
+`
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			"$2a$12$adminhash",
+			[]byte("dashboardspass"),
+			"$2a$12$dashhash",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		// kibanaserver should be created
+		Expect(output).To(HaveKey("kibanaserver"))
+		kibana, ok := output["kibanaserver"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(kibana["hash"]).To(Equal("$2a$12$dashhash"))
+		Expect(kibana["reserved"]).To(Equal(true))
+
+		// Custom user must still be present
+		Expect(output).To(HaveKey("customuser"))
+		custom, ok := output["customuser"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(custom["hash"]).To(Equal("$2a$12$customhash"))
+	})
+
+	It("should add admin backend role if missing", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "adminhash"
+  reserved: true
+  backend_roles:
+    - "other_role"
+kibanaserver:
+  hash: "kibanahash"
+  reserved: true
+  description: "Demo user for the OpenSearch Dashboards server"
+`
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			"$2a$12$newhash",
+			[]byte("dashboardspass"),
+			"$2a$12$newkibanahash",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		admin, ok := output["admin"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+
+		roles, ok := admin["backend_roles"].([]interface{})
+		Expect(ok).To(BeTrue())
+
+		// Should contain both the original role and "admin"
+		roleStrings := make([]string, len(roles))
+		for i, r := range roles {
+			roleStrings[i] = r.(string)
+		}
+		Expect(roleStrings).To(ContainElement("other_role"))
+		Expect(roleStrings).To(ContainElement("admin"))
 	})
 })


### PR DESCRIPTION
### Description
This PR fixes issue that additional users next to `admin` and `kibanaserver` are dropped, once the securityconfig job runs.

This PR is a "split off" (redo) from https://github.com/opensearch-project/opensearch-k8s-operator/pull/1356

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/1371

### Check List
- [X] Commits are signed per the DCO using --signoff 
- [X] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
