### PR TITLE
fix: honor deprecated transport.adminDn as fallback for admin_dn

### DIFF
--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for OpenSearch Cluster
 type: application
 
 ## The opensearch-cluster Helm Chart version
-version: 3.3.3
+version: 3.3.4
 
 ## The operator version
 appVersion: 2.8.0

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -127,4 +127,4 @@ The following table lists the configurable parameters of the Helm chart.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Opensearch-cluster Helm Chart version: `3.3.3`
+Opensearch-cluster Helm Chart version: `3.3.4`

--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -62,6 +62,9 @@ spec:
         {{- with .tls.transport.nodesDn }}
         nodesDn: {{ . | toYaml | nindent 10 }}
         {{- end }}
+        {{- with .tls.transport.adminDn }}
+        adminDn: {{ . | toYaml | nindent 10 }}
+        {{- end }}
         {{- with .tls.transport.secret }}
         secret: {{ . | toYaml | nindent 10 }}
         {{- end }}

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -334,7 +334,7 @@ spec:
         name: my-first-cluster-admin-cert # The secret must have keys tls.crt and tls.key
 ```
 
-Make sure the DN of the certificate is set in the `adminDn` field.
+Make sure the DN of the certificate is listed under `security.tls.http.adminDn` (OpenSearch 2.0.0+). Clusters created with operator 2.x may still have the value under the deprecated `security.tls.transport.adminDn`; the operator honors that as a fallback.
 
 ### Adding plugins
 
@@ -1528,7 +1528,7 @@ Similarly, for OpenSearch Dashboards, if you don't provide `dashboards.opensearc
 
 You must also configure SSL/TLS HTTP. You can either let the operator generate all needed certificates or supply them yourself. If you use your own certificates you must also provide an admin certificate that the operator can use to apply the securityconfig.
 
-If you provided your own certificate for SSL/TLS HTTP, then you must also provide an admin client certificate (as a Kubernetes TLS secret with fields `ca.crt`, `tls.key` and `tls.crt`) as `adminSecret.name`. The DN of the certificate must be listed under `security.tls.http.adminDn`. Be advised that the `adminDn` must be defined in a way that the admin certficate cannot be used or recognized as a node certficiate, otherwise OpenSearch will reject any authentication request using the admin certificate.
+If you provided your own certificate for SSL/TLS HTTP, then you must also provide an admin client certificate (as a Kubernetes TLS secret with fields `ca.crt`, `tls.key` and `tls.crt`) as `adminSecret.name`. The DN of the certificate must be listed under `security.tls.http.adminDn`. For clusters migrated from operator 2.x, the deprecated `security.tls.transport.adminDn` is still honored when `http.adminDn` is empty. Be advised that the `adminDn` must be defined in a way that the admin certficate cannot be used or recognized as a node certficiate, otherwise OpenSearch will reject any authentication request using the admin certificate.
 
 To apply the securityconfig to the OpenSearch cluster, the Operator uses a separate Kubernetes job (named `<cluster-name>-securityconfig-update`). This job is run during the initial provisioning of the cluster. The Operator also monitors the secret with the securityconfig for any changes and then reruns the update job to apply the new config. Note that the Operator only checks for changes in certain intervals, so it might take a minute or two for the changes to be applied. If the changes are not applied after a few minutes, please use 'kubectl' to check the logs of the pod of the `<cluster-name>-securityconfig-update` job. If you have an error in your configuration it will be reported there.
 

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchclusters.yaml
@@ -4819,6 +4819,37 @@ spec:
                             type: string
                         type: object
                     type: object
