### PR TITLE
fix: harden upgrade state machine against abort, custom images, and crashloops

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -912,26 +912,62 @@ func WorkingPodForRollingRestart(k8sClient k8s.K8sClient, sts *appsv1.StatefulSe
 	return "", errors.New("unable to calculate the working pod for rolling restart")
 }
 
-// DeleteStuckPodWithOlderRevision deletes the crashed pod only if there is any update in StatefulSet.
-func DeleteStuckPodWithOlderRevision(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) error {
+// DeleteStuckPodWithOlderRevision deletes a CrashLoopBackOff pod that is still on an older
+// StatefulSet revision so the update can proceed. Returns the deleted pod name when a delete occurs.
+func DeleteStuckPodWithOlderRevision(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) (string, error) {
 	podWithOlderRevision, err := GetPodWithOlderRevision(k8sClient, sts)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if podWithOlderRevision != nil {
 		for _, container := range podWithOlderRevision.Status.ContainerStatuses {
 			// If any container is getting crashed, restart it by deleting the pod so that new update in sts can take place.
 			if !container.Ready && container.State.Waiting != nil && container.State.Waiting.Reason == "CrashLoopBackOff" {
-				return k8sClient.DeletePod(&corev1.Pod{
+				err := k8sClient.DeletePod(&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      podWithOlderRevision.Name,
 						Namespace: sts.Namespace,
 					},
 				})
+				if err != nil {
+					return "", err
+				}
+				return podWithOlderRevision.Name, nil
 			}
 		}
 	}
-	return nil
+	return "", nil
+}
+
+// CrashLoopBackOffPods returns names of pods in the StatefulSet that have a container in CrashLoopBackOff.
+func CrashLoopBackOffPods(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) ([]string, error) {
+	var pods []string
+	for i := int32(0); i < lo.FromPtrOr(sts.Spec.Replicas, 1); i++ {
+		podName := ReplicaHostName(*sts, i)
+		pod, err := k8sClient.GetPod(podName, sts.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		for _, container := range pod.Status.ContainerStatuses {
+			if !container.Ready && container.State.Waiting != nil && container.State.Waiting.Reason == "CrashLoopBackOff" {
+				pods = append(pods, pod.Name)
+				break
+			}
+		}
+	}
+	return pods, nil
+}
+
+// ClearUpgraderComponentStatuses removes all Upgrader entries from componentsStatus,
+// including entries for node pools that no longer exist in the spec.
+func ClearUpgraderComponentStatuses(statuses []opensearchv1.ComponentStatus) []opensearchv1.ComponentStatus {
+	result := make([]opensearchv1.ComponentStatus, 0, len(statuses))
+	for _, status := range statuses {
+		if status.Component != "Upgrader" {
+			result = append(result, status)
+		}
+	}
+	return result
 }
 
 // GetPodWithOlderRevision fetches the pod that is not having the updated revision.

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -969,26 +969,62 @@ func WorkingPodForRollingRestart(k8sClient k8s.K8sClient, sts *appsv1.StatefulSe
 	return "", errors.New("unable to calculate the working pod for rolling restart")
 }
 
-// DeleteStuckPodWithOlderRevision deletes the crashed pod only if there is any update in StatefulSet.
-func DeleteStuckPodWithOlderRevision(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) error {
+// DeleteStuckPodWithOlderRevision deletes a CrashLoopBackOff pod that is still on an older
+// StatefulSet revision so the update can proceed. Returns the deleted pod name when a delete occurs.
+func DeleteStuckPodWithOlderRevision(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) (string, error) {
 	podWithOlderRevision, err := GetPodWithOlderRevision(k8sClient, sts)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if podWithOlderRevision != nil {
 		for _, container := range podWithOlderRevision.Status.ContainerStatuses {
 			// If any container is getting crashed, restart it by deleting the pod so that new update in sts can take place.
 			if !container.Ready && container.State.Waiting != nil && container.State.Waiting.Reason == "CrashLoopBackOff" {
-				return k8sClient.DeletePod(&corev1.Pod{
+				err := k8sClient.DeletePod(&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      podWithOlderRevision.Name,
 						Namespace: sts.Namespace,
 					},
 				})
+				if err != nil {
+					return "", err
+				}
+				return podWithOlderRevision.Name, nil
 			}
 		}
 	}
-	return nil
+	return "", nil
+}
+
+// CrashLoopBackOffPods returns names of pods in the StatefulSet that have a container in CrashLoopBackOff.
+func CrashLoopBackOffPods(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) ([]string, error) {
+	var pods []string
+	for i := int32(0); i < lo.FromPtrOr(sts.Spec.Replicas, 1); i++ {
+		podName := ReplicaHostName(*sts, i)
+		pod, err := k8sClient.GetPod(podName, sts.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		for _, container := range pod.Status.ContainerStatuses {
+			if !container.Ready && container.State.Waiting != nil && container.State.Waiting.Reason == "CrashLoopBackOff" {
+				pods = append(pods, pod.Name)
+				break
+			}
+		}
+	}
+	return pods, nil
+}
+
+// ClearUpgraderComponentStatuses removes all Upgrader entries from componentsStatus,
+// including entries for node pools that no longer exist in the spec.
+func ClearUpgraderComponentStatuses(statuses []opensearchv1.ComponentStatus) []opensearchv1.ComponentStatus {
+	result := make([]opensearchv1.ComponentStatus, 0, len(statuses))
+	for _, status := range statuses {
+		if status.Component != "Upgrader" {
+			result = append(result, status)
+		}
+	}
+	return result
 }
 
 // GetPodWithOlderRevision fetches the pod that is not having the updated revision.

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -343,3 +343,69 @@ var _ = Describe("TlsCASecretRef", func() {
 		Expect(TlsCASecretRef(cluster).Name).To(BeEmpty())
 	})
 })
+
+var _ = Describe("Upgrade status helpers", func() {
+	Describe("ClearUpgraderComponentStatuses", func() {
+		It("should remove all Upgrader entries including orphaned pools", func() {
+			statuses := []opensearchv1.ComponentStatus{
+				{Component: "RollingRestart", Status: "Finished"},
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "removed-pool", Status: "Upgrading"},
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				{Component: "Scaler", Description: "masters", Status: "Finished"},
+			}
+
+			result := ClearUpgraderComponentStatuses(statuses)
+			Expect(result).To(ConsistOf(
+				opensearchv1.ComponentStatus{Component: "RollingRestart", Status: "Finished"},
+				opensearchv1.ComponentStatus{Component: "Scaler", Description: "masters", Status: "Finished"},
+			))
+		})
+	})
+
+	Describe("HasPinnedCustomImage", func() {
+		It("should return true when a custom image is set", func() {
+			image := "example.com/opensearch:1"
+			cluster := &opensearchv1.OpenSearchCluster{
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						ImageSpec: &opensearchv1.ImageSpec{Image: &image},
+					},
+				},
+			}
+			Expect(HasPinnedCustomImage(cluster)).To(BeTrue())
+			Expect(PinnedCustomImage(cluster)).To(Equal(image))
+		})
+
+		It("should return false when no custom image is set", func() {
+			cluster := &opensearchv1.OpenSearchCluster{
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{Version: "2.12.0"},
+				},
+			}
+			Expect(HasPinnedCustomImage(cluster)).To(BeFalse())
+			Expect(PinnedCustomImage(cluster)).To(BeEmpty())
+		})
+	})
+
+	Describe("IsUpgradeInProgress", func() {
+		It("should be true while an upgrade target marker exists", func() {
+			status := opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+					{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				},
+			}
+			Expect(IsUpgradeInProgress(status)).To(BeTrue())
+		})
+
+		It("should be false when only Upgraded entries remain", func() {
+			status := opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				},
+			}
+			Expect(IsUpgradeInProgress(status)).To(BeFalse())
+		})
+	})
+})

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -720,3 +720,69 @@ var _ = Describe("HotReloadEnabled", func() {
 		Expect(HotReloadEnabled(cluster("3.0.0"), ptr.To(false))).To(BeFalse())
 	})
 })
