### PR TITLE
fix: address unit test failures and bump go 1.25.13 to address stdlib CVEs

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -4,7 +4,7 @@ This page provides information how to develop changes for the operator code. Ple
 
 ## Needed environment and tools
 
-The operator is developed in Go, as such you need a current Go toolkit (for Linux most distributions provide packages, otherwise get it from the [go homepage](https://go.dev/)). Please use version 1.25.12 as this version is used by the CI pipelines. You also need an editor/IDE, ideally with Go support. We recommend either [VS Code](https://code.visualstudio.com/) with the official Go extension or [GoLand](https://www.jetbrains.com/go/).
+The operator is developed in Go, as such you need a current Go toolkit (for Linux most distributions provide packages, otherwise get it from the [go homepage](https://go.dev/)). Please use version 1.25.13 as this version is used by the CI pipelines. You also need an editor/IDE, ideally with Go support. We recommend either [VS Code](https://code.visualstudio.com/) with the official Go extension or [GoLand](https://www.jetbrains.com/go/).
 
 Additional tools you will need:
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.12
+go 1.25.13
 
 use (
 	./opensearch-operator

--- a/opensearch-operator/Dockerfile
+++ b/opensearch-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.12 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.13 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/opensearch-operator/config/rbac/role.yaml
+++ b/opensearch-operator/config/rbac/role.yaml
@@ -156,9 +156,9 @@ rules:
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
   resourceNames:
   - opensearch-node-attributes
+  resources:
+  - clusterroles
   verbs:
   - bind

--- a/opensearch-operator/functionaltests/go.mod
+++ b/opensearch-operator/functionaltests/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-k8s-operator/functionaltests
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/opensearch-operator/go.mod
+++ b/opensearch-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator
 
-go 1.25.12
+go 1.25.13
 
 require (
 	emperror.dev/errors v0.8.1

--- a/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s/mock_K8sClient.go
+++ b/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s/mock_K8sClient.go
@@ -5,7 +5,6 @@ package k8s
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,6 +13,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	opensearch_orgv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -376,6 +377,52 @@ func (_c *MockK8sClient_CreateService_Call) RunAndReturn(run func(*v1.Service) (
 	return _c
 }
 
+// DeleteClusterRoleBinding provides a mock function with given fields: name
+func (_m *MockK8sClient) DeleteClusterRoleBinding(name string) error {
+	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteClusterRoleBinding")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockK8sClient_DeleteClusterRoleBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteClusterRoleBinding'
+type MockK8sClient_DeleteClusterRoleBinding_Call struct {
+	*mock.Call
+}
+
+// DeleteClusterRoleBinding is a helper method to define mock.On call
+//   - name string
+func (_e *MockK8sClient_Expecter) DeleteClusterRoleBinding(name interface{}) *MockK8sClient_DeleteClusterRoleBinding_Call {
+	return &MockK8sClient_DeleteClusterRoleBinding_Call{Call: _e.mock.On("DeleteClusterRoleBinding", name)}
+}
+
+func (_c *MockK8sClient_DeleteClusterRoleBinding_Call) Run(run func(name string)) *MockK8sClient_DeleteClusterRoleBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockK8sClient_DeleteClusterRoleBinding_Call) Return(_a0 error) *MockK8sClient_DeleteClusterRoleBinding_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockK8sClient_DeleteClusterRoleBinding_Call) RunAndReturn(run func(string) error) *MockK8sClient_DeleteClusterRoleBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteDeployment provides a mock function with given fields: deployment, orphan
 func (_m *MockK8sClient) DeleteDeployment(deployment *appsv1.Deployment, orphan bool) error {
 	ret := _m.Called(deployment, orphan)
@@ -558,6 +605,52 @@ func (_c *MockK8sClient_DeleteStatefulSet_Call) Return(_a0 error) *MockK8sClient
 }
 
 func (_c *MockK8sClient_DeleteStatefulSet_Call) RunAndReturn(run func(*appsv1.StatefulSet, bool) error) *MockK8sClient_DeleteStatefulSet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// EnsureClusterRoleBinding provides a mock function with given fields: crb
+func (_m *MockK8sClient) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) error {
+	ret := _m.Called(crb)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnsureClusterRoleBinding")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*rbacv1.ClusterRoleBinding) error); ok {
+		r0 = rf(crb)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockK8sClient_EnsureClusterRoleBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnsureClusterRoleBinding'
+type MockK8sClient_EnsureClusterRoleBinding_Call struct {
+	*mock.Call
+}
+
+// EnsureClusterRoleBinding is a helper method to define mock.On call
+//   - crb *rbacv1.ClusterRoleBinding
+func (_e *MockK8sClient_Expecter) EnsureClusterRoleBinding(crb interface{}) *MockK8sClient_EnsureClusterRoleBinding_Call {
+	return &MockK8sClient_EnsureClusterRoleBinding_Call{Call: _e.mock.On("EnsureClusterRoleBinding", crb)}
+}
+
+func (_c *MockK8sClient_EnsureClusterRoleBinding_Call) Run(run func(crb *rbacv1.ClusterRoleBinding)) *MockK8sClient_EnsureClusterRoleBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*rbacv1.ClusterRoleBinding))
+	})
+	return _c
+}
+
+func (_c *MockK8sClient_EnsureClusterRoleBinding_Call) Return(_a0 error) *MockK8sClient_EnsureClusterRoleBinding_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockK8sClient_EnsureClusterRoleBinding_Call) RunAndReturn(run func(*rbacv1.ClusterRoleBinding) error) *MockK8sClient_EnsureClusterRoleBinding_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1640,18 +1733,6 @@ func (_c *MockK8sClient_WaitForPodDeletion_Call) Return(_a0 error) *MockK8sClien
 func (_c *MockK8sClient_WaitForPodDeletion_Call) RunAndReturn(run func(string, string) error) *MockK8sClient_WaitForPodDeletion_Call {
 	_c.Call.Return(run)
 	return _c
-}
-
-// EnsureClusterRoleBinding provides a mock function for EnsureClusterRoleBinding.
-func (_m *MockK8sClient) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) error {
-	ret := _m.Called(crb)
-	return ret.Error(0)
-}
-
-// DeleteClusterRoleBinding provides a mock function for DeleteClusterRoleBinding.
-func (_m *MockK8sClient) DeleteClusterRoleBinding(name string) error {
-	ret := _m.Called(name)
-	return ret.Error(0)
 }
 
 // NewMockK8sClient creates a new instance of MockK8sClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1790,7 +1790,7 @@ var _ = Describe("Builders", func() {
 			clusterObject := clusterWithAttributes()
 			sts := NewSTSForNodePool("foobar", &clusterObject, opensearchv1.NodePool{}, "foobar", nil, nil)
 			command := sts.Spec.Template.Spec.Containers[0].Command
