### PR TITLE
fix: skip non-YAML files when validating securityconfig secret

### DIFF
--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -291,9 +291,14 @@ func BuildCmdArg(instance *opensearchv1.OpenSearchCluster, secret *corev1.Secret
 		filePath := fmt.Sprintf("%s/%s", securityconfigPath, k)
 		fileType, ok := ymlToFileType[k]
 		if !ok {
-			// If the yml file is invalid, do not return the error
-			// Just log it and build the commands for valid yml files
-			log.Error(fmt.Errorf("invalid yml file %s in securityconfig secret", k), fmt.Sprintf("skipping %s", k))
+			if strings.HasSuffix(k, ".yml") || strings.HasSuffix(k, ".yaml") {
+				// If the yml file is invalid, do not return the error
+				// Just log it and build the commands for valid yml files
+				log.Error(fmt.Errorf("invalid yml file %s in securityconfig secret", k), fmt.Sprintf("skipping %s", k))
+			} else {
+				// Non-yml files (e.g. log4j2.properties) are not applied by securityadmin, skip them silently
+				log.Info(fmt.Sprintf("skipping non-yml file %s in securityconfig secret", k))
+			}
 			continue
 		}
 		// Necessary as kubectl apply for stringData doesn't completely remove the field from the secret

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -150,6 +150,8 @@ config:
 					"internal_users.yml": internalUsersYAML("", ""),
 					// Invalid yml in secret should not throw an error
 					"invalid.yml": []byte("foo"),
+					// Non-yml files in secret should be skipped without an error
+					"log4j2.properties": []byte("rootLogger.level = info"),
 					// Empty contents for a yml should be ignored
 					"action_groups.yml": []byte(actionGroupsYAML),
 				},
@@ -235,6 +237,8 @@ config:
 			Expect(actualCmdArg).To(ContainSubstring("action_groups.yml"))
 			// Verify that invalid files were not included in the command
 			Expect(actualCmdArg).ToNot(ContainSubstring("invalid.yml"))
+			// Verify that non-yml files were not included in the command
+			Expect(actualCmdArg).ToNot(ContainSubstring("log4j2.properties"))
 			// Verify that files not present in the secret are not included
 			Expect(actualCmdArg).ToNot(ContainSubstring("audit.yml"))
 		})


### PR DESCRIPTION
### Description
`BuildCmdArg` logs an error for every key in the securityconfig secret that is not one of the known security plugin yml files. Secrets commonly carry non-YAML files as well (e.g. `log4j2.properties` when using the opensearch-cluster helm chart), which resulted in a misleading error being logged on every reconcile:

```
"error":"invalid yml file log4j2.properties in securityconfig secret"
```

These files were already (correctly) skipped when building the securityadmin command; only the logging was wrong. This change logs the error only for unrecognized `.yml`/`.yaml` files and skips other files with an info-level message instead.

### Issues Resolved
Fixes #983

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented (n/a — logging-only change)
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart (n/a)
- [ ] Changes to CRDs documented (n/a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