+
+var _ = Describe("Upgrade status helpers", func() {
+	Describe("ClearUpgraderComponentStatuses", func() {
+		It("should remove all Upgrader entries including orphaned pools", func() {
+			statuses := []opensearchv1.ComponentStatus{
+				{Component: "RollingRestart", Status: "Finished"},
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "removed-pool", Status: "Upgrading"},
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				{Component: "Scaler", Description: "masters", Status: "Finished"},
+			}
+
+			result := ClearUpgraderComponentStatuses(statuses)
+			Expect(result).To(ConsistOf(
+				opensearchv1.ComponentStatus{Component: "RollingRestart", Status: "Finished"},
+				opensearchv1.ComponentStatus{Component: "Scaler", Description: "masters", Status: "Finished"},
+			))
+		})
+	})
+
+	Describe("HasPinnedCustomImage", func() {
+		It("should return true when a custom image is set", func() {
+			image := "example.com/opensearch:1"
+			cluster := &opensearchv1.OpenSearchCluster{
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						ImageSpec: &opensearchv1.ImageSpec{Image: &image},
+					},
+				},
+			}
+			Expect(HasPinnedCustomImage(cluster)).To(BeTrue())
+			Expect(PinnedCustomImage(cluster)).To(Equal(image))
+		})
+
+		It("should return false when no custom image is set", func() {
+			cluster := &opensearchv1.OpenSearchCluster{
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{Version: "2.12.0"},
+				},
+			}
+			Expect(HasPinnedCustomImage(cluster)).To(BeFalse())
+			Expect(PinnedCustomImage(cluster)).To(BeEmpty())
+		})
+	})
+
+	Describe("IsUpgradeInProgress", func() {
+		It("should be true while an upgrade target marker exists", func() {
+			status := opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+					{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				},
+			}
+			Expect(IsUpgradeInProgress(status)).To(BeTrue())
+		})
+
+		It("should be false when only Upgraded entries remain", func() {
+			status := opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				},
+			}
+			Expect(IsUpgradeInProgress(status)).To(BeFalse())
+		})
+	})
+})

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -116,7 +116,7 @@ func HasPinnedCustomImage(cr *opensearchv1.OpenSearchCluster) bool {
 	if cr == nil || cr.Spec.General.ImageSpec == nil {
 		return false
 	}
-	return cr.Spec.General.ImageSpec.Image != nil && *cr.Spec.General.ImageSpec.Image != ""
+	return cr.Spec.General.Image != nil && *cr.Spec.General.Image != ""
 }
 
 // PinnedCustomImage returns the pinned custom image string, or empty if none is set.
@@ -124,7 +124,7 @@ func PinnedCustomImage(cr *opensearchv1.OpenSearchCluster) string {
 	if !HasPinnedCustomImage(cr) {
 		return ""
 	}
-	return *cr.Spec.General.ImageSpec.Image
+	return *cr.Spec.General.Image
 }
 
 // Function to help identify httpPort, securityConfigPort and securityConfigPath for 1.x and 2.x OpenSearch Operator.

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -110,6 +110,23 @@ func useCustomImage(customImageSpec *opensearchv1.ImageSpec, result *opensearchv
 	return false
 }
 
