### PR TITLE
fix: don't block reconciliation when monitoring is enabled but ServiceMonitor CRD is missing

### DIFF
--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
@@ -91,6 +93,47 @@ func (r *ClusterReconciler) canManageClusterRoleBindings() bool {
 	return !r.skipClusterRoleBindingManagement
 }
 
+// reconcileServiceMonitor creates or removes the prometheus-operator
+// ServiceMonitor. A missing ServiceMonitor CRD is tolerated in both
+// directions so that it never blocks the rest of the reconcile chain
+// (e.g. the dashboards deployment, see #746).
+func (r *ClusterReconciler) reconcileServiceMonitor(result *reconciler.CombinedResult) {
+	serviceMonitor := builders.NewServiceMonitor(r.instance)
+	if r.instance.Spec.General.Monitoring.Enable {
+		result.CombineErr(ctrl.SetControllerReference(r.instance, serviceMonitor, r.client.Scheme()))
+		res, err := r.client.ReconcileResource(serviceMonitor, reconciler.StatePresent)
+		if err != nil && isServiceMonitorCRDMissing(err) {
+			r.logger.Info("ServiceMonitor CRD not found, skipping ServiceMonitor creation. Install the prometheus-operator CRDs to enable monitoring")
+			if r.recorder != nil {
+				r.recorder.Event(r.instance, "Warning", "Monitoring", "ServiceMonitor CRD not installed, skipping ServiceMonitor creation")
+			}
+			return
+		}
+		result.Combine(res, err)
+	} else {
+		res, err := r.client.ReconcileResource(serviceMonitor, reconciler.StateAbsent)
+		if err != nil && isServiceMonitorCRDMissing(err) {
+			r.logger.Info("ServiceMonitor crd not found, skipping deletion")
+			return
+		}
+		result.Combine(res, err)
+	}
+}
+
+// isServiceMonitorCRDMissing reports whether err indicates that the
+// prometheus-operator ServiceMonitor CRD is not installed in the cluster.
+func isServiceMonitorCRDMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	var noMatch *apimeta.NoKindMatchError
+	if errors.As(err, &noMatch) {
+		return true
+	}
+	return strings.Contains(err.Error(), "no matches for kind \"ServiceMonitor\"") ||
+		strings.Contains(err.Error(), "unable to retrieve the complete list of server APIs: monitoring.coreos.com/v1")
+}
+
 func (r *ClusterReconciler) Reconcile() (ctrl.Result, error) {
 	// lg := log.FromContext(r.ctx)
 	result := reconciler.CombinedResult{}
@@ -99,25 +142,7 @@ func (r *ClusterReconciler) Reconcile() (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	if r.instance.Spec.General.Monitoring.Enable {
-		serviceMonitor := builders.NewServiceMonitor(r.instance)
-		result.CombineErr(ctrl.SetControllerReference(r.instance, serviceMonitor, r.client.Scheme()))
-		result.Combine(r.client.ReconcileResource(serviceMonitor, reconciler.StatePresent))
-
-	} else {
-		serviceMonitor := builders.NewServiceMonitor(r.instance)
-		res, err := r.client.ReconcileResource(serviceMonitor, reconciler.StateAbsent)
-		if err != nil {
-			if strings.Contains(err.Error(), "unable to retrieve the complete list of server APIs: monitoring.coreos.com/v1") {
-				r.logger.Info("ServiceMonitor crd not found, skipping deletion")
-			} else {
-				result.Combine(res, err)
-			}
-		} else {
-			result.Combine(res, err)
-		}
-
-	}
+	r.reconcileServiceMonitor(&result)
 	clusterService := builders.NewServiceForCR(r.instance)
 	result.CombineErr(ctrl.SetControllerReference(r.instance, clusterService, r.client.Scheme()))
 	result.Combine(r.client.ReconcileResource(clusterService, reconciler.StatePresent))

--- a/opensearch-operator/pkg/reconcilers/cluster_test.go
+++ b/opensearch-operator/pkg/reconcilers/cluster_test.go
@@ -1,14 +1,18 @@
 package reconcilers
 
 import (
+	"errors"
 	"time"
 
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconciler"
 	"github.com/stretchr/testify/mock"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -189,6 +193,64 @@ var _ = Describe("Bootstrap Pod Reconciliation Fix", func() {
 			)
 			Expect(util.PodSpecChanged(modifiedPod, originalPod)).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("ServiceMonitor reconciliation", func() {
+	newMonitoringInstance := func() *opensearchv1.OpenSearchCluster {
+		return &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "monitoring-test",
+				Namespace: "test-namespace",
+			},
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{
+					Monitoring: opensearchv1.MonitoringConfig{Enable: true},
+				},
+			},
+		}
+	}
+
+	It("should not fail the reconcile when monitoring is enabled but the ServiceMonitor CRD is missing", func() {
+		mockClient := k8s.NewMockK8sClient(GinkgoT())
+		instance := newMonitoringInstance()
+		underTest := &ClusterReconciler{
+			client:   mockClient,
+			instance: instance,
+			recorder: record.NewFakeRecorder(1),
+		}
+
+		mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+		mockClient.EXPECT().
+			ReconcileResource(mock.AnythingOfType("*v1.ServiceMonitor"), reconciler.StatePresent).
+			Return(nil, &apimeta.NoKindMatchError{
+				GroupKind: schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+			})
+
+		result := reconciler.CombinedResult{}
+		underTest.reconcileServiceMonitor(&result)
+
+		Expect(result.Err).NotTo(HaveOccurred())
+	})
+
+	It("should surface other ServiceMonitor errors", func() {
+		mockClient := k8s.NewMockK8sClient(GinkgoT())
+		instance := newMonitoringInstance()
+		underTest := &ClusterReconciler{
+			client:   mockClient,
+			instance: instance,
+			recorder: record.NewFakeRecorder(1),
+		}
+
+		mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+		mockClient.EXPECT().
+			ReconcileResource(mock.AnythingOfType("*v1.ServiceMonitor"), reconciler.StatePresent).
+			Return(nil, errors.New("some other failure"))
+
+		result := reconciler.CombinedResult{}
+		underTest.reconcileServiceMonitor(&result)
+
+		Expect(result.Err).To(MatchError(ContainSubstring("some other failure")))
 	})
 })
 


### PR DESCRIPTION
### Description
When `general.monitoring.enable: true` is set but the prometheus-operator CRDs are not installed in the cluster, creating the `ServiceMonitor` fails and the cluster reconciler returns an error. This aborts the reconcile chain before the dashboards reconciler ever runs, so no dashboards pods are created (and later reconcilers are blocked too).

This change tolerates a missing `ServiceMonitor` CRD on the create path the same way the delete path already does: it logs a warning and emits a `Warning` event on the OpenSearchCluster resource instead of failing the reconcile, so the rest of the chain (dashboards, upgrade, restart, snapshot repository) keeps running. Any other ServiceMonitor error still surfaces as before.

### Issues Resolved
Fixes #746

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