+                  nodeAttributes:
+                    description: |-
+                      NodeAttributes derives OpenSearch node attributes (node.attr.*) from
+                      Kubernetes node labels at runtime. For each entry the operator injects an
+                      init container that reads the label off the node hosting the pod and
+                      exposes its value to OpenSearch, enabling shard allocation awareness
+                      (e.g. zone or rack awareness) without splitting topology into separate
+                      node pools. The pods' ServiceAccount must be allowed to "get" nodes.
+                    items:
+                      description: |-
+                        NodeAttribute maps a Kubernetes node label onto an OpenSearch node attribute
+                        so that shard allocation awareness can follow the cluster's physical topology.
+                      properties:
+                        name:
+                          description: |-
+                            Name is the OpenSearch node attribute, i.e. the suffix after "node.attr.".
+                            For zone awareness configured with
+                            cluster.routing.allocation.awareness.attributes: zone this is "zone",
+                            yielding the node.attr.zone setting.
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$
+                          type: string
+                        nodeLabel:
+                          description: |-
+                            NodeLabel is the Kubernetes node label whose value is copied into the
+                            attribute, e.g. "topology.kubernetes.io/zone".
+                          type: string
+                      required:
+                      - name
+                      - nodeLabel
+                      type: object
+                    type: array
                   opensearchHome:
                     description: OpenSearch installation directory inside the container.
                       Defaults to /usr/share/opensearch if not set.

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -216,7 +216,11 @@ func (r *TLSReconciler) handleAdminCertificate() (*ctrl.Result, error) {
 	} else {
 		adminDn := r.configuredAdminDn()
 		if len(adminDn) == 0 {
-			r.logger.Info("An admin cert secret is configured but no adminDn is set; securityadmin.sh will not be able to authenticate. Set security.tls.http.adminDn to the DN of the admin certificate.")
+			// Do not render plugins.security.authcz.admin_dn: [""] ΓÇö that makes
+			// securityadmin.sh fail with "is not an admin user". Leave the key
+			// unset so additionalConfig can still supply it.
+			r.logger.Error(nil, "An admin cert secret is configured but no adminDn is set; securityadmin.sh will not be able to authenticate. Set security.tls.http.adminDn to the DN of the admin certificate.")
+			return res, nil
 		}
 		certDN = strings.Join(adminDn, "\",\"")
 	}

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -199,50 +199,52 @@ func (r *TLSReconciler) handleAdminCertificate() (*ctrl.Result, error) {
 
 	var res *ctrl.Result
 	var certDN string
-	var shouldGenerate bool
 
-	if r.instance.Spec.Security.Config != nil && r.instance.Spec.Security.Config.AdminSecret.Name != "" {
-		shouldGenerate = false
-	} else {
-		shouldGenerate = true
-	}
+	shouldGenerate := r.instance.Spec.Security.Config == nil || r.instance.Spec.Security.Config.AdminSecret.Name == ""
 
-	if helpers.SecurityChangeVersion(r.instance) {
-		tlsConfig := r.instance.Spec.Security.Tls.Http
-		if shouldGenerate {
-			ca, err := r.getReferencedCaCertOrDefault(r.adminCAConfig())
-			if err != nil {
-				return nil, err
-			}
-
-			res, err = r.createAdminSecret(ca)
-			if err != nil {
-				return nil, err
-			}
-			certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
-		} else {
-			certDN = strings.Join(tlsConfig.AdminDn, "\",\"")
+	if shouldGenerate {
+		ca, err := r.getReferencedCaCertOrDefault(r.adminCAConfig())
+		if err != nil {
+			return nil, err
 		}
-	} else {
-		tlsConfig := r.instance.Spec.Security.Tls.Transport
-		if shouldGenerate {
-			ca, err := r.getReferencedCaCertOrDefault(r.adminCAConfig())
-			if err != nil {
-				return nil, err
-			}
 
-			res, err = r.createAdminSecret(ca)
-			if err != nil {
-				return nil, err
-			}
-			certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
-		} else {
-			certDN = strings.Join(tlsConfig.AdminDn, "\",\"") //nolint:staticcheck
+		res, err = r.createAdminSecret(ca)
+		if err != nil {
+			return nil, err
 		}
+		certDN = fmt.Sprintf("CN=admin,OU=%s", clusterName)
+	} else {
+		adminDn := r.configuredAdminDn()
+		if len(adminDn) == 0 {
+			r.logger.Info("An admin cert secret is configured but no adminDn is set; securityadmin.sh will not be able to authenticate. Set security.tls.http.adminDn to the DN of the admin certificate.")
+		}
+		certDN = strings.Join(adminDn, "\",\"")
 	}
 
 	r.reconcilerContext.AddConfig("plugins.security.authcz.admin_dn", fmt.Sprintf("[\"%s\"]", certDN))
 	return res, nil
+}
+
+// configuredAdminDn returns the admin DNs configured in the spec.
+// OpenSearch >= 2.0.0 reads security.tls.http.adminDn; the deprecated
+// security.tls.transport.adminDn is honored as a fallback so clusters created
+// before the field moved (operator <= 2.x) keep working after an upgrade.
+func (r *TLSReconciler) configuredAdminDn() []string {
+	tlsConfig := r.instance.Spec.Security.Tls
+	if helpers.SecurityChangeVersion(r.instance) {
+		if tlsConfig.Http != nil && len(tlsConfig.Http.AdminDn) > 0 {
+			return tlsConfig.Http.AdminDn
+		}
+		if tlsConfig.Transport != nil && len(tlsConfig.Transport.AdminDn) > 0 { //nolint:staticcheck
+			r.logger.Info("security.tls.http.adminDn is not set, falling back to the deprecated security.tls.transport.adminDn")
+			return tlsConfig.Transport.AdminDn //nolint:staticcheck
+		}
+		return nil
+	}
+	if tlsConfig.Transport != nil {
+		return tlsConfig.Transport.AdminDn //nolint:staticcheck
+	}
+	return nil
 }
 
 func (r *TLSReconciler) adminCAConfig() corev1.LocalObjectReference {

--- a/opensearch-operator/pkg/reconcilers/tls_test.go
+++ b/opensearch-operator/pkg/reconcilers/tls_test.go
@@ -1065,5 +1065,17 @@ var _ = Describe("TLS Controller", func() {
 			Expect(exists).To(BeTrue())
 			Expect(value).To(Equal("[\"CN=newadmin\"]"))
 		})
+
+		It("Should not render an empty admin_dn when neither field is set", func() {
+			spec := makeSpec("tls-admindn-empty", nil, nil)
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.authcz.admin_dn"]
+			Expect(exists).To(BeFalse())
+			Expect(value).ToNot(Equal("[\"\"]"))
+		})
 	})
 })

