### PR TITLE
fix: don't clear allocation exclusion for nodes whose nodePool was removed

### DIFF
--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -419,6 +419,12 @@ func (r *ScalerReconciler) drainNode(currentStatus opensearchv1.ComponentStatus,
 	if err != nil {
 		return err
 	}
+	// Same reason as removeStatefulSet: the drain needs replica movement, which
+	// allocation.enable=primaries blocks. Idempotent.
+	if err := services.ReactivateShardAllocation(clusterClient); err != nil {
+		lg.Error(err, "failed to reactivate shard allocation before draining")
+		return err
+	}
 	nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
 	if err != nil {
 		lg.Error(err, "failed to check shards on node")
@@ -506,6 +512,18 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	_, err = services.AppendExcludeNodeHost(clusterClient, lg, lastReplicaNodeName)
 	if err != nil {
 		lg.Error(err, fmt.Sprintf("failed to exclude node %s", lastReplicaNodeName))
+		return nil, err
+	}
+
+	// This drain only finishes once replicas move off the excluded node, which
+	// allocation.enable=primaries prevents. RollingRestart and Upgrade set that
+	// while restarting a pod and clear it when their cycle ends, but a drain
+	// starting mid-cycle would wait forever: returning Requeue below
+	// short-circuits the reconciler chain (see opensearchController.go), so
+	// neither of them runs again to clear it. Reactivating here is idempotent -
+	// it no-ops when allocation is already unrestricted.
+	if err := services.ReactivateShardAllocation(clusterClient); err != nil {
+		lg.Error(err, "failed to reactivate shard allocation before draining")
 		return nil, err
 	}
 

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -11,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconciler"
 	"github.com/stretchr/testify/mock"
@@ -68,6 +70,38 @@ func registerClusterSettingsResponders(transport *httpmock.MockTransport) {
 		`=~.*/_cluster/settings.*`,
 		httpmock.NewStringResponder(200, `{"transient":{},"persistent":{}}`),
 	)
+}
+
+// registerAllocationEnableSpy makes GET _cluster/settings report
+// allocation.enable=primaries, and returns a pointer that records the last
+// value any PUT _cluster/settings request actually set allocation.enable to
+// (other PUTs, e.g. AppendExcludeNodeHost's, only touch "exclude" and leave
+// it unchanged).
+func registerAllocationEnableSpy(transport *httpmock.MockTransport) *string {
+	transport.RegisterResponder(
+		http.MethodGet,
+		`=~.*/_cluster/settings.*`,
+		httpmock.NewStringResponder(200, `{"transient":{"cluster.routing.allocation.enable":"primaries"},"persistent":{}}`),
+	)
+	reactivatedTo := new(string)
+	transport.RegisterResponder(
+		http.MethodPut,
+		`=~.*/_cluster/settings.*`,
+		func(req *http.Request) (*http.Response, error) {
+			var body responses.ClusterSettingsResponse
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			cluster, _ := body.Transient["cluster"].(map[string]interface{})
+			routing, _ := cluster["routing"].(map[string]interface{})
+			allocation, _ := routing["allocation"].(map[string]interface{})
+			if v, ok := allocation["enable"].(string); ok {
+				*reactivatedTo = v
+			}
+			return httpmock.NewStringResponse(200, `{"transient":{},"persistent":{}}`), nil
+		},
+	)
+	return reactivatedTo
 }
 
 func registerCatShardsResponder(transport *httpmock.MockTransport, status int, body string) {
@@ -559,6 +593,7 @@ var _ = Describe("Scaler Controller", func() {
 			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
 			registerOsPingResponders(transport, &spec)
 			registerCatShardsResponder(transport, http.StatusInternalServerError, `{"error":"unavailable"}`)
+			registerClusterSettingsResponders(transport)
 
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
 			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
@@ -614,6 +649,7 @@ var _ = Describe("Scaler Controller", func() {
 			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
 			registerOsPingResponders(transport, &spec)
 			registerCatShardsResponder(transport, http.StatusOK, `[]`)
+			registerClusterSettingsResponders(transport)
 
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
 			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
@@ -634,6 +670,39 @@ var _ = Describe("Scaler Controller", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(markedDrained).To(BeTrue())
+		})
+
+		It("Should reactivate shard allocation before checking whether the node has drained", func() {
+			// Regression test: a RollingRestart/Upgrade cycle sets
+			// allocation.enable=primaries while restarting a pod and only clears it
+			// once its own cycle ends. If a Scaler drain starts mid-cycle, primaries
+			// blocks exactly the replica movement the drain is waiting on, and
+			// returning Requeue from drainNode short-circuits the reconciler chain
+			// before RollingRestart/Upgrade run again to clear it - a livelock.
+			// drainNode must reactivate allocation itself before checking for shards.
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, nil)
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, `[]`)
+			reactivatedTo := registerAllocationEnableSpy(transport)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+			mockClient.On("UpdateOpenSearchClusterStatus", client.ObjectKeyFromObject(&spec), mock.AnythingOfType("func(*v1.OpenSearchCluster)")).Run(func(args mock.Arguments) {
+				updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+				updateFn(&spec)
+			}).Return(nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			err := underTest.drainNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*reactivatedTo).To(Equal("all"))
 		})
 
 		It("Should emit a Warning and DrainStalled condition when a drain makes no progress", func() {
@@ -742,6 +811,39 @@ var _ = Describe("Scaler Controller", func() {
 			Expect(requeue).To(BeTrue())
 			Expect(*currentSts.Spec.Replicas).To(Equal(int32(3)))
 			mockClient.AssertNotCalled(GinkgoT(), "ReconcileResource", mock.Anything, mock.Anything)
+		})
+
+		It("Should reactivate shard allocation before checking whether a removed nodePool's StatefulSet has drained", func() {
+			// Same deadlock as drainNode: removeStatefulSet's drain (run from
+			// cleanupStatefulSets for a nodePool dropped from spec.NodePools) needs
+			// replica movement off the excluded node, which allocation.enable=primaries
+			// blocks just the same.
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 1)
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterNamespace, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General:  opensearchv1.GeneralConfig{ServiceName: clusterName, HttpPort: 9200},
+					ConfMgmt: opensearchv1.ConfMgmt{SmartScaler: true},
+				},
+			}
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, `[]`)
+			reactivatedTo := registerAllocationEnableSpy(transport)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+			mockClient.On("ReconcileResource", mock.Anything, reconciler.StateAbsent).Return(&ctrl.Result{}, nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			result, err := underTest.removeStatefulSet(currentSts)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&ctrl.Result{}))
+			Expect(*reactivatedTo).To(Equal("all"))
 		})
 	})
 })

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kube-openapi/pkg/validation/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -528,6 +529,17 @@ func scalerHasExcludeOrDrainInProgress(instance *opensearchv1.OpenSearchCluster)
 	return false
 }
 