+// HasPinnedCustomImage reports whether the cluster pins a full custom OpenSearch image,
+// which causes ResolveImage to ignore spec.general.version for the pod template.
+func HasPinnedCustomImage(cr *opensearchv1.OpenSearchCluster) bool {
+	if cr == nil || cr.Spec.General.ImageSpec == nil {
+		return false
+	}
+	return cr.Spec.General.ImageSpec.Image != nil && *cr.Spec.General.ImageSpec.Image != ""
+}
+
+// PinnedCustomImage returns the pinned custom image string, or empty if none is set.
+func PinnedCustomImage(cr *opensearchv1.OpenSearchCluster) string {
+	if !HasPinnedCustomImage(cr) {
+		return ""
+	}
+	return *cr.Spec.General.ImageSpec.Image
+}
+
 // Function to help identify httpPort, securityConfigPort and securityConfigPath for 1.x and 2.x OpenSearch Operator.
 func VersionCheck(instance *opensearchv1.OpenSearchCluster) (int32, int32, string) {
 	var httpPort int32

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -146,7 +146,7 @@ func HasPinnedCustomImage(cr *opensearchv1.OpenSearchCluster) bool {
 	if cr == nil || cr.Spec.General.ImageSpec == nil {
 		return false
 	}
-	return cr.Spec.General.ImageSpec.Image != nil && *cr.Spec.General.ImageSpec.Image != ""
+	return cr.Spec.General.Image != nil && *cr.Spec.General.Image != ""
 }
 
 // PinnedCustomImage returns the pinned custom image string, or empty if none is set.
@@ -154,7 +154,7 @@ func PinnedCustomImage(cr *opensearchv1.OpenSearchCluster) string {
 	if !HasPinnedCustomImage(cr) {
 		return ""
 	}
-	return *cr.Spec.General.ImageSpec.Image
+	return *cr.Spec.General.Image
 }
 
 // Function to help identify httpPort, securityConfigPort and securityConfigPath for 1.x and 2.x OpenSearch Operator.

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -140,6 +140,23 @@ func useCustomImage(customImageSpec *opensearchv1.ImageSpec, result *opensearchv
 	return false
 }
 
+// HasPinnedCustomImage reports whether the cluster pins a full custom OpenSearch image,
+// which causes ResolveImage to ignore spec.general.version for the pod template.
+func HasPinnedCustomImage(cr *opensearchv1.OpenSearchCluster) bool {
+	if cr == nil || cr.Spec.General.ImageSpec == nil {
+		return false
+	}
+	return cr.Spec.General.ImageSpec.Image != nil && *cr.Spec.General.ImageSpec.Image != ""
+}
+
+// PinnedCustomImage returns the pinned custom image string, or empty if none is set.
+func PinnedCustomImage(cr *opensearchv1.OpenSearchCluster) string {
+	if !HasPinnedCustomImage(cr) {
+		return ""
+	}
+	return *cr.Spec.General.ImageSpec.Image
+}
+
 // Function to help identify httpPort, securityConfigPort and securityConfigPath for 1.x and 2.x OpenSearch Operator.
 func VersionCheck(instance *opensearchv1.OpenSearchCluster) (int32, int32, string) {
 	var httpPort int32

--- a/opensearch-operator/pkg/reconcilers/emptydir_recovery.go
+++ b/opensearch-operator/pkg/reconcilers/emptydir_recovery.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	emptyDirRecoveryComponent      = "EmptyDirRecovery"
-	emptyDirRecoveryStatusPending  = "Pending"
-	emptyDirRecoveryGracePeriod    = 5 * time.Minute
+	emptyDirRecoveryComponent     = "EmptyDirRecovery"
+	emptyDirRecoveryStatusPending = "Pending"
+	emptyDirRecoveryGracePeriod   = 5 * time.Minute
 )
 
 type emptyDirPodStats struct {

--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -120,6 +120,7 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 
 		if sts.Status.ReadyReplicas != ptr.Deref(sts.Spec.Replicas, 1) {
 			r.logger.Info("StatefulSet is not ready", "name", sts.Name, "namespace", sts.Namespace, "readyReplicas", sts.Status.ReadyReplicas, "desiredReplicas", ptr.Deref(sts.Spec.Replicas, 1))
+			r.handleUnreadyPods(nodePool, &sts)
 			return ctrl.Result{
 				Requeue:      true,
 				RequeueAfter: 10 * time.Second,
@@ -418,6 +419,33 @@ func (r *RollingRestartReconciler) findStatus() *opensearchv1.ComponentStatus {
 		return &found
 	}
 	return nil
+}
+
+// handleUnreadyPods tries to unblock rolling restarts stalled by CrashLoopBackOff pods and emits Warning events.
+func (r *RollingRestartReconciler) handleUnreadyPods(pool opensearchv1.NodePool, sts *appsv1.StatefulSet) {
+	annotations := map[string]string{"cluster-name": r.instance.GetName()}
+	deletedPod, err := helpers.DeleteStuckPodWithOlderRevision(r.client, sts)
+	if err != nil {
+		r.logger.Error(err, "Could not delete stuck pod with older revision", "pool", pool.Component)
+	} else if deletedPod != "" {
+		r.logger.Info("Deleted stuck CrashLoopBackOff pod with older revision", "pod", deletedPod, "pool", pool.Component)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "RollingRestart",
+			"Deleted stuck CrashLoopBackOff pod '%s' in node pool '%s' to allow the rolling restart to proceed", deletedPod, pool.Component)
+	}
+
+	crashPods, err := helpers.CrashLoopBackOffPods(r.client, sts)
+	if err != nil {
+		r.logger.Error(err, "Could not list CrashLoopBackOff pods", "pool", pool.Component)
+		return
+	}
+	for _, podName := range crashPods {
+		if podName == deletedPod {
+			continue
+		}
+		r.logger.Info("Rolling restart stalled by CrashLoopBackOff pod", "pod", podName, "pool", pool.Component)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "RollingRestart",
+			"Pod '%s' in node pool '%s' is in CrashLoopBackOff; rolling restart is stalled until the pod becomes ready", podName, pool.Component)
+	}
 }
 
 func (r *RollingRestartReconciler) DeleteResources() (ctrl.Result, error) {

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/util"
 	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -31,10 +32,11 @@ var (
 )
 
 const (
-	componentNameUpgrader   = "Upgrader"
-	upgradeStatusPending    = "Pending"
-	upgradeStatusInProgress = "Upgrading"
-	upgradeStatusFinished   = "Finished"
+	componentNameUpgrader    = "Upgrader"
+	upgradeStatusPending     = "Pending"
+	upgradeStatusInProgress  = "Upgrading"
+	upgradeStatusFinished    = "Finished"
+	upgradeTargetDescription = "__upgrade_target__"
 )
 
 const upgradeReconcilerName = "upgrade"
@@ -70,12 +72,15 @@ func NewUpgradeReconciler(
 func (r *UpgradeReconciler) Name() string { return upgradeReconcilerName }
 
 func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
-	// If versions are in sync do nothing
+	annotations := map[string]string{"cluster-name": r.instance.GetName()}
+
+	// If versions are in sync do nothing ΓÇö but always clear leftover Upgrader bookkeeping so an
+	// aborted/reverted upgrade cannot skip pools on the next upgrade (issue #1453).
 	if r.instance.Spec.General.Version == r.instance.Status.Version {
-		// If phase is UPGRADING but versions are in sync, set it back to RUNNING
-		if r.instance.Status.Phase == opensearchv1.PhaseUpgrading {
+		if r.instance.Status.Phase == opensearchv1.PhaseUpgrading || r.hasUpgraderStatuses() {
 			err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
 				instance.Status.Phase = opensearchv1.PhaseRunning
+				instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
 			})
 			return ctrl.Result{}, err
 		}
@@ -90,12 +95,42 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		}, nil
 	}
 
-	annotations := map[string]string{"cluster-name": r.instance.GetName()}
+	// A pinned custom image ignores spec.general.version for the pod template. Bumping version
+	// alone would otherwise look like an instant successful upgrade with no pods restarted.
+	if helpers.HasPinnedCustomImage(r.instance) {
+		r.logger.Info("Skipping version upgrade because a custom image is pinned",
+			"image", helpers.PinnedCustomImage(r.instance),
+			"requestedVersion", r.instance.Spec.General.Version,
+			"statusVersion", r.instance.Status.Version)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
+			"spec.general.version changed to %s but a custom image is pinned (%s); pods are not upgraded by version changes. Update imageSpec.image (or remove it) to change the running image",
+			r.instance.Spec.General.Version, helpers.PinnedCustomImage(r.instance))
+		err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+			instance.Status.Version = instance.Spec.General.Version
+			instance.Status.Phase = opensearchv1.PhaseRunning
+			instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
+		})
+		return ctrl.Result{}, err
+	}
 
 	// If version validation fails log a warning and do nothing
 	if err := r.validateUpgrade(); err != nil {
 		r.logger.V(1).Error(err, "version validation failed", "currentVersion", r.instance.Status.Version, "requestedVersion", r.instance.Spec.General.Version)
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Upgrade", "Failed to validation version, currentVersion: %s , requestedVersion: %s", r.instance.Status.Version, r.instance.Spec.General.Version)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Failed to validate version, currentVersion: %s , requestedVersion: %s", r.instance.Status.Version, r.instance.Spec.General.Version)
+		return ctrl.Result{}, err
+	}
+
+	// Reset per-pool progress when the upgrade target changes mid-flight (or after an abort that
+	// left stale Upgraded entries while versions still differ).
+	if err := r.ensureUpgradeTarget(); err != nil {
+		r.logger.Error(err, "Could not update upgrade target status")
+		return ctrl.Result{}, err
+	}
+
+	// Drop Upgrader entries for pools that were removed from the spec so they cannot permanently
+	// leave IsUpgradeInProgress stuck true.
+	if err := r.cleanOrphanedUpgraderStatuses(); err != nil {
+		r.logger.Error(err, "Could not clean orphaned upgrader statuses")
 		return ctrl.Result{}, err
 	}
 