--- a/opensearch-operator/pkg/reconcilers/tls_test.go
+++ b/opensearch-operator/pkg/reconcilers/tls_test.go
@@ -994,4 +994,76 @@ var _ = Describe("TLS Controller", func() {
 			))
 		})
 	})
+
+	Context("When Reconciling with a provided admin cert secret", func() {
+		makeSpec := func(clusterName string, httpAdminDn, transportAdminDn []string) opensearchv1.OpenSearchCluster {
+			return opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{Version: "2.8.0"},
+					Security: &opensearchv1.Security{
+						Config: &opensearchv1.SecurityConfig{
+							AdminSecret: corev1.LocalObjectReference{Name: "my-admin-cert"},
+						},
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{
+								Generate: false,
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									Secret:   corev1.LocalObjectReference{Name: "cert-transport"},
+									CaSecret: corev1.LocalObjectReference{Name: "casecret-transport"},
+								},
+								NodesDn: []string{"CN=mycn"},
+								AdminDn: transportAdminDn,
+							},
+							Http: &opensearchv1.TlsConfigHttp{
+								Generate: false,
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									Secret:   corev1.LocalObjectReference{Name: "cert-http"},
+									CaSecret: corev1.LocalObjectReference{Name: "casecret-http"},
+								},
+								AdminDn: httpAdminDn,
+							},
+						},
+					},
+				},
+			}
+		}
+
+		It("Should use http.adminDn when set", func() {
+			spec := makeSpec("tls-admindn-http", []string{"CN=admin1", "CN=admin2"}, nil)
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.authcz.admin_dn"]
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal("[\"CN=admin1\",\"CN=admin2\"]"))
+		})
+
+		It("Should fall back to the deprecated transport.adminDn when http.adminDn is not set", func() {
+			// Clusters migrated from operator 2.x only carry adminDn under tls.transport
+			spec := makeSpec("tls-admindn-migrated", nil, []string{"CN=admin"})
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.authcz.admin_dn"]
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal("[\"CN=admin\"]"))
+		})
+
+		It("Should prefer http.adminDn over transport.adminDn when both are set", func() {
+			spec := makeSpec("tls-admindn-both", []string{"CN=newadmin"}, []string{"CN=oldadmin"})
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.authcz.admin_dn"]
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal("[\"CN=newadmin\"]"))
+		})
+	})
 })


### PR DESCRIPTION
### Description

Operator 2.x only had `spec.security.tls.transport.adminDn` — the `http` TLS config had no such field, and `handleAdminCertificate` read the transport value. In 3.0.0-alpha the field moved to `security.tls.http.adminDn` for OpenSearch >= 2.0.0, and the migration controller copies old CRs verbatim, so every cluster migrated from a 2.x operator carries `adminDn` under `tls.transport` only. The TLS reconciler ignored it and rendered:

```
plugins.security.authcz.admin_dn: [""]
```

which breaks the securityconfig update job — securityadmin.sh connects with the provided admin cert, but its DN is not registered as an admin_dn:

```
Connected as "CN=admin"
ERR: "CN=admin" is not an admin user
```

This PR makes the reconciler read `http.adminDn` first and fall back to the deprecated `transport.adminDn` when it is empty, so pre-3.0 CRs keep working after an upgrade — matching the field's deprecation notice (deprecated, not removed). When neither is set while an admin cert secret is provided, a warning is logged instead of silently rendering a broken config. The two identical generate branches in `handleAdminCertificate` were also collapsed into one, since they only differed in which `adminDn` field they read.

Note for reviewers: guessing a fallback DN such as `CN=admin,OU=<cluster>` (the approach in #1479) does not work here — this code path only runs when the user provides their *own* admin cert via `security.config.adminSecret`, so the operator cannot know the cert's subject, and a fabricated DN still fails securityadmin.sh. The correct value for migrated clusters is the one already present in `transport.adminDn`.

### Issues Resolved

Closes #1475

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
