### PR TITLE
fix: fail closed on scale-down drain checks so nodes still holding data are not removed

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/errors.go
+++ b/opensearch-operator/opensearch-gateway/services/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrClusterHealthOperation            = errors.New("cluster health failed")
 	ErrClusterSettingsOperation          = errors.New("cluster settings failed")
 	ErrCatIndicesOperation               = errors.New("cat indices failed")
+	ErrCatShardsOperation                = errors.New("cat shards failed")
 )
 
 func ErrClusterAllocationExplainGetFailed(resp string) error {
@@ -30,4 +31,8 @@ func ErrClusterSettingsPutFailed(resp string) error {
 
 func ErrCatIndicesFailed(resp string) error {
 	return fmt.Errorf("%w: %s", ErrCatIndicesOperation, resp)
+}
+
+func ErrCatShardsFailed(resp string) error {
+	return fmt.Errorf("%w: %s", ErrCatShardsOperation, resp)
 }

--- a/opensearch-operator/opensearch-gateway/services/os_client.go
+++ b/opensearch-operator/opensearch-gateway/services/os_client.go
@@ -207,6 +207,9 @@ func (client *OsClusterClient) CatShards(headers []string) ([]responses.CatShard
 		return response, err
 	}
 	defer helpers.SafeClose(indicesRes.Body)
+	if indicesRes.IsError() {
+		return response, ErrCatShardsFailed(indicesRes.String())
+	}
 	err = json.NewDecoder(indicesRes.Body).Decode(&response)
 	return response, err
 }
@@ -223,6 +226,9 @@ func (client *OsClusterClient) CatNamedIndicesShards(headers []string, indices [
 		return response, err
 	}
 	defer helpers.SafeClose(indicesRes.Body)
+	if indicesRes.IsError() {
+		return response, ErrCatShardsFailed(indicesRes.String())
+	}
 	err = json.NewDecoder(indicesRes.Body).Decode(&response)
 	return response, err
 }

--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -57,15 +57,24 @@ func extractNodeName(fullNodeName string) string {
 	return trimmed
 }
 
+// shardsOnNodeFromResponse returns shards whose source node matches nodeName.
+// Relocating shards (_cat/shards "source -> ip id target") are counted against
+// the source node via extractNodeName, so a drain cannot treat an in-flight
+// relocation as an empty node.
+func shardsOnNodeFromResponse(response []responses.CatShardsResponse, nodeName string) []responses.CatShardsResponse {
+	var matched []responses.CatShardsResponse
+	for _, shard := range response {
+		if extractNodeName(shard.NodeName) == nodeName {
+			matched = append(matched, shard)
+		}
+	}
+	return matched
+}
+
 // hasShardsOnNodeFromResponse returns true if any shard in the response is on the given node.
 // It uses extractNodeName so that relocation format (source -> ip id target) is handled correctly.
 func hasShardsOnNodeFromResponse(response []responses.CatShardsResponse, nodeName string) bool {
-	for _, shardsData := range response {
-		if extractNodeName(shardsData.NodeName) == nodeName {
-			return true
-		}
-	}
-	return false
+	return len(shardsOnNodeFromResponse(response, nodeName)) > 0
 }
 
 func HasShardsOnNode(service *OsClusterClient, nodeName string) (bool, error) {
@@ -640,22 +649,21 @@ func CheckPodSafeToDelete(service *OsClusterClient, nodeName string) (bool, erro
 		return false, err
 	}
 
-	// Check each shard on the node
+	// Check each shard on the node. Relocating shards must count as still on the
+	// source node; comparing the raw _cat/shards node field misses "source -> ...".
 	nodeShardsCount := 0
 	nodeStuckReplicasCount := 0
 
-	for _, shard := range shards {
-		if shard.NodeName == nodeName {
-			nodeShardsCount += 1
+	for _, shard := range shardsOnNodeFromResponse(shards, nodeName) {
+		nodeShardsCount += 1
 
-			if shard.PrimaryOrReplica == "r" {
-				isStuck, err := DetectShardStuckVersionMismatch(service, shard)
-				if err != nil {
-					return false, err
-				}
-				if isStuck {
-					nodeStuckReplicasCount += 1
-				}
+		if shard.PrimaryOrReplica == "r" {
+			isStuck, err := DetectShardStuckVersionMismatch(service, shard)
+			if err != nil {
+				return false, err
+			}
+			if isStuck {
+				nodeStuckReplicasCount += 1
 			}
 		}
 	}

--- a/opensearch-operator/opensearch-gateway/services/os_data_service_test.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service_test.go
@@ -211,6 +211,31 @@ func TestHasShardsOnNodeFromResponse(t *testing.T) {
 	}
 }
 
+// TestShardsOnNodeFromResponseRelocatingSource is the CheckPodSafeToDelete
+// regression for issue #1447: a shard relocating off the node must still count
+// as present so the pod is not deleted while it is the relocation source.
+func TestShardsOnNodeFromResponseRelocatingSource(t *testing.T) {
+	shards := []responses.CatShardsResponse{
+		{Index: "idx", Shard: "0", PrimaryOrReplica: "p", State: "RELOCATING", NodeName: "opensearch-data-1 -> 172.31.233.51 4kGSHQhmRQ-83pvvBbTYow opensearch-data-8"},
+	}
+
+	onSource := shardsOnNodeFromResponse(shards, "opensearch-data-1")
+	if len(onSource) != 1 {
+		t.Fatalf("relocating shard should count on source node, got %d", len(onSource))
+	}
+
+	onTarget := shardsOnNodeFromResponse(shards, "opensearch-data-8")
+	if len(onTarget) != 0 {
+		t.Fatalf("relocating shard should not count on target node, got %d", len(onTarget))
+	}
+
+	// Raw string equality is what CheckPodSafeToDelete used to do and would
+	// miss this shard entirely, reporting the node as empty.
+	if shards[0].NodeName == "opensearch-data-1" {
+		t.Fatal("test fixture is wrong: raw NodeName should be the relocation string")
+	}
+}
+
 func TestDetermineUnsupportedClusterSettings(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -3,6 +3,7 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/utils/ptr"
@@ -21,7 +22,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const scalerReconcilerName = "scaler"
+const (
+	scalerReconcilerName        = "scaler"
+	drainStartedConditionPrefix = "drainStarted:"
+	drainStalledCondition       = "DrainStalled"
+	// drainStallWarningAfter is how long a scale-down drain may wait with no
+	// observed emptiness before a Warning event and DrainStalled condition are
+	// recorded. The drain itself is not aborted.
+	drainStallWarningAfter = 15 * time.Minute
+)
 
 type ScalerReconciler struct {
 	client            k8s.K8sClient
@@ -220,8 +229,7 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opensearchv1.ComponentS
 	lastReplicaNodeName := helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas)
 
 	// Verify that the node being removed is the same one that was excluded/drained
-	if len(currentStatus.Conditions) > 0 {
-		targetNodeName := currentStatus.Conditions[0]
+	if targetNodeName := scalerTargetNodeName(currentStatus.Conditions); targetNodeName != "" {
 		if lastReplicaNodeName != targetNodeName {
 			lg.Info(fmt.Sprintf("Group: %s, Target node %s does not match last replica %s, resetting to Running", nodePoolGroupName, targetNodeName, lastReplicaNodeName))
 			*currentSts.Spec.Replicas++
@@ -237,6 +245,55 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opensearchv1.ComponentS
 				lg.Error(err, "failed to update status")
 			}
 			return true, fmt.Errorf("target node mismatch during decrease: excluded/drained %s but would remove %s, reset to Running", targetNodeName, lastReplicaNodeName)
+		}
+	}
+
+	var clusterClient *services.OsClusterClient
+	if smartDecrease {
+		var err error
+		clusterClient, err = util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
+		if err != nil {
+			*currentSts.Spec.Replicas++
+			lg.Error(err, "failed to create os client")
+			r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to create os client before removing node %s", lastReplicaNodeName)
+			return true, err
+		}
+
+		// Drained is persisted on the CR; allocation exclusions are only transient
+		// cluster settings. Re-check emptiness before shrinking so a lost exclusion
+		// cannot delete a node that still holds data.
+		nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
+		if err != nil {
+			*currentSts.Spec.Replicas++
+			lg.Error(err, "failed to verify node is empty before scale-down")
+			r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to verify node %s is empty before scale-down", lastReplicaNodeName)
+			return true, err
+		}
+		if nodeNotEmpty {
+			*currentSts.Spec.Replicas++
+			lg.Info(fmt.Sprintf("Group: %s, Node %s still has shards after drain, resetting to Excluded", nodePoolGroupName, lastReplicaNodeName))
+			r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Node %s still has shards after being marked drained; re-excluding and waiting", lastReplicaNodeName)
+			if _, excludeErr := services.AppendExcludeNodeHost(clusterClient, lg, lastReplicaNodeName); excludeErr != nil {
+				lg.Error(excludeErr, fmt.Sprintf("failed to re-apply exclusion for node %s", lastReplicaNodeName))
+			}
+			startedAt, ok := drainStartedAt(currentStatus.Conditions)
+			if !ok {
+				startedAt = time.Now().UTC()
+			}
+			stalled := drainHasStalled(startedAt, time.Now().UTC(), drainStallWarningAfter)
+			componentStatus := opensearchv1.ComponentStatus{
+				Component:   "Scaler",
+				Status:      "Excluded",
+				Description: nodePoolGroupName,
+				Conditions:  scalerDrainConditions(lastReplicaNodeName, startedAt, stalled),
+			}
+			if err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+				instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, instance.Status.ComponentsStatus)
+			}); err != nil {
+				lg.Error(err, "failed to update status")
+				return true, err
+			}
+			return true, nil
 		}
 	}
 
@@ -258,12 +315,6 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opensearchv1.ComponentS
 
 	if !smartDecrease {
 		return false, err
-	}
-	clusterClient, err := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
-	if err != nil {
-		lg.Error(err, "failed to create os client")
-		r.recorder.AnnotatedEventf(r.instance, annotations, "WARN", "failed to remove node exclude", "Group-%s . failed to remove node exclude %s", nodePoolGroupName, lastReplicaNodeName)
-		return true, err
 	}
 
 	success, err := services.RemoveExcludeNodeHost(clusterClient, lg, lastReplicaNodeName)
@@ -298,7 +349,7 @@ func (r *ScalerReconciler) excludeNode(currentStatus opensearchv1.ComponentStatu
 			Component:   "Scaler",
 			Status:      "Excluded",
 			Description: nodePoolGroupName,
-			Conditions:  []string{lastReplicaNodeName},
+			Conditions:  scalerDrainConditions(lastReplicaNodeName, time.Now().UTC(), false),
 		}
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished to Exclude %s/%s", r.instance.Namespace, r.instance.Name)
 		lg.Info(fmt.Sprintf("Group: %s, Excluded node: %s", nodePoolGroupName, lastReplicaNodeName))
@@ -339,8 +390,8 @@ func (r *ScalerReconciler) drainNode(currentStatus opensearchv1.ComponentStatus,
 
 	// Retrieve the target node name from the status conditions set during exclude phase
 	var lastReplicaNodeName string
-	if len(currentStatus.Conditions) > 0 {
-		lastReplicaNodeName = currentStatus.Conditions[0]
+	if target := scalerTargetNodeName(currentStatus.Conditions); target != "" {
+		lastReplicaNodeName = target
 	} else {
 		// Fallback for backwards compatibility
 		lastReplicaNodeName = helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas-1)
@@ -369,9 +420,17 @@ func (r *ScalerReconciler) drainNode(currentStatus opensearchv1.ComponentStatus,
 		return err
 	}
 	nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
+	if err != nil {
+		lg.Error(err, "failed to check shards on node")
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to check shards on node %s; not marking drained", lastReplicaNodeName)
+		return err
+	}
 	if nodeNotEmpty {
 		lg.Info(fmt.Sprintf("Group: %s, Waiting for node %s to drain", nodePoolGroupName, lastReplicaNodeName))
-		return err
+		if _, excludeErr := services.AppendExcludeNodeHost(clusterClient, lg, lastReplicaNodeName); excludeErr != nil {
+			lg.Error(excludeErr, fmt.Sprintf("failed to re-apply exclusion for node %s during drain", lastReplicaNodeName))
+		}
+		return r.recordDrainWait(currentStatus, lastReplicaNodeName, nodePoolGroupName, annotations)
 	}
 
 	componentStatus := opensearchv1.ComponentStatus{
@@ -489,4 +548,95 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	}
 	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished scaling")
 	return result, err
+}
+
+func (r *ScalerReconciler) recordDrainWait(currentStatus opensearchv1.ComponentStatus, nodeName, nodePoolGroupName string, annotations map[string]string) error {
+	lg := log.FromContext(r.ctx)
+	startedAt, ok := drainStartedAt(currentStatus.Conditions)
+	if !ok {
+		startedAt = time.Now().UTC()
+	}
+	stalled := drainHasStalled(startedAt, time.Now().UTC(), drainStallWarningAfter)
+	alreadyStalled := hasDrainStalledCondition(currentStatus.Conditions)
+	if stalled && !alreadyStalled {
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler",
+			"Drain of node %s in group %s has made no progress for %s; check remaining capacity, disk watermarks, or replica settings",
+			nodeName, nodePoolGroupName, drainStallWarningAfter)
+	}
+	newConditions := scalerDrainConditions(nodeName, startedAt, stalled || alreadyStalled)
+	if drainConditionsEqual(currentStatus.Conditions, newConditions) {
+		return nil
+	}
+	componentStatus := opensearchv1.ComponentStatus{
+		Component:   "Scaler",
+		Status:      "Excluded",
+		Description: nodePoolGroupName,
+		Conditions:  newConditions,
+	}
+	err := r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {
+		instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, instance.Status.ComponentsStatus)
+	})
+	if err != nil {
+		lg.Error(err, "failed to update drain wait status")
+		return err
+	}
+	return nil
+}
+
+func scalerTargetNodeName(conditions []string) string {
+	if len(conditions) == 0 {
+		return ""
+	}
+	return conditions[0]
+}
+
+func drainStartedAt(conditions []string) (time.Time, bool) {
+	for _, condition := range conditions {
+		if strings.HasPrefix(condition, drainStartedConditionPrefix) {
+			startedAt, err := time.Parse(time.RFC3339, strings.TrimPrefix(condition, drainStartedConditionPrefix))
+			if err == nil {
+				return startedAt, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func hasDrainStalledCondition(conditions []string) bool {
+	for _, condition := range conditions {
+		if condition == drainStalledCondition {
+			return true
+		}
+	}
+	return false
+}
+
+func scalerDrainConditions(nodeName string, startedAt time.Time, stalled bool) []string {
+	conditions := []string{nodeName}
+	if !startedAt.IsZero() {
+		conditions = append(conditions, drainStartedConditionPrefix+startedAt.UTC().Format(time.RFC3339))
+	}
+	if stalled {
+		conditions = append(conditions, drainStalledCondition)
+	}
+	return conditions
+}
+
+func drainHasStalled(startedAt, now time.Time, threshold time.Duration) bool {
+	if startedAt.IsZero() || threshold <= 0 {
+		return false
+	}
+	return !now.Before(startedAt.Add(threshold))
+}
+
+func drainConditionsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -3,7 +3,10 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
@@ -12,6 +15,7 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconciler"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -29,6 +33,100 @@ func newScalerReconciler(client *k8s.MockK8sClient, spec *opensearchv1.OpenSearc
 		instance:          spec,
 	}
 	return underTest
+}
+
+func mockScalerAdminSecret(mockClient *k8s.MockK8sClient, clusterName, namespace string) {
+	mockClient.On("GetSecret", clusterName+"-admin-password", namespace).Return(corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName + "-admin-password",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("admin"),
+		},
+	}, nil)
+}
+
+func registerOsPingResponders(transport *httpmock.MockTransport, cluster *opensearchv1.OpenSearchCluster) {
+	clusterURL := helpers.ClusterURL(cluster)
+	mainBody := `{"name":"test","cluster_name":"test","version":{"number":"2.11.0"}}`
+	for _, u := range []string{clusterURL, clusterURL + "/"} {
+		transport.RegisterResponder(http.MethodHead, u, httpmock.NewStringResponder(200, "OK"))
+		transport.RegisterResponder(http.MethodGet, u, httpmock.NewStringResponder(200, mainBody))
+	}
+}
+
+func registerClusterSettingsResponders(transport *httpmock.MockTransport) {
+	transport.RegisterResponder(
+		http.MethodGet,
+		`=~.*/_cluster/settings.*`,
+		httpmock.NewStringResponder(200, `{"transient":{},"persistent":{}}`),
+	)
+	transport.RegisterResponder(
+		http.MethodPut,
+		`=~.*/_cluster/settings.*`,
+		httpmock.NewStringResponder(200, `{"transient":{},"persistent":{}}`),
+	)
+}
+
+func registerCatShardsResponder(transport *httpmock.MockTransport, status int, body string) {
+	transport.RegisterResponder(
+		http.MethodGet,
+		`=~.*/_cat/shards.*`,
+		httpmock.NewStringResponder(status, body),
+	)
+}
+
+func scalerDrainTestCluster(clusterName, namespace, nodePoolComponent, status, nodeName string, extraConditions []string) opensearchv1.OpenSearchCluster {
+	conditions := append([]string{nodeName}, extraConditions...)
+	return opensearchv1.OpenSearchCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+			UID:       "dummyuid",
+		},
+		Spec: opensearchv1.ClusterSpec{
+			General: opensearchv1.GeneralConfig{
+				ServiceName: clusterName,
+				HttpPort:    9200,
+			},
+			ConfMgmt: opensearchv1.ConfMgmt{
+				SmartScaler: true,
+			},
+			NodePools: []opensearchv1.NodePool{
+				{
+					Component: nodePoolComponent,
+					Replicas:  2,
+				},
+			},
+		},
+		Status: opensearchv1.ClusterStatus{
+			ComponentsStatus: []opensearchv1.ComponentStatus{
+				{
+					Component:   "Scaler",
+					Status:      status,
+					Description: nodePoolComponent,
+					Conditions:  conditions,
+				},
+			},
+		},
+	}
+}
+
+func scalerDrainTestSts(clusterName, namespace, nodePoolComponent string, replicas int32) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", clusterName, nodePoolComponent),
+			Namespace: namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To(replicas),
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: replicas,
+		},
+	}
 }
 
 var _ = Describe("Scaler Controller", func() {
@@ -420,6 +518,230 @@ var _ = Describe("Scaler Controller", func() {
 				requeue = r
 			}
 			Expect(requeue).To(BeFalse())
+		})
+	})
+
+	Context("When computing drain stall", func() {
+		It("Should not stall before the threshold", func() {
+			started := time.Now().UTC().Add(-14 * time.Minute)
+			Expect(drainHasStalled(started, time.Now().UTC(), drainStallWarningAfter)).To(BeFalse())
+		})
+
+		It("Should stall once the threshold has elapsed", func() {
+			started := time.Now().UTC().Add(-16 * time.Minute)
+			Expect(drainHasStalled(started, time.Now().UTC(), drainStallWarningAfter)).To(BeTrue())
+		})
+
+		It("Should keep the node name as the first condition", func() {
+			started := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+			conditions := scalerDrainConditions("node-1", started, true)
+			Expect(scalerTargetNodeName(conditions)).To(Equal("node-1"))
+			got, ok := drainStartedAt(conditions)
+			Expect(ok).To(BeTrue())
+			Expect(got).To(Equal(started))
+			Expect(hasDrainStalledCondition(conditions)).To(BeTrue())
+		})
+	})
+
+	Context("When draining nodes (issue #1447)", func() {
+		const (
+			clusterName       = "test-cluster"
+			clusterNamespace  = "test-namespace"
+			nodePoolComponent = "data"
+		)
+
+		It("Should fail closed when _cat/shards errors instead of marking the node drained", func() {
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, nil)
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusInternalServerError, `{"error":"unavailable"}`)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			err := underTest.drainNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cat shards failed"))
+			for _, status := range spec.Status.ComponentsStatus {
+				Expect(status.Status).ToNot(Equal("Drained"))
+			}
+			mockClient.AssertNotCalled(GinkgoT(), "UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything)
+		})
+
+		It("Should keep waiting when the node still has shards", func() {
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			started := time.Now().UTC().Add(-time.Minute)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, []string{
+				drainStartedConditionPrefix + started.Format(time.RFC3339),
+			})
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, fmt.Sprintf(
+				`[{"index":"idx","shard":"0","prirep":"p","state":"STARTED","node":"%s"}]`, targetNodeName,
+			))
+			registerClusterSettingsResponders(transport)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			err := underTest.drainNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent)
+
+			Expect(err).NotTo(HaveOccurred())
+			for _, status := range spec.Status.ComponentsStatus {
+				Expect(status.Status).ToNot(Equal("Drained"))
+			}
+			mockClient.AssertNotCalled(GinkgoT(), "UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything)
+		})
+
+		It("Should mark the node drained only when it has no shards", func() {
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, nil)
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, `[]`)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+			var markedDrained bool
+			mockClient.On("UpdateOpenSearchClusterStatus", client.ObjectKeyFromObject(&spec), mock.AnythingOfType("func(*v1.OpenSearchCluster)")).Run(func(args mock.Arguments) {
+				updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+				updateFn(&spec)
+				for _, status := range spec.Status.ComponentsStatus {
+					if status.Component == "Scaler" && status.Status == "Drained" {
+						markedDrained = true
+					}
+				}
+			}).Return(nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			err := underTest.drainNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(markedDrained).To(BeTrue())
+		})
+
+		It("Should emit a Warning and DrainStalled condition when a drain makes no progress", func() {
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			started := time.Now().UTC().Add(-16 * time.Minute)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, []string{
+				drainStartedConditionPrefix + started.Format(time.RFC3339),
+			})
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, fmt.Sprintf(
+				`[{"index":"idx","shard":"0","prirep":"p","state":"STARTED","node":"%s"}]`, targetNodeName,
+			))
+			registerClusterSettingsResponders(transport)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+			var stalled bool
+			mockClient.On("UpdateOpenSearchClusterStatus", client.ObjectKeyFromObject(&spec), mock.AnythingOfType("func(*v1.OpenSearchCluster)")).Run(func(args mock.Arguments) {
+				updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+				updateFn(&spec)
+				for _, status := range spec.Status.ComponentsStatus {
+					if status.Component == "Scaler" && hasDrainStalledCondition(status.Conditions) {
+						stalled = true
+						Expect(status.Status).To(Equal("Excluded"))
+					}
+				}
+			}).Return(nil)
+
+			recorder := record.NewFakeRecorder(5)
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			underTest.recorder = recorder
+			err := underTest.drainNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stalled).To(BeTrue())
+			var events []string
+			close(recorder.Events)
+			for event := range recorder.Events {
+				events = append(events, event)
+			}
+			Expect(events).To(ContainElement(ContainSubstring("has made no progress")))
+		})
+
+		It("Should not shrink the StatefulSet when decreaseOneNode finds shards still on the node", func() {
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Drained", targetNodeName, nil)
+			spec.Spec.NodePools[0].Replicas = 1
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, fmt.Sprintf(
+				`[{"index":"idx","shard":"0","prirep":"p","state":"STARTED","node":"%s"}]`, targetNodeName,
+			))
+			registerClusterSettingsResponders(transport)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+			var resetToExcluded bool
+			mockClient.On("UpdateOpenSearchClusterStatus", client.ObjectKeyFromObject(&spec), mock.AnythingOfType("func(*v1.OpenSearchCluster)")).Run(func(args mock.Arguments) {
+				updateFn := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+				updateFn(&spec)
+				for _, status := range spec.Status.ComponentsStatus {
+					if status.Component == "Scaler" && status.Status == "Excluded" {
+						resetToExcluded = true
+					}
+				}
+			}).Return(nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			requeue, err := underTest.decreaseOneNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent, true)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeTrue())
+			Expect(resetToExcluded).To(BeTrue())
+			Expect(*currentSts.Spec.Replicas).To(Equal(int32(3)))
+			mockClient.AssertNotCalled(GinkgoT(), "ReconcileResource", mock.Anything, mock.Anything)
+		})
+
+		It("Should not shrink the StatefulSet when decreaseOneNode cannot verify emptiness", func() {
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Drained", targetNodeName, nil)
+			spec.Spec.NodePools[0].Replicas = 1
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusInternalServerError, `{"error":"unavailable"}`)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			requeue, err := underTest.decreaseOneNode(spec.Status.ComponentsStatus[0], currentSts, nodePoolComponent, true)
+
+			Expect(err).To(HaveOccurred())
+			Expect(requeue).To(BeTrue())
+			Expect(*currentSts.Spec.Replicas).To(Equal(int32(3)))
+			mockClient.AssertNotCalled(GinkgoT(), "ReconcileResource", mock.Anything, mock.Anything)
 		})
 	})
 })


### PR DESCRIPTION
### Description
fix #1447

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