@@ -157,16 +192,7 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
 			instance.Status.Version = instance.Spec.General.Version
 			instance.Status.Phase = opensearchv1.PhaseRunning
-			for _, pool := range instance.Spec.NodePools {
-				componentStatus := opensearchv1.ComponentStatus{
-					Component:   componentNameUpgrader,
-					Description: pool.Component,
-				}
-				currentStatus, found := helpers.FindFirstPartial(instance.Status.ComponentsStatus, componentStatus, helpers.GetByDescriptionAndComponent)
-				if found {
-					instance.Status.ComponentsStatus = helpers.RemoveIt(currentStatus, instance.Status.ComponentsStatus)
-				}
-			}
+			instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
 		})
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Upgrade", "Finished upgrade - NewVersion: %s", r.instance.Spec.General.Version)
 		return ctrl.Result{}, err
@@ -174,6 +200,94 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		// We should never get here so return an error
 		return ctrl.Result{}, ErrUnexpectedStatus
 	}
+}
+
+func (r *UpgradeReconciler) hasUpgraderStatuses() bool {
+	for _, status := range r.instance.Status.ComponentsStatus {
+		if status.Component == componentNameUpgrader {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureUpgradeTarget records the version currently being upgraded to. If the target changes
+// (or no target is recorded yet while Upgrader entries exist), clear per-pool progress so pools
+// are not skipped.
+func (r *UpgradeReconciler) ensureUpgradeTarget() error {
+	target := opensearchv1.ComponentStatus{
+		Component:   componentNameUpgrader,
+		Description: upgradeTargetDescription,
+	}
+	current, found := helpers.FindFirstPartial(r.instance.Status.ComponentsStatus, target, helpers.GetByDescriptionAndComponent)
+	desiredVersion := r.instance.Spec.General.Version
+
+	if found && current.Status == desiredVersion {
+		return nil
+	}
+
+	r.logger.Info("Resetting upgrade progress for new target version",
+		"previousTarget", current.Status,
+		"newTarget", desiredVersion,
+		"hadPreviousTarget", found)
+
+	targetStatus := opensearchv1.ComponentStatus{
+		Component:   componentNameUpgrader,
+		Description: upgradeTargetDescription,
+		Status:      desiredVersion,
+	}
+	err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+		instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
+		instance.Status.ComponentsStatus = append(instance.Status.ComponentsStatus, targetStatus)
+	})
+	if err != nil {
+		return err
+	}
+	// Keep the local copy in sync so pool selection in this reconcile does not use stale entries.
+	r.instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(r.instance.Status.ComponentsStatus)
+	r.instance.Status.ComponentsStatus = append(r.instance.Status.ComponentsStatus, targetStatus)
+	return nil
+}
+
+func (r *UpgradeReconciler) cleanOrphanedUpgraderStatuses() error {
+	validPools := make(map[string]struct{}, len(r.instance.Spec.NodePools)+1)
+	for _, pool := range r.instance.Spec.NodePools {
+		validPools[pool.Component] = struct{}{}
+	}
+	validPools[upgradeTargetDescription] = struct{}{}
+
+	filtered := make([]opensearchv1.ComponentStatus, 0, len(r.instance.Status.ComponentsStatus))
+	removed := false
+	for _, status := range r.instance.Status.ComponentsStatus {
+		if status.Component == componentNameUpgrader {
+			if _, ok := validPools[status.Description]; !ok {
+				removed = true
+				continue
+			}
+		}
+		filtered = append(filtered, status)
+	}
+	if !removed {
+		return nil
+	}
+
+	err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+		kept := make([]opensearchv1.ComponentStatus, 0, len(instance.Status.ComponentsStatus))
+		for _, status := range instance.Status.ComponentsStatus {
+			if status.Component == componentNameUpgrader {
+				if _, ok := validPools[status.Description]; !ok {
+					continue
+				}
+			}
+			kept = append(kept, status)
+		}
+		instance.Status.ComponentsStatus = kept
+	})
+	if err != nil {
+		return err
+	}
+	r.instance.Status.ComponentsStatus = filtered
+	return nil
 }
 
 // Currently provides basic validation on versions.
@@ -193,7 +307,7 @@ func (r *UpgradeReconciler) validateUpgrade() error {
 
 	// Don't allow version downgrades as they might cause unexpected issues
 	if new.LessThan(existing) {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Error", "Upgrade", "Invalid version: specified version is a downgrade")
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Invalid version: specified version is a downgrade")
 		return ErrVersionDowngrade
 	}
 
@@ -205,7 +319,7 @@ func (r *UpgradeReconciler) validateUpgrade() error {
 	}
 
 	if !upgradeConstraint.Check(new) {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Error", "Upgrade", "Invalid version: specified version is more than 1 major version greater than existing")
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Invalid version: specified version is more than 1 major version greater than existing")
 		return ErrMajorVersionJump
 	}
 
@@ -342,6 +456,7 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opensearchv1.NodePool) error 
 	if sts.Status.ReadyReplicas < lo.FromPtrOr(sts.Spec.Replicas, 1) {
 		r.logger.Info("Waiting for all pods to be ready")
 		conditions = append(conditions, "Waiting for all pods to be ready")
+		r.handleUnreadyPods(pool, &sts, annotations)
 		r.setComponentConditions(conditions, pool.Component)
 		return nil
 	}
@@ -442,6 +557,32 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opensearchv1.NodePool) error 
 	}
 
 	return nil