+// stsOwnsPod reports whether podName is one of sts's replicas.
+func stsOwnsPod(sts appsv1.StatefulSet, podName string) bool {
+	replicas := ptr.Deref(sts.Spec.Replicas, 1)
+	for ord := int32(0); ord < replicas; ord++ {
+		if helpers.ReplicaHostName(sts, ord) == podName {
+			return true
+		}
+	}
+	return false
+}
+
 // isPodStale returns true if the named pod should no longer be in the exclude list:
 // the pod does not exist, or it belongs to our cluster and has the updated revision (already restarted).
 func isPodStale(k8sClient k8s.K8sClient, instance *opensearchv1.OpenSearchCluster, podName string) (bool, error) {
@@ -544,16 +556,30 @@ func isPodStale(k8sClient k8s.K8sClient, instance *opensearchv1.OpenSearchCluste
 		if err != nil {
 			return false, err
 		}
-		replicas := ptr.Deref(sts.Spec.Replicas, 1)
-		for ord := int32(0); ord < replicas; ord++ {
-			if helpers.ReplicaHostName(sts, ord) != podName {
-				continue
-			}
+		if stsOwnsPod(sts, podName) {
 			rev, ok := pod.Labels["controller-revision-hash"]
 			if !ok {
 				return false, fmt.Errorf("pod %s has no controller-revision-hash label", podName)
 			}
+			// A revision match means this pod already restarted in place - safe to clean
+			// up its exclusion. Doesn't apply to a removed nodePool (see below): that
+			// StatefulSet never restarts, so its revision matches from the start.
 			return rev == sts.Status.UpdateRevision, nil
+		}
+	}
+
+	// The nodePool may have been renamed (removed from spec.NodePools, replaced by a
+	// new one). Its StatefulSet is still being drained and removed by the Scaler's
+	// removeStatefulSet, which owns the node's exclusion until that finishes - never
+	// treat it as stale. Only a pod with no owning StatefulSet at all is stale.
+	stsList, err := k8sClient.ListStatefulSets(client.InNamespace(instance.Namespace),
+		client.MatchingLabels{helpers.ClusterLabel: instance.Name})
+	if err != nil {
+		return false, err
+	}
+	for i := range stsList.Items {
+		if stsOwnsPod(stsList.Items[i], podName) {
+			return false, nil
 		}
 	}
 	return true, nil

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -9,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	opsterTLS "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/tls"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -16,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Additional volumes", func() {
@@ -410,6 +413,35 @@ var _ = Describe("isPodStale", func() {
 		})
 	})
 
