### PR TITLE
fix: generate release notes and mark prereleases in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
       - 'v*'
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     environment:
       name: k8s-operator
@@ -53,12 +55,18 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        id: create_release
-        with:
-          draft: true
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ github.ref }}
-          name: ${{ github.ref }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Generate notes against the previous operator (v*) tag explicitly:
+          # GitHub's default baseline is the latest published release, which is
+          # usually an interleaved helm chart release with an unrelated diff range.
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -vx "$GITHUB_REF_NAME" | head -1)
+          EXTRA_ARGS=""
+          [ -n "$PREV_TAG" ] && EXTRA_ARGS="--notes-start-tag $PREV_TAG"
+          case "$GITHUB_REF_NAME" in *-*) EXTRA_ARGS="$EXTRA_ARGS --prerelease";; esac
+          gh release create "$GITHUB_REF_NAME" \
+            --draft $EXTRA_ARGS \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes
 


### PR DESCRIPTION
### Description
Fixes the release workflow so GitHub releases created from `v*` tags get a proper changelog and correct latest/pre-release marking:

- **Auto-generated release notes**: the draft release now gets GitHub's generated notes (merged-PR list + Full Changelog link). The previous `v*` tag is passed explicitly via `--notes-start-tag`, because GitHub's automatic baseline detection picks the most recent published release — which in this repo is usually an interleaved helm chart release (`opensearch-cluster-x.y.z` / `opensearch-operator-x.y.z`), producing a wrong diff range.
- **Pre-release marking**: tags containing a hyphen (e.g. `v3.0.0-alpha`) are created with `--prerelease`, so pre-releases can no longer take the "Latest" badge from the newest stable release (which is how `v3.0.0-alpha` ended up displayed as the repo's latest release).
- Replaced the third-party `softprops/action-gh-release` action with the runner-native `gh` CLI — one less pinned dependency, and it supports `--notes-start-tag` which the action does not.

The release is still created as a **draft**, preserving the current flow of publishing manually after the Jenkins-built images are promoted.

Verified end-to-end on a fork: pushing a `v3.0.0-test1` tag produced a draft release marked as pre-release, titled correctly, with notes generated against the `v2.8.0` baseline.

Complementing one-time cleanups already applied to this repo's releases: `v3.0.0-alpha` marked as pre-release, `v2.8.0` set as latest.

### Issues Resolved
Resolves #1425

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