+}
+
+// handleUnreadyPods tries to unblock upgrades stalled by CrashLoopBackOff pods and emits Warning events.
+func (r *UpgradeReconciler) handleUnreadyPods(pool opensearchv1.NodePool, sts *appsv1.StatefulSet, annotations map[string]string) {
+	deletedPod, err := helpers.DeleteStuckPodWithOlderRevision(r.client, sts)
+	if err != nil {
+		r.logger.Error(err, "Could not delete stuck pod with older revision", "pool", pool.Component)
+	} else if deletedPod != "" {
+		r.logger.Info("Deleted stuck CrashLoopBackOff pod with older revision", "pod", deletedPod, "pool", pool.Component)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
+			"Deleted stuck CrashLoopBackOff pod '%s' in node pool '%s' to allow the upgrade to proceed", deletedPod, pool.Component)
+	}
+
+	crashPods, err := helpers.CrashLoopBackOffPods(r.client, sts)
+	if err != nil {
+		r.logger.Error(err, "Could not list CrashLoopBackOff pods", "pool", pool.Component)
+		return
+	}
+	for _, podName := range crashPods {
+		if podName == deletedPod {
+			continue
+		}
+		r.logger.Info("Upgrade stalled by CrashLoopBackOff pod", "pod", podName, "pool", pool.Component)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
+			"Pod '%s' in node pool '%s' is in CrashLoopBackOff; upgrade is stalled until the pod becomes ready", podName, pool.Component)
+	}
 }
 
 func (r *UpgradeReconciler) setComponentConditions(conditions []string, component string) {

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/util"
 	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -31,10 +32,11 @@ var (
 )
 
 const (
-	componentNameUpgrader   = "Upgrader"
-	upgradeStatusPending    = "Pending"
-	upgradeStatusInProgress = "Upgrading"
-	upgradeStatusFinished   = "Finished"
+	componentNameUpgrader    = "Upgrader"
+	upgradeStatusPending     = "Pending"
+	upgradeStatusInProgress  = "Upgrading"
+	upgradeStatusFinished    = "Finished"
+	upgradeTargetDescription = "__upgrade_target__"
 )
 
 const upgradeReconcilerName = "upgrade"
@@ -70,12 +72,15 @@ func NewUpgradeReconciler(
 func (r *UpgradeReconciler) Name() string { return upgradeReconcilerName }
 
 func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
-	// If versions are in sync do nothing
+	annotations := map[string]string{"cluster-name": r.instance.GetName()}
+
+	// If versions are in sync do nothing ΓÇö but always clear leftover Upgrader bookkeeping so an
+	// aborted/reverted upgrade cannot skip pools on the next upgrade (issue #1453).
 	if r.instance.Spec.General.Version == r.instance.Status.Version {
-		// If phase is UPGRADING but versions are in sync, set it back to RUNNING
-		if r.instance.Status.Phase == opensearchv1.PhaseUpgrading {
+		if r.instance.Status.Phase == opensearchv1.PhaseUpgrading || r.hasUpgraderStatuses() {
 			err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
 				instance.Status.Phase = opensearchv1.PhaseRunning
+				instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
 			})
 			return ctrl.Result{}, err
 		}
@@ -90,15 +95,45 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		}, nil
 	}
 
-	annotations := map[string]string{"cluster-name": r.instance.GetName()}
+	// A pinned custom image ignores spec.general.version for the pod template. Bumping version
+	// alone would otherwise look like an instant successful upgrade with no pods restarted.
+	if helpers.HasPinnedCustomImage(r.instance) {
+		r.logger.Info("Skipping version upgrade because a custom image is pinned",
+			"image", helpers.PinnedCustomImage(r.instance),
+			"requestedVersion", r.instance.Spec.General.Version,
+			"statusVersion", r.instance.Status.Version)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
+			"spec.general.version changed to %s but a custom image is pinned (%s); pods are not upgraded by version changes. Update imageSpec.image (or remove it) to change the running image",
+			r.instance.Spec.General.Version, helpers.PinnedCustomImage(r.instance))
+		err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+			instance.Status.Version = instance.Spec.General.Version
+			instance.Status.Phase = opensearchv1.PhaseRunning
+			instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
+		})
+		return ctrl.Result{}, err
+	}
 
 	// If version validation fails log a warning and do nothing. Return a
 	// terminal error so the main chain can continue (restart, snapshots, etc.)
 	// instead of freezing all maintenance on a permanent spec mistake.
 	if err := r.validateUpgrade(); err != nil {
 		r.logger.V(1).Error(err, "version validation failed", "currentVersion", r.instance.Status.Version, "requestedVersion", r.instance.Spec.General.Version)
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Failed to validation version, currentVersion: %s , requestedVersion: %s", r.instance.Status.Version, r.instance.Spec.General.Version)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Failed to validate version, currentVersion: %s , requestedVersion: %s", r.instance.Status.Version, r.instance.Spec.General.Version)
 		return ctrl.Result{}, AsTerminal(err)
+	}
+
+	// Reset per-pool progress when the upgrade target changes mid-flight (or after an abort that
+	// left stale Upgraded entries while versions still differ).
+	if err := r.ensureUpgradeTarget(); err != nil {
+		r.logger.Error(err, "Could not update upgrade target status")
+		return ctrl.Result{}, err
+	}
+
+	// Drop Upgrader entries for pools that were removed from the spec so they cannot permanently
+	// leave IsUpgradeInProgress stuck true.
+	if err := r.cleanOrphanedUpgraderStatuses(); err != nil {
+		r.logger.Error(err, "Could not clean orphaned upgrader statuses")
+		return ctrl.Result{}, err
 	}
 
 	// Set phase to UPGRADING if not already set
@@ -159,16 +194,7 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
 			instance.Status.Version = instance.Spec.General.Version
 			instance.Status.Phase = opensearchv1.PhaseRunning
-			for _, pool := range instance.Spec.NodePools {
-				componentStatus := opensearchv1.ComponentStatus{
-					Component:   componentNameUpgrader,
-					Description: pool.Component,
-				}
-				currentStatus, found := helpers.FindFirstPartial(instance.Status.ComponentsStatus, componentStatus, helpers.GetByDescriptionAndComponent)
-				if found {
-					instance.Status.ComponentsStatus = helpers.RemoveIt(currentStatus, instance.Status.ComponentsStatus)
-				}
-			}
+			instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
 		})
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Upgrade", "Finished upgrade - NewVersion: %s", r.instance.Spec.General.Version)
 		return ctrl.Result{}, err
@@ -176,6 +202,94 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		// We should never get here so return an error
 		return ctrl.Result{}, ErrUnexpectedStatus
 	}