+	When("pod's ordinal is no longer covered by its nodePool's StatefulSet (replicas already decremented)", func() {
+		It("returns true (stale), so a failed RemoveExcludeNodeHost can be retried", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			// The Scaler decremented Spec.Replicas from 3 to 2 as its last step, but a
+			// prior RemoveExcludeNodeHost for the ordinal-2 pod failed, leaving a
+			// leftover exclusion for a pod ordinal the StatefulSet no longer owns.
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-masters-2",
+					Namespace: ns,
+					Labels:    map[string]string{"controller-revision-hash": updateRev},
+				},
+			}
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			mockClient.EXPECT().GetPod("cluster-masters-2", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+			mockClient.EXPECT().ListStatefulSets(client.InNamespace(ns), client.MatchingLabels{helpers.ClusterLabel: instance.Name}).
+				Return(appsv1.StatefulSetList{Items: []appsv1.StatefulSet{sts}}, nil)
+
+			stale, err := isPodStale(mockClient, instance, "cluster-masters-2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stale).To(BeTrue())
+		})
+	})
+
 	When("pod has no controller-revision-hash label", func() {
 		It("returns error", func() {
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
@@ -435,7 +467,7 @@ var _ = Describe("isPodStale", func() {
 		})
 	})
 
-	When("pod does not belong to any node pool STS", func() {
+	When("pod does not belong to any STS at all", func() {
 		It("returns true (stale)", func() {
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
 			pod := v1.Pod{
@@ -452,10 +484,74 @@ var _ = Describe("isPodStale", func() {
 			}
 			mockClient.EXPECT().GetPod("other-pod-0", ns).Return(pod, nil)
 			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+			mockClient.EXPECT().ListStatefulSets(client.InNamespace(ns), client.MatchingLabels{helpers.ClusterLabel: instance.Name}).
+				Return(appsv1.StatefulSetList{Items: []appsv1.StatefulSet{sts}}, nil)
 
 			stale, err := isPodStale(mockClient, instance, "other-pod-0")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stale).To(BeTrue())
+		})
+	})
+
+	When("ListStatefulSets fails while checking for a removed nodePool's StatefulSet", func() {
+		It("returns that error instead of falling through and reporting stale", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-pod-0",
+					Namespace: ns,
+					Labels:    map[string]string{"controller-revision-hash": "some-rev"},
+				},
+			}
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			listErr := fmt.Errorf("list failed")
+			mockClient.EXPECT().GetPod("other-pod-0", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+			mockClient.EXPECT().ListStatefulSets(client.InNamespace(ns), client.MatchingLabels{helpers.ClusterLabel: instance.Name}).
+				Return(appsv1.StatefulSetList{}, listErr)
+
+			stale, err := isPodStale(mockClient, instance, "other-pod-0")
+			Expect(err).To(MatchError(listErr))
+			Expect(stale).To(BeFalse())
+		})
+	})
+
+	When("pod belongs to a nodePool that has been removed from spec.NodePools but whose StatefulSet is still being gracefully drained", func() {
+		It("returns false (not stale), even though its revision trivially matches UpdateRevision (it was never rolling-restarted)", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			// "basic" was renamed out of instance.Spec.NodePools, but its StatefulSet
+			// still exists while the Scaler drains and removes it one replica at a
+			// time. Its revision matches from the start since it never restarts, so
+			// the restart-in-place heuristic must not apply here.
+			removedPoolSts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-basic", Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-basic-1",
+					Namespace: ns,
+					Labels:    map[string]string{"controller-revision-hash": updateRev},
+				},
+			}
+			mastersSts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			mockClient.EXPECT().GetPod("cluster-basic-1", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(mastersSts, nil)
+			mockClient.EXPECT().ListStatefulSets(client.InNamespace(ns), client.MatchingLabels{helpers.ClusterLabel: instance.Name}).
+				Return(appsv1.StatefulSetList{Items: []appsv1.StatefulSet{mastersSts, removedPoolSts}}, nil)
+
+			stale, err := isPodStale(mockClient, instance, "cluster-basic-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stale).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
isPodStale only checked StatefulSets belonging to nodePools still present in spec.NodePools. When a nodePool is removed entirely (e.g. a nodePool rename that drops the old component and adds a new one), its StatefulSet is still being gracefully drained one replica at a time by the Scaler's removeStatefulSet, which owns that node's cluster.routing.allocation.exclude._name entry for the duration of the drain.

Because the removed nodePool is no longer in spec.NodePools, isPodStale's per-nodePool lookup never found the pod and fell through to "stale", so CleanStaleExclusionList (run at the start of every scaler/rollingRestart/upgrade reconcile) cleared the exclusion out from under the in-progress drain on every reconcile pass. That let OpenSearch reallocate shards back onto the node being removed, so removeStatefulSet's drain check could never converge - a permanent livelock during any nodePool rename that combines with a concurrent rolling restart.

Fix: check every StatefulSet still carrying the cluster's label (via ListStatefulSets) before falling back to "stale", so a pod being actively drained by removeStatefulSet is never mistaken for stale. This check is kept separate from the existing per-nodePool revision comparison, since a StatefulSet whose nodePool was removed is never rolling-restarted - its pods' revision trivially equals UpdateRevision from the start, so the restart-in-place heuristic used for in-spec nodePools doesn't apply and would misfire if reused here.



### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
