### PR TITLE
fix: stop bootstrap pod recreate loop from admission spec drift

### DIFF
--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -815,31 +815,31 @@ func (r *ClusterReconciler) UpdateClusterStatus() error {
 	})
 }
 
-// reconcileBootstrapPod handles bootstrap pod reconciliation with recreation for any changes
+// reconcileBootstrapPod creates the bootstrap pod if it is missing and recreates
+// it only when the operator's last-applied spec has changed. Live spec drift from
+// admission controllers (LimitRange, mutating webhooks) is ignored so the pod is
+// not deleted in a loop. See https://github.com/opensearch-project/opensearch-k8s-operator/issues/1364
 func (r *ClusterReconciler) reconcileBootstrapPod(desiredPod *corev1.Pod) (*ctrl.Result, error) {
-	// Check if bootstrap pod exists
 	existingPod, err := r.client.GetPod(desiredPod.Name, desiredPod.Namespace)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return &ctrl.Result{}, err
 	}
 
 	if k8serrors.IsNotFound(err) {
-		// Pod doesn't exist, create it
 		r.logger.Info("Creating bootstrap pod", "pod", desiredPod.Name)
 		return r.client.ReconcileResource(desiredPod, reconciler.StateCreated)
 	}
 
-	updatePod := desiredPod.DeepCopy()
-	if _, err := r.client.ReconcileResource(updatePod, reconciler.StatePresent); err != nil {
-		if isImmutablePodUpdateErr(err) {
-			r.logger.Info("Bootstrap pod update touched immutable fields, recreating pod", "pod", desiredPod.Name)
-			return r.recreateBootstrapPod(&existingPod, desiredPod)
-		}
-		r.logger.Error(err, "Failed to update bootstrap pod", "pod", desiredPod.Name)
-		return &ctrl.Result{}, err
+	if existingPod.DeletionTimestamp != nil {
+		return &ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Second}, nil
 	}
 
-	return &ctrl.Result{}, nil
+	if !util.BootstrapPodNeedsRecreation(&existingPod, desiredPod) {
+		return &ctrl.Result{}, nil
+	}
+
+	r.logger.Info("Bootstrap pod spec changed, recreating pod", "pod", desiredPod.Name)
+	return r.recreateBootstrapPod(&existingPod, desiredPod)
 }
 
 func (r *ClusterReconciler) recreateBootstrapPod(existingPod *corev1.Pod, desiredPod *corev1.Pod) (*ctrl.Result, error) {
@@ -854,16 +854,4 @@ func (r *ClusterReconciler) recreateBootstrapPod(existingPod *corev1.Pod, desire
 
 	r.logger.Info("Creating new bootstrap pod with updated spec", "pod", desiredPod.Name)
 	return r.client.ReconcileResource(desiredPod, reconciler.StateCreated)
-}
-
-func isImmutablePodUpdateErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	if statusErr, ok := err.(*k8serrors.StatusError); ok {
-		if statusErr.ErrStatus.Reason == metav1.StatusReasonInvalid && strings.Contains(statusErr.ErrStatus.Message, "pod updates may not change") {
-			return true
-		}
-	}
-	return strings.Contains(err.Error(), "pod updates may not change")
 }

--- a/opensearch-operator/pkg/reconcilers/cluster_test.go
+++ b/opensearch-operator/pkg/reconcilers/cluster_test.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/patch"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconciler"
 	"github.com/stretchr/testify/mock"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -21,6 +23,7 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/builders"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/util"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -193,8 +196,168 @@ var _ = Describe("Bootstrap Pod Reconciliation Fix", func() {
 			)
 			Expect(util.PodSpecChanged(modifiedPod, originalPod)).To(BeFalse())
 		})