+}
+
+func (r *UpgradeReconciler) hasUpgraderStatuses() bool {
+	for _, status := range r.instance.Status.ComponentsStatus {
+		if status.Component == componentNameUpgrader {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureUpgradeTarget records the version currently being upgraded to. If the target changes
+// (or no target is recorded yet while Upgrader entries exist), clear per-pool progress so pools
+// are not skipped.
+func (r *UpgradeReconciler) ensureUpgradeTarget() error {
+	target := opensearchv1.ComponentStatus{
+		Component:   componentNameUpgrader,
+		Description: upgradeTargetDescription,
+	}
+	current, found := helpers.FindFirstPartial(r.instance.Status.ComponentsStatus, target, helpers.GetByDescriptionAndComponent)
+	desiredVersion := r.instance.Spec.General.Version
+
+	if found && current.Status == desiredVersion {
+		return nil
+	}
+
+	r.logger.Info("Resetting upgrade progress for new target version",
+		"previousTarget", current.Status,
+		"newTarget", desiredVersion,
+		"hadPreviousTarget", found)
+
+	targetStatus := opensearchv1.ComponentStatus{
+		Component:   componentNameUpgrader,
+		Description: upgradeTargetDescription,
+		Status:      desiredVersion,
+	}
+	err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+		instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(instance.Status.ComponentsStatus)
+		instance.Status.ComponentsStatus = append(instance.Status.ComponentsStatus, targetStatus)
+	})
+	if err != nil {
+		return err
+	}
+	// Keep the local copy in sync so pool selection in this reconcile does not use stale entries.
+	r.instance.Status.ComponentsStatus = helpers.ClearUpgraderComponentStatuses(r.instance.Status.ComponentsStatus)
+	r.instance.Status.ComponentsStatus = append(r.instance.Status.ComponentsStatus, targetStatus)
+	return nil
+}
+
+func (r *UpgradeReconciler) cleanOrphanedUpgraderStatuses() error {
+	validPools := make(map[string]struct{}, len(r.instance.Spec.NodePools)+1)
+	for _, pool := range r.instance.Spec.NodePools {
+		validPools[pool.Component] = struct{}{}
+	}
+	validPools[upgradeTargetDescription] = struct{}{}
+
+	filtered := make([]opensearchv1.ComponentStatus, 0, len(r.instance.Status.ComponentsStatus))
+	removed := false
+	for _, status := range r.instance.Status.ComponentsStatus {
+		if status.Component == componentNameUpgrader {
+			if _, ok := validPools[status.Description]; !ok {
+				removed = true
+				continue
+			}
+		}
+		filtered = append(filtered, status)
+	}
+	if !removed {
+		return nil
+	}
+
+	err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+		kept := make([]opensearchv1.ComponentStatus, 0, len(instance.Status.ComponentsStatus))
+		for _, status := range instance.Status.ComponentsStatus {
+			if status.Component == componentNameUpgrader {
+				if _, ok := validPools[status.Description]; !ok {
+					continue
+				}
+			}
+			kept = append(kept, status)
+		}
+		instance.Status.ComponentsStatus = kept
+	})
+	if err != nil {
+		return err
+	}
+	r.instance.Status.ComponentsStatus = filtered
+	return nil
 }
 
 // Currently provides basic validation on versions.
@@ -195,7 +309,7 @@ func (r *UpgradeReconciler) validateUpgrade() error {
 
 	// Don't allow version downgrades as they might cause unexpected issues
 	if new.LessThan(existing) {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Error", "Upgrade", "Invalid version: specified version is a downgrade")
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Invalid version: specified version is a downgrade")
 		return ErrVersionDowngrade
 	}
 
@@ -207,7 +321,7 @@ func (r *UpgradeReconciler) validateUpgrade() error {
 	}
 
 	if !upgradeConstraint.Check(new) {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Error", "Upgrade", "Invalid version: specified version is more than 1 major version greater than existing")
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Invalid version: specified version is more than 1 major version greater than existing")
 		return ErrMajorVersionJump
 	}
 
@@ -344,6 +458,7 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opensearchv1.NodePool) error 
 	if sts.Status.ReadyReplicas < lo.FromPtrOr(sts.Spec.Replicas, 1) {
 		r.logger.Info("Waiting for all pods to be ready")
 		conditions = append(conditions, "Waiting for all pods to be ready")
+		r.handleUnreadyPods(pool, &sts, annotations)
 		r.setComponentConditions(conditions, pool.Component)
 		return nil
 	}
@@ -444,6 +559,32 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opensearchv1.NodePool) error 
 	}
 
 	return nil
