### PR TITLE
fix: generate admin/dashboards passwords that meet the security plugin policy

### DIFF
--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Builders", func() {
 			result := NewSTSForNodePool("foobar", &clusterObject, opensearchv1.NodePool{}, "foobar", nil, nil)
 
 			installCmd := fmt.Sprintf(
-				"set -f && ./bin/opensearch-plugin install --batch '%s' '%s' && ./opensearch-docker-entrypoint.sh",
+				"./bin/opensearch-plugin install --batch '%s' '%s' && ./opensearch-docker-entrypoint.sh",
 				pluginA,
 				pluginB,
 			)
@@ -665,7 +665,7 @@ var _ = Describe("Builders", func() {
 			result := NewBootstrapPod(&clusterObject, nil, nil)
 
 			installCmd := fmt.Sprintf(
-				"set -f && ./bin/opensearch-plugin install --batch '%s' '%s' && ./opensearch-docker-entrypoint.sh",
+				"./bin/opensearch-plugin install --batch '%s' '%s' && ./opensearch-docker-entrypoint.sh",
 				pluginA,
 				pluginB,
 			)
@@ -721,7 +721,7 @@ var _ = Describe("Builders", func() {
 
 			actual := result.Spec.Containers[0].Command
 			Expect(len(actual)).To(Equal(3))
-			Expect(actual[2]).To(Equal("set -f && ./opensearch-docker-entrypoint.sh"))
+			Expect(actual[2]).To(Equal("./opensearch-docker-entrypoint.sh"))
 		})
 
 		It("should use PVC for data volume instead of emptyDir", func() {
@@ -1041,7 +1041,7 @@ var _ = Describe("Builders", func() {
 			clusterObject.Spec.NodePools = append(clusterObject.Spec.NodePools, nodePool)
 
 			sts := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil)
-			Expect(sts.Spec.Template.Spec.Containers[0].Command[2]).To(Equal("set -f && " + customCommand))
+			Expect(sts.Spec.Template.Spec.Containers[0].Command[2]).To(Equal(customCommand))
 		})
 	})
 

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -286,6 +286,19 @@ func FindByPath(obj interface{}, keys []string) (interface{}, bool) {
 	return val, ok
 }
 
+// GenerateSecurePassword returns a cryptographically secure random password
+// that satisfies the OpenSearch security plugin's default password policy:
+// minimum 8 characters with at least one uppercase letter, one lowercase
+// letter, one digit and one special character. The entropy comes from the 26
+// random base32 characters returned by rand.Text (130 bits); the fixed suffix
+// only guarantees the required character classes. Shell glob characters
+// (e.g. '*', '?', '[') are deliberately avoided so the password is not
+// mangled by unquoted variable expansions in the OpenSearch image's startup
+// scripts (see issue #955).
+func GenerateSecurePassword() string {
+	return rand.Text() + "aB3!"
+}
+
 func EnsureAdminCredentialsSecret(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSearchCluster) (*corev1.Secret, bool, error) {
 	// Check if user provided AdminCredentialsSecret via Security.Config
 	if cr.Spec.Security != nil && cr.Spec.Security.Config != nil && cr.Spec.Security.Config.AdminCredentialsSecret.Name != "" {
@@ -303,7 +316,7 @@ func EnsureAdminCredentialsSecret(k8sClient k8s.K8sClient, cr *opensearchv1.Open
 		return nil, true, err
 	}
 
-	randomPassword := rand.Text()
+	randomPassword := GenerateSecurePassword()
 
 	adminSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1096,7 +1109,7 @@ func EnsureDashboardsCredentialsSecret(k8sClient k8s.K8sClient, cr *opensearchv1
 		return nil, true, err
 	}
 
-	randomPassword := rand.Text()
+	randomPassword := GenerateSecurePassword()
 	// NOTE(joseb): we cannot set random password when security plugin is disabled.
 	if !IsSecurityPluginEnabled(cr) {
 		randomPassword = "kibanaserver"

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -4,8 +4,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+	k8smocks "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/stretchr/testify/mock"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -606,5 +609,89 @@ kibanaserver:
 		}
 		Expect(roleStrings).To(ContainElement("other_role"))
 		Expect(roleStrings).To(ContainElement("admin"))
+	})
+})
+
+// OpenSearch 2.12+ rejects admin passwords missing any of: uppercase,
+// lowercase, digit, special character (see issue #1415).
+func expectPolicyCompliant(password string) {
+	GinkgoHelper()
+	Expect(len(password)).To(BeNumerically(">=", 8))
+	Expect(password).To(MatchRegexp(`[A-Z]`), "password must contain an uppercase letter")
+	Expect(password).To(MatchRegexp(`[a-z]`), "password must contain a lowercase letter")
+	Expect(password).To(MatchRegexp(`[0-9]`), "password must contain a digit")
+	Expect(password).To(MatchRegexp(`[^A-Za-z0-9]`), "password must contain a special character")
+}
+
+var _ = Describe("GenerateSecurePassword", func() {
+	It("satisfies the security plugin password policy", func() {
+		for i := 0; i < 100; i++ {
+			expectPolicyCompliant(GenerateSecurePassword())
+		}
+	})
+
+	It("avoids shell glob characters that get mangled by unquoted expansion (issue #955)", func() {
+		for i := 0; i < 100; i++ {
+			Expect(GenerateSecurePassword()).ToNot(MatchRegexp(`[*?\[\]$` + "`" + `\\'"]`))
+		}
+	})
+
+	It("returns unique passwords", func() {
+		Expect(GenerateSecurePassword()).ToNot(Equal(GenerateSecurePassword()))
+	})
+})
+
+var _ = Describe("EnsureAdminCredentialsSecret", func() {
+	It("generates a password that satisfies the security plugin password policy", func() {
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "pwtest", Namespace: "pwtest"},
+		}
+		secretName := GeneratedAdminCredentialsSecretName(cr)
+
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		notFound := &k8serrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+		mockClient.EXPECT().GetSecret(secretName, "pwtest").Return(corev1.Secret{}, notFound).Once()
+		var created *corev1.Secret
+		mockClient.EXPECT().CreateSecret(mock.Anything).Run(func(secret *corev1.Secret) {
+			created = secret
+		}).Return(nil, nil).Once()
+		mockClient.EXPECT().GetSecret(secretName, "pwtest").Return(corev1.Secret{}, nil).Once()
+
+		_, _, err := EnsureAdminCredentialsSecret(mockClient, cr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(created).ToNot(BeNil())
+		Expect(created.StringData["username"]).To(Equal("admin"))
+		expectPolicyCompliant(created.StringData["password"])
+	})
+})
+
+var _ = Describe("EnsureDashboardsCredentialsSecret", func() {
+	It("generates a password that satisfies the security plugin password policy", func() {
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "pwtest", Namespace: "pwtest"},
+			Spec: opensearchv1.ClusterSpec{
+				Security: &opensearchv1.Security{
+					Tls: &opensearchv1.TlsConfig{
+						Http: &opensearchv1.TlsConfigHttp{Enabled: ptr.To(true)},
+					},
+				},
+			},
+		}
+		secretName := GeneratedDashboardsCredentialsSecretName(cr)
+
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		notFound := &k8serrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+		mockClient.EXPECT().GetSecret(secretName, "pwtest").Return(corev1.Secret{}, notFound).Once()
+		var created *corev1.Secret
+		mockClient.EXPECT().CreateSecret(mock.Anything).Run(func(secret *corev1.Secret) {
+			created = secret
+		}).Return(nil, nil).Once()
+		mockClient.EXPECT().GetSecret(secretName, "pwtest").Return(corev1.Secret{}, nil).Once()
+
+		_, _, err := EnsureDashboardsCredentialsSecret(mockClient, cr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(created).ToNot(BeNil())
+		Expect(created.StringData["username"]).To(Equal("kibanaserver"))
+		expectPolicyCompliant(created.StringData["password"])
 	})
 })

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -179,12 +179,10 @@ func BuildMainCommand(installerBinary string, pluginsList []string, batchMode bo
 			com = com + " '" + strings.ReplaceAll(plugin, "'", "\\'") + "'"
 		}
 
