### PR TITLE
fix(ismpolicy): allow errorNotification channel without destination

### DIFF
--- a/opensearch-operator/opensearch-gateway/requests/IsmPolicy.go
+++ b/opensearch-operator/opensearch-gateway/requests/IsmPolicy.go
@@ -21,7 +21,7 @@ type ISMPolicySpec struct {
 type ErrorNotification struct {
 	// The destination URL.
 	Destination *Destination `json:"destination,omitempty"`
-	Channel     string       `json:"channel,omitempty"`
+	Channel     NotificationChannel `json:"channel,omitempty"`
 	// The text of the message
 	MessageTemplate *MessageTemplate `json:"message_template,omitempty"`
 }

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -298,37 +298,40 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 		DefaultState: r.instance.Spec.DefaultState,
 		Description:  r.instance.Spec.Description,
 	}
-	if r.instance.Spec.ErrorNotification != nil && r.instance.Spec.ErrorNotification.Destination != nil && r.instance.Spec.ErrorNotification.MessageTemplate != nil {
-		dest := requests.Destination{}
-		if r.instance.Spec.ErrorNotification.Destination.Amazon != nil {
-			dest.Amazon = &requests.DestinationURL{
-				URL: r.instance.Spec.ErrorNotification.Destination.Amazon.URL,
-			}
-		}
-		if r.instance.Spec.ErrorNotification.Destination.Chime != nil {
-			dest.Chime = &requests.DestinationURL{
-				URL: r.instance.Spec.ErrorNotification.Destination.Chime.URL,
-			}
-		}
-		if r.instance.Spec.ErrorNotification.Destination.Slack != nil {
-			dest.Slack = &requests.DestinationURL{
-				URL: r.instance.Spec.ErrorNotification.Destination.Slack.URL,
-			}
-		}
-		if r.instance.Spec.ErrorNotification.Destination.CustomWebhook != nil {
-			dest.CustomWebhook = &requests.DestinationURL{
-				URL: r.instance.Spec.ErrorNotification.Destination.CustomWebhook.URL,
-			}
-		}
-		if dest.Amazon == nil && dest.Chime == nil && dest.Slack == nil && dest.CustomWebhook == nil {
-			return nil, errors.New("exactly one errorNotification.destination must be set")
-		}
+	if r.instance.Spec.ErrorNotification != nil {
 		messageTemplate := requests.MessageTemplate{Source: r.instance.Spec.ErrorNotification.MessageTemplate.Source}
 
 		policy.ErrorNotification = &requests.ErrorNotification{
 			Channel:         r.instance.Spec.ErrorNotification.Channel,
-			Destination:     &dest,
 			MessageTemplate: &messageTemplate,
+		}
+
+		if r.instance.Spec.ErrorNotification.Destination != nil {
+			dest := requests.Destination{}
+			if r.instance.Spec.ErrorNotification.Destination.Amazon != nil {
+				dest.Amazon = &requests.DestinationURL{
+					URL: r.instance.Spec.ErrorNotification.Destination.Amazon.URL,
+				}
+			}
+			if r.instance.Spec.ErrorNotification.Destination.Chime != nil {
+				dest.Chime = &requests.DestinationURL{
+					URL: r.instance.Spec.ErrorNotification.Destination.Chime.URL,
+				}
+			}
+			if r.instance.Spec.ErrorNotification.Destination.Slack != nil {
+				dest.Slack = &requests.DestinationURL{
+					URL: r.instance.Spec.ErrorNotification.Destination.Slack.URL,
+				}
+			}
+			if r.instance.Spec.ErrorNotification.Destination.CustomWebhook != nil {
+				dest.CustomWebhook = &requests.DestinationURL{
+					URL: r.instance.Spec.ErrorNotification.Destination.CustomWebhook.URL,
+				}
+			}
+			if dest.Amazon == nil && dest.Chime == nil && dest.Slack == nil && dest.CustomWebhook == nil {
+				return nil, errors.New("exactly one errorNotification.destination must be set")
+			}
+			policy.ErrorNotification.Destination = &dest
 		}
 	}
 

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -304,8 +304,13 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 		}
 		messageTemplate := requests.MessageTemplate{Source: r.instance.Spec.ErrorNotification.MessageTemplate.Source}
 
+		channel := requests.NotificationChannel{}
+		if r.instance.Spec.ErrorNotification.Channel != "" {
+			channel.ID = r.instance.Spec.ErrorNotification.Channel
+		}
+
 		policy.ErrorNotification = &requests.ErrorNotification{
-			Channel:         r.instance.Spec.ErrorNotification.Channel,
+			Channel:         channel,
 			MessageTemplate: &messageTemplate,
 		}
 

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -299,6 +299,9 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 		Description:  r.instance.Spec.Description,
 	}
 	if r.instance.Spec.ErrorNotification != nil {
+		if r.instance.Spec.ErrorNotification.MessageTemplate == nil {
+			return nil, errors.New("errorNotification.messageTemplate must be set")
+		}
 		messageTemplate := requests.MessageTemplate{Source: r.instance.Spec.ErrorNotification.MessageTemplate.Source}
 
 		policy.ErrorNotification = &requests.ErrorNotification{


### PR DESCRIPTION
fix(ismpolicy): allow errorNotification channel without destination

The current code requires both errorNotification.destination AND
errorNotification.messageTemplate to be set before creating the ISM policy.
This means an errorNotification with just a channel name (e.g. for simple
notifications without a custom webhook destination) is silently ignored.

Fix: Check only ErrorNotification != nil, then conditionally handle Destination
if present. The channel and messageTemplate are always set when ErrorNotification
is present.

Fixes #1443