+}
+
+// handleUnreadyPods tries to unblock upgrades stalled by CrashLoopBackOff pods and emits Warning events.
+func (r *UpgradeReconciler) handleUnreadyPods(pool opensearchv1.NodePool, sts *appsv1.StatefulSet, annotations map[string]string) {
+	deletedPod, err := helpers.DeleteStuckPodWithOlderRevision(r.client, sts)
+	if err != nil {
+		r.logger.Error(err, "Could not delete stuck pod with older revision", "pool", pool.Component)
+	} else if deletedPod != "" {
+		r.logger.Info("Deleted stuck CrashLoopBackOff pod with older revision", "pod", deletedPod, "pool", pool.Component)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
+			"Deleted stuck CrashLoopBackOff pod '%s' in node pool '%s' to allow the upgrade to proceed", deletedPod, pool.Component)
+	}
+
+	crashPods, err := helpers.CrashLoopBackOffPods(r.client, sts)
+	if err != nil {
+		r.logger.Error(err, "Could not list CrashLoopBackOff pods", "pool", pool.Component)
+		return
+	}
+	for _, podName := range crashPods {
+		if podName == deletedPod {
+			continue
+		}
+		r.logger.Info("Upgrade stalled by CrashLoopBackOff pod", "pod", podName, "pool", pool.Component)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
+			"Pod '%s' in node pool '%s' is in CrashLoopBackOff; upgrade is stalled until the pod becomes ready", podName, pool.Component)
+	}
 }
 
 func (r *UpgradeReconciler) setComponentConditions(conditions []string, component string) {

--- a/opensearch-operator/pkg/reconcilers/upgrade_test.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade_test.go
@@ -1,0 +1,191 @@
+package reconcilers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func newUpgradeReconciler(mockClient *k8s.MockK8sClient, cluster *opensearchv1.OpenSearchCluster) *UpgradeReconciler {
+	reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, cluster, cluster.Spec.NodePools)
+	return &UpgradeReconciler{
+		client:            mockClient,
+		ctx:               context.Background(),
+		recorder:          record.NewFakeRecorder(20),
+		reconcilerContext: &reconcilerContext,
+		instance:          cluster,
+		logger:            zap.New().WithName("upgrade-test"),
+	}
+}
+
+var _ = Describe("Upgrade Reconciler", func() {
+	var (
+		mockClient *k8s.MockK8sClient
+		cluster    *opensearchv1.OpenSearchCluster
+	)
+
+	BeforeEach(func() {
+		mockClient = k8s.NewMockK8sClient(GinkgoT())
+		cluster = &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+				UID:       "dummyuid",
+			},
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{
+					Version: "2.11.0",
+				},
+				NodePools: []opensearchv1.NodePool{
+					{Component: "data", Roles: []string{"data"}, Replicas: 1},
+					{Component: "masters", Roles: []string{"cluster_manager"}, Replicas: 1},
+				},
+			},
+			Status: opensearchv1.ClusterStatus{
+				Version:     "2.11.0",
+				Phase:       opensearchv1.PhaseRunning,
+				Initialized: true,
+			},
+		}
+	})
+
+	Describe("stale Upgrader status cleanup", func() {
+		It("should clear Upgrader entries when versions are in sync", func() {
+			cluster.Status.Phase = opensearchv1.PhaseUpgrading
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "masters", Status: "Upgrading"},
+				{Component: "RollingRestart", Status: "Finished"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			result, err := underTest.Reconcile()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(cluster.Status.Phase).To(Equal(opensearchv1.PhaseRunning))
+			Expect(cluster.Status.ComponentsStatus).To(ConsistOf(
+				opensearchv1.ComponentStatus{Component: "RollingRestart", Status: "Finished"},
+			))
+		})
+
+		It("should reset pool progress when the upgrade target changes", func() {
+			cluster.Spec.General.Version = "2.13.0"
+			cluster.Status.Version = "2.11.0"
+			cluster.Status.Phase = opensearchv1.PhaseUpgrading
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "masters", Status: "Upgrading"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			err := underTest.ensureUpgradeTarget()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cluster.Status.ComponentsStatus).To(ConsistOf(
+				opensearchv1.ComponentStatus{
+					Component:   "Upgrader",
+					Description: "__upgrade_target__",
+					Status:      "2.13.0",
+				},
+			))
+
+			pool, status := underTest.findNextNodePoolForUpgrade()
+			Expect(status.Status).To(Equal(upgradeStatusPending))
+			Expect(pool.Component).To(Equal("data"))
+		})
+
+		It("should remove Upgrader entries for pools no longer in the spec", func() {
+			cluster.Spec.General.Version = "2.12.0"
+			cluster.Status.Version = "2.11.0"
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "gone", Status: "Upgrading"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			err := underTest.cleanOrphanedUpgraderStatuses()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster.Status.ComponentsStatus).To(ConsistOf(
+				opensearchv1.ComponentStatus{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				opensearchv1.ComponentStatus{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+			))
+			Expect(helpers.IsUpgradeInProgress(cluster.Status)).To(BeTrue())
+		})
+	})
+
+	Describe("custom image pinned", func() {
+		It("should sync status.version without running a silent upgrade", func() {
+			image := "example.com/opensearch:custom"
+			cluster.Spec.General.Version = "2.12.0"
+			cluster.Spec.General.ImageSpec = &opensearchv1.ImageSpec{Image: &image}
+			cluster.Status.Version = "2.11.0"
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			result, err := underTest.Reconcile()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(cluster.Status.Version).To(Equal("2.12.0"))
+			Expect(cluster.Status.Phase).To(Equal(opensearchv1.PhaseRunning))
+			Expect(cluster.Status.ComponentsStatus).To(BeEmpty())
+		})
+	})
+
+	Describe("findNextNodePoolForUpgrade", func() {
+		It("should skip the upgrade target marker when selecting pools", func() {
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+			}
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			pool, status := underTest.findNextNodePoolForUpgrade()
+			Expect(status.Status).To(Equal(upgradeStatusPending))
+			Expect(pool.Component).To(Equal("data"))
+		})
+	})
+
+	Describe("validateUpgrade events", func() {
+		It("should reject downgrades", func() {
+			cluster.Spec.General.Version = "2.10.0"
+			cluster.Status.Version = "2.11.0"
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			err := underTest.validateUpgrade()
+			Expect(err).To(MatchError(ErrVersionDowngrade))
+		})
+	})
+})

--- a/opensearch-operator/pkg/reconcilers/upgrade_test.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/stretchr/testify/mock"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var _ = Describe("Upgrade version validation", func() {
@@ -40,5 +43,181 @@ var _ = Describe("Upgrade version validation", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(IsTerminal(err)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("downgrade"))
+	})
+})
+
+func newUpgradeReconciler(mockClient *k8s.MockK8sClient, cluster *opensearchv1.OpenSearchCluster) *UpgradeReconciler {
+	reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, cluster, cluster.Spec.NodePools)
+	return &UpgradeReconciler{
+		client:            mockClient,
+		ctx:               context.Background(),
+		recorder:          record.NewFakeRecorder(20),
+		reconcilerContext: &reconcilerContext,
+		instance:          cluster,
+		logger:            zap.New().WithName("upgrade-test"),
+	}
+}
+
+var _ = Describe("Upgrade Reconciler", func() {
+	var (
+		mockClient *k8s.MockK8sClient
+		cluster    *opensearchv1.OpenSearchCluster
+	)
+
+	BeforeEach(func() {
+		mockClient = k8s.NewMockK8sClient(GinkgoT())
+		cluster = &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+				UID:       "dummyuid",
+			},
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{
+					Version: "2.11.0",
+				},
+				NodePools: []opensearchv1.NodePool{
+					{Component: "data", Roles: []string{"data"}, Replicas: 1},
+					{Component: "masters", Roles: []string{"cluster_manager"}, Replicas: 1},
+				},
+			},
+			Status: opensearchv1.ClusterStatus{
+				Version:     "2.11.0",
+				Phase:       opensearchv1.PhaseRunning,
+				Initialized: true,
+			},
+		}
+	})
+
+	Describe("stale Upgrader status cleanup", func() {
+		It("should clear Upgrader entries when versions are in sync", func() {
+			cluster.Status.Phase = opensearchv1.PhaseUpgrading
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "masters", Status: "Upgrading"},
+				{Component: "RollingRestart", Status: "Finished"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			result, err := underTest.Reconcile()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(cluster.Status.Phase).To(Equal(opensearchv1.PhaseRunning))
+			Expect(cluster.Status.ComponentsStatus).To(ConsistOf(
+				opensearchv1.ComponentStatus{Component: "RollingRestart", Status: "Finished"},
+			))
+		})
+
+		It("should reset pool progress when the upgrade target changes", func() {
+			cluster.Spec.General.Version = "2.13.0"
+			cluster.Status.Version = "2.11.0"
+			cluster.Status.Phase = opensearchv1.PhaseUpgrading
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "masters", Status: "Upgrading"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			err := underTest.ensureUpgradeTarget()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cluster.Status.ComponentsStatus).To(ConsistOf(
+				opensearchv1.ComponentStatus{
+					Component:   "Upgrader",
+					Description: "__upgrade_target__",
+					Status:      "2.13.0",
+				},
+			))
+
+			pool, status := underTest.findNextNodePoolForUpgrade()
+			Expect(status.Status).To(Equal(upgradeStatusPending))
+			Expect(pool.Component).To(Equal("data"))
+		})
+
+		It("should remove Upgrader entries for pools no longer in the spec", func() {
+			cluster.Spec.General.Version = "2.12.0"
+			cluster.Status.Version = "2.11.0"
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+				{Component: "Upgrader", Description: "gone", Status: "Upgrading"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			err := underTest.cleanOrphanedUpgraderStatuses()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster.Status.ComponentsStatus).To(ConsistOf(
+				opensearchv1.ComponentStatus{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+				opensearchv1.ComponentStatus{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+			))
+			Expect(helpers.IsUpgradeInProgress(cluster.Status)).To(BeTrue())
+		})
+	})
+
+	Describe("custom image pinned", func() {
+		It("should sync status.version without running a silent upgrade", func() {
+			image := "example.com/opensearch:custom"
+			cluster.Spec.General.Version = "2.12.0"
+			cluster.Spec.General.ImageSpec = &opensearchv1.ImageSpec{Image: &image}
+			cluster.Status.Version = "2.11.0"
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "data", Status: "Upgraded"},
+			}
+
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+					updateFn(cluster)
+				}).Return(nil).Once()
+
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			result, err := underTest.Reconcile()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(cluster.Status.Version).To(Equal("2.12.0"))
+			Expect(cluster.Status.Phase).To(Equal(opensearchv1.PhaseRunning))
+			Expect(cluster.Status.ComponentsStatus).To(BeEmpty())
+		})
+	})
+
+	Describe("findNextNodePoolForUpgrade", func() {
+		It("should skip the upgrade target marker when selecting pools", func() {
+			cluster.Status.ComponentsStatus = []opensearchv1.ComponentStatus{
+				{Component: "Upgrader", Description: "__upgrade_target__", Status: "2.12.0"},
+			}
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			pool, status := underTest.findNextNodePoolForUpgrade()
+			Expect(status.Status).To(Equal(upgradeStatusPending))
+			Expect(pool.Component).To(Equal("data"))
+		})
+	})
+
+	Describe("validateUpgrade events", func() {
+		It("should reject downgrades", func() {
+			cluster.Spec.General.Version = "2.10.0"
+			cluster.Status.Version = "2.11.0"
+			underTest := newUpgradeReconciler(mockClient, cluster)
+			err := underTest.validateUpgrade()
+			Expect(err).To(MatchError(ErrVersionDowngrade))
+		})
 	})
 })