-			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && set -f && ./opensearch-docker-entrypoint.sh"))
+			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && ./opensearch-docker-entrypoint.sh"))
 		})
 
 		It("should wire the same mechanism into the bootstrap pod", func() {
@@ -1800,7 +1800,7 @@ var _ = Describe("Builders", func() {
 			Expect(findContainer(pod.Spec.InitContainers, nodeAttributesVolumeName)).NotTo(BeNil())
 			Expect(pod.Spec.Volumes).To(ContainElement(nodeAttributesVolume()))
 			command := pod.Spec.Containers[0].Command
-			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && set -f && ./opensearch-docker-entrypoint.sh"))
+			Expect(command[len(command)-1]).To(ContainSubstring(". /usr/share/opensearch/config/node-attributes/attributes.env && ./opensearch-docker-entrypoint.sh"))
 		})
 
 		It("should bind the managed ServiceAccount to the shared node-attributes ClusterRole", func() {


### PR DESCRIPTION
### Description
rebuild the operator with Go 1.25.13 to fix CVE-2026-39821, CVE-2026-33818, CVE-2026-56853, CVE-2026-56859, and CVE-2026-56862

In addition, it fixes unit test failures introduced by this https://github.com/opensearch-project/opensearch-k8s-operator/commit/71450f548f1f97a73ffc66aaae61605c096d6fe5

@synhershko lets merge this asap
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
