### PR TITLE
fix: drop stale 'set -f' from node-attributes entrypoint test expectations

### DIFF
--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1790,7 +1790,7 @@ var _ = Describe("Builders", func() {
 			clusterObject := clusterWithAttributes()
 			sts := NewSTSForNodePool("foobar", &clusterObject, opensearchv1.NodePool{}, "foobar", nil, nil)
 			command := sts.Spec.Template.Spec.Containers[0].Command
-			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && set -f && ./opensearch-docker-entrypoint.sh"))
+			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && ./opensearch-docker-entrypoint.sh"))
 		})
 
 		It("should wire the same mechanism into the bootstrap pod", func() {
@@ -1800,7 +1800,7 @@ var _ = Describe("Builders", func() {
 			Expect(findContainer(pod.Spec.InitContainers, nodeAttributesVolumeName)).NotTo(BeNil())
 			Expect(pod.Spec.Volumes).To(ContainElement(nodeAttributesVolume()))
 			command := pod.Spec.Containers[0].Command
-			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && set -f && ./opensearch-docker-entrypoint.sh"))
+			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && ./opensearch-docker-entrypoint.sh"))
 		})
 
 		It("should bind the managed ServiceAccount to the shared node-attributes ClusterRole", func() {


### PR DESCRIPTION
### Description
Unit tests are currently failing on `main` and on every open PR (see e.g. #1489, #1480, #1490):

```
[FAIL] Builders when configuring node attributes from node labels [It] should source the attributes file before the OpenSearch entrypoint
[FAIL] Builders when configuring node attributes from node labels [It] should wire the same mechanism into the bootstrap pod
```

This is a semantic merge conflict: #1463 (node-label based shard allocation awareness) was written while `BuildMainCommand` still prefixed the entrypoint with `set -f`, and its tests assert that prefix in the expected command string. 93c4356 then removed the `set -f` prefix, so the code no longer emits it while the two node-attributes tests still expect it.

This updates the two expectations to match the actual generated command. Verified locally: full `go test ./...` passes with the CI envtest version (1.27).

### Issues Resolved
Unblocks CI for all open PRs.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