--- a/opensearch-operator/webhook/opensearch_cluster_webhook.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook.go
@@ -70,7 +70,30 @@ func (v *OpenSearchClusterValidator) ValidateUpdate(ctx context.Context, oldObj,
 		return nil, err
 	}
 
+	// Reject version-only changes when a custom image pins the running image (version is ignored).
+	if err := validateCustomImageVersionChange(oldCluster, newCluster); err != nil {
+		return nil, err
+	}
+
 	return v.validateTlsConfig(newCluster)
+}
+
+// validateCustomImageVersionChange rejects bumping spec.general.version while a custom image remains
+// pinned unchanged. In that case ResolveImage ignores version, so an "upgrade" would be a silent no-op.
+func validateCustomImageVersionChange(oldCluster, newCluster *opensearchv1.OpenSearchCluster) error {
+	if !helpers.HasPinnedCustomImage(newCluster) {
+		return nil
+	}
+	if oldCluster.Spec.General.Version == newCluster.Spec.General.Version {
+		return nil
+	}
+	oldImage := helpers.PinnedCustomImage(oldCluster)
+	newImage := helpers.PinnedCustomImage(newCluster)
+	if oldImage == newImage {
+		return fmt.Errorf("cannot change spec.general.version from %s to %s while a custom image is pinned (%s); update imageSpec.image (or remove it) to change the running image, since version is ignored when a custom image is set",
+			oldCluster.Spec.General.Version, newCluster.Spec.General.Version, newImage)
+	}
+	return nil
 }
 
 // validateNodePoolComponentUniqueness ensures no two node pools share the same component name,

--- a/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
@@ -445,7 +445,7 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 			}
 			newCluster := oldCluster.DeepCopy()
 			newCluster.Spec.General.Version = "2.12.0"
-			newCluster.Spec.General.ImageSpec.Image = &newImage
+			newCluster.Spec.General.Image = &newImage
 
 			warnings, err := validator.ValidateUpdate(ctx, oldCluster, newCluster)
 			Expect(err).NotTo(HaveOccurred())

--- a/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
@@ -403,6 +403,72 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 			Expect(err.Error()).To(ContainSubstring("duplicate node pool component name 'masters'"))
 			Expect(warnings).To(BeEmpty())
 		})
+
+		It("should reject version change when a custom image remains pinned", func() {
+			image := "example.com/opensearch:custom-1"
+			oldCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.11.0",
+						ImageSpec: &opensearchv1.ImageSpec{
+							Image: &image,
+						},
+					},
+					NodePools: []opensearchv1.NodePool{{Component: "masters"}},
+				},
+			}
+			newCluster := oldCluster.DeepCopy()
+			newCluster.Spec.General.Version = "2.12.0"
+
+			warnings, err := validator.ValidateUpdate(ctx, oldCluster, newCluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot change spec.general.version"))
+			Expect(err.Error()).To(ContainSubstring("custom image is pinned"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow version change when the pinned custom image also changes", func() {
+			oldImage := "example.com/opensearch:custom-1"
+			newImage := "example.com/opensearch:custom-2"
+			oldCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.11.0",
+						ImageSpec: &opensearchv1.ImageSpec{
+							Image: &oldImage,
+						},
+					},
+					NodePools: []opensearchv1.NodePool{{Component: "masters"}},
+				},
+			}
+			newCluster := oldCluster.DeepCopy()
+			newCluster.Spec.General.Version = "2.12.0"
+			newCluster.Spec.General.ImageSpec.Image = &newImage
+
+			warnings, err := validator.ValidateUpdate(ctx, oldCluster, newCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow version change when no custom image is pinned", func() {
+			oldCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.11.0",
+					},
+					NodePools: []opensearchv1.NodePool{{Component: "masters"}},
+				},
+			}
+			newCluster := oldCluster.DeepCopy()
+			newCluster.Spec.General.Version = "2.12.0"
+
+			warnings, err := validator.ValidateUpdate(ctx, oldCluster, newCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
 	})
 
 	Describe("ValidateDelete", func() {


### PR DESCRIPTION
### Description
clear stale upgrader status on abort, revert, reject version bumps with a pinned custom image, recover CrashLoopBackOff pods with warning events, and use valid k8s event types

fixes #1453

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
