### PR TITLE
fix(tls): handle empty adminDn list after upgrade

### DIFF
--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -188,8 +188,10 @@ func (r *TLSReconciler) handleAdminCertificate() (*ctrl.Result, error) {
 				return nil, err
 			}
 			certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
-		} else {
+		} else if len(tlsConfig.AdminDn) > 0 {
 			certDN = strings.Join(tlsConfig.AdminDn, "\",\"")
+		} else {
+			certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
 		}
 	} else {
 		tlsConfig := r.instance.Spec.Security.Tls.Transport
@@ -204,8 +206,10 @@ func (r *TLSReconciler) handleAdminCertificate() (*ctrl.Result, error) {
 				return nil, err
 			}
 			certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
-		} else {
+		} else if len(tlsConfig.AdminDn) > 0 {
 			certDN = strings.Join(tlsConfig.AdminDn, "\",\"") //nolint:staticcheck
+		} else {
+			certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
 		}
 	}
 


### PR DESCRIPTION
fix(tls): handle empty adminDn list after upgrade

When an existing OpenSearch cluster is upgraded and the admin cert secret is
provided (not auto-generated), the operator was rendering an empty admin_dn
string if spec.security.tls.http.adminDn was empty.

This caused the securityadmin.sh job to fail with:
  ERR: "CN=admin" is not an admin user
  Seems you use a client certificate but this one is not registered as admin_dn

Fix: Only use tlsConfig.AdminDn when it has entries; fall back to the generated
DN (CN=admin,OU=<cluster>) when the list is empty.

Fixes #1475