+
+		It("should ignore admission controller drift when last-applied spec is unchanged", func() {
+			instance := bootstrapTestCluster("admission-drift-test")
+			desired := builders.NewBootstrapPod(instance, nil, nil)
+
+			existing := desired.DeepCopy()
+			Expect(patch.DefaultAnnotator.SetLastAppliedAnnotation(existing)).To(Succeed())
+			simulateAdmissionControllerDrift(existing)
+
+			Expect(util.BootstrapPodNeedsRecreation(existing, desired)).To(BeFalse())
+		})
+
+		It("should recreate when the operator desired spec has changed", func() {
+			instance := bootstrapTestCluster("spec-change-test")
+			original := builders.NewBootstrapPod(instance, nil, nil)
+
+			existing := original.DeepCopy()
+			Expect(patch.DefaultAnnotator.SetLastAppliedAnnotation(existing)).To(Succeed())
+
+			desired := original.DeepCopy()
+			desired.Spec.ServiceAccountName = "updated-sa"
+			Expect(util.BootstrapPodNeedsRecreation(existing, desired)).To(BeTrue())
+		})
+
+		It("should not recreate when last-applied annotation is missing", func() {
+			instance := bootstrapTestCluster("missing-annotation-test")
+			desired := builders.NewBootstrapPod(instance, nil, nil)
+			existing := desired.DeepCopy()
+			simulateAdmissionControllerDrift(existing)
+
+			Expect(util.BootstrapPodNeedsRecreation(existing, desired)).To(BeFalse())
+		})
+	})
+
+	Context("reconcileBootstrapPod", func() {
+		It("should create the pod when it does not exist", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			instance := bootstrapTestCluster("create-test")
+			desired := builders.NewBootstrapPod(instance, nil, nil)
+			underTest := &ClusterReconciler{client: mockClient, instance: instance}
+
+			mockClient.EXPECT().
+				GetPod(desired.Name, desired.Namespace).
+				Return(corev1.Pod{}, k8serrors.NewNotFound(schema.GroupResource{Resource: "pods"}, desired.Name))
+			mockClient.EXPECT().
+				ReconcileResource(desired, reconciler.StateCreated).
+				Return(&ctrl.Result{}, nil)
+
+			result, err := underTest.reconcileBootstrapPod(desired)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&ctrl.Result{}))
+		})
+
+		It("should not patch or recreate when admission controllers mutated the live spec", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			instance := bootstrapTestCluster("drift-reconcile-test")
+			desired := builders.NewBootstrapPod(instance, nil, nil)
+			existing := desired.DeepCopy()
+			Expect(patch.DefaultAnnotator.SetLastAppliedAnnotation(existing)).To(Succeed())
+			simulateAdmissionControllerDrift(existing)
+
+			underTest := &ClusterReconciler{client: mockClient, instance: instance}
+			mockClient.EXPECT().
+				GetPod(desired.Name, desired.Namespace).
+				Return(*existing, nil)
+
+			result, err := underTest.reconcileBootstrapPod(desired)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&ctrl.Result{}))
+		})
+
+		It("should recreate the pod when the operator desired spec has changed", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			instance := bootstrapTestCluster("recreate-test")
+			original := builders.NewBootstrapPod(instance, nil, nil)
+			existing := original.DeepCopy()
+			Expect(patch.DefaultAnnotator.SetLastAppliedAnnotation(existing)).To(Succeed())
+
+			desired := original.DeepCopy()
+			desired.Spec.ServiceAccountName = "updated-sa"
+
+			underTest := &ClusterReconciler{client: mockClient, instance: instance}
+			mockClient.EXPECT().
+				GetPod(desired.Name, desired.Namespace).
+				Return(*existing, nil)
+			mockClient.EXPECT().DeletePod(mock.Anything).Return(nil)
+			mockClient.EXPECT().WaitForPodDeletion(desired.Name, desired.Namespace).Return(nil)
+			mockClient.EXPECT().
+				ReconcileResource(desired, reconciler.StateCreated).
+				Return(&ctrl.Result{}, nil)
+
+			result, err := underTest.reconcileBootstrapPod(desired)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&ctrl.Result{}))
+		})
+
+		It("should requeue when the existing bootstrap pod is terminating", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			instance := bootstrapTestCluster("terminating-test")
+			desired := builders.NewBootstrapPod(instance, nil, nil)
+			existing := desired.DeepCopy()
+			now := metav1.Now()
+			existing.DeletionTimestamp = &now
+
+			underTest := &ClusterReconciler{client: mockClient, instance: instance}
+			mockClient.EXPECT().
+				GetPod(desired.Name, desired.Namespace).
+				Return(*existing, nil)
+
+			result, err := underTest.reconcileBootstrapPod(desired)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Second}))
+		})
 	})
 })
+
+func bootstrapTestCluster(name string) *opensearchv1.OpenSearchCluster {
+	return &opensearchv1.OpenSearchCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-namespace",
+		},
+		Spec: opensearchv1.ClusterSpec{
+			General: opensearchv1.GeneralConfig{
+				HttpPort:       9200,
+				ServiceName:    name,
+				Version:        "2.8.0",
+				ServiceAccount: "default-sa",
+			},
+			Bootstrap: opensearchv1.BootstrapConfig{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "purpose",
+						Operator: "Equal",
+						Value:    "logging",
+						Effect:   "NoSchedule",
+					},
+				},
+			},
+		},
+		Status: opensearchv1.ClusterStatus{
+			Initialized: false,
+		},
+	}
+}
+
+func simulateAdmissionControllerDrift(pod *corev1.Pod) {
+	pod.Spec.SchedulerName = "gke-custom-scheduler"
+	injected := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+	for i := range pod.Spec.InitContainers {
+		pod.Spec.InitContainers[i].Resources = injected
+	}
+}
 
 var _ = Describe("ServiceMonitor reconciliation", func() {
 	newMonitoringInstance := func() *opensearchv1.OpenSearchCluster {

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -6,6 +6,7 @@ import (
 	cryptotls "crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -20,6 +21,7 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/services"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/builders"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/patch"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/tls"
 	appsv1 "k8s.io/api/apps/v1"
@@ -443,6 +445,25 @@ func PodSpecChanged(existing, desired *corev1.Pod) bool {
 	sanitizeBootstrapPodSpec(&desiredSpec)
 
 	return !apiequality.Semantic.DeepEqual(existingSpec, desiredSpec)
+}
+
+// BootstrapPodNeedsRecreation reports whether the operator's desired bootstrap
+// pod spec has changed since the pod was last applied. Live spec mutations from
+// admission controllers (LimitRange, mutating webhooks) are ignored by comparing
+// against the last-applied annotation rather than the live pod spec. Pods
+// without a last-applied annotation are left running to avoid recreate loops.
+func BootstrapPodNeedsRecreation(existing, desired *corev1.Pod) bool {
+	original, err := patch.DefaultAnnotator.GetOriginalConfiguration(existing)
+	if err != nil || len(original) == 0 {
+		return false
+	}
+
+	lastApplied := &corev1.Pod{}
+	if err := json.Unmarshal(original, lastApplied); err != nil {
+		return false
+	}
+
+	return PodSpecChanged(lastApplied, desired)
 }
 
 func sanitizeBootstrapPodSpec(spec *corev1.PodSpec) {


### PR DESCRIPTION
### Description
compare last-applied vs desired spec so limitRange and mutating webhooks no longer trigger delete/recreate. Recreate only when the operator spec actually changed

### Issues Resolved
fix #1364

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