-		// Disable shell glob expansion so credentials containing wildcard characters
-		// (e.g. OPENSEARCH_INITIAL_ADMIN_PASSWORD='...*...') are not altered by bash.
-		com = "set -f && " + com + " && " + entrypoint
+		com = com + " && " + entrypoint
 		mainCommand = append(mainCommand, com)
 	} else {
-		mainCommand = []string{"/bin/bash", "-c", "set -f && " + entrypoint}
+		mainCommand = []string{"/bin/bash", "-c", entrypoint}
 	}
 
 	return mainCommand


### PR DESCRIPTION
### Description

The operator generated admin and Dashboards credentials with `crypto/rand.Text()`, which returns base32 strings (uppercase letters and digits only). OpenSearch 2.12+ rejects such passwords — the security plugin requires at least one uppercase letter, one lowercase letter, one digit and one special character — so any cluster relying on operator-generated credentials failed to start (#1415).

Passwords are now generated by a new `GenerateSecurePassword()` helper: 26 random base32 characters from `crypto/rand` (130 bits of entropy) plus a fixed `aB3!` suffix that deterministically guarantees the required character classes. Shell glob characters (`*`, `?`, `[`) are deliberately excluded from the alphabet so generated passwords can never be mangled by unquoted variable expansions in the OpenSearch image's startup scripts — the failure mode behind #955.

This PR also reverts the `set -f` prefix introduced in #1445. Shell options do not propagate to child processes (`bash -c 'set -f && ./entrypoint.sh'` runs the entrypoint in a fresh shell with globbing re-enabled — easily verified with a script that echoes an unquoted `*`-containing variable), so it never protected the password references inside `opensearch-docker-entrypoint.sh` / `install_demo_configuration.sh`. Meanwhile it silently disabled globbing for user-supplied custom commands. The operator's own command line never contains the password (plugin URLs are single-quoted, the entrypoint path is a literal), so nothing is lost by removing it. Operator-side password handling is otherwise safe: the password is bcrypt-hashed in Go and delivered via `secretKeyRef`, and every operator-authored shell reference to it is quoted.

Tests added:
- `GenerateSecurePassword` satisfies the password policy, avoids shell-special characters, and returns unique values
- `EnsureAdminCredentialsSecret` and `EnsureDashboardsCredentialsSecret` produce policy-compliant passwords (these fail against the previous `rand.Text()` implementation)
- reverted the `set -f` expectations in the builder tests

### Issues Resolved
Fixes #1415
Relates to #955 (prevents the glob-mangling failure mode for operator-generated passwords)

Supersedes #1481

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented (n/a — bug fix, no API change)
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart — n/a
- [ ] Changes to CRDs documented — n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
