### PR TITLE
fix: keep bootstrap pod until a real node has joined the cluster

### DIFF
--- a/opensearch-operator/controllers/bootstrap_test.go
+++ b/opensearch-operator/controllers/bootstrap_test.go
@@ -1,0 +1,115 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/builders"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Regression test for #1486: the bootstrap pod must be kept (Status.Initialized stays false)
+// until every cluster-manager pod has actually joined the cluster according to _cat/nodes,
+// not merely reported Ready.
+var _ = Describe("Bootstrap pod removal", Ordered, func() {
+	const (
+		clusterName = "bootstrap-join-test"
+		namespace   = clusterName
+		timeout     = time.Second * 30
+		interval    = time.Second * 1
+	)
+	var (
+		cluster          = ComposeOpensearchCrd(clusterName, namespace)
+		bootstrapName    = builders.BootstrapPodName(&cluster)
+		catNodesRoute    = "=~^" + regexp.QuoteMeta(helpers.ClusterURL(&cluster)+"/_cat/nodes")
+		registerCatNodes = func(names ...string) {
+			body := "["
+			for i, n := range names {
+				if i > 0 {
+					body += ","
+				}
+				body += fmt.Sprintf(`{"name":%q}`, n)
+			}
+			osTransport.RegisterResponder(http.MethodGet, catNodesRoute, httpmock.NewStringResponder(200, body+"]"))
+		}
+		getCluster = func() opensearchv1.OpenSearchCluster {
+			c := opensearchv1.OpenSearchCluster{}
+			Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&cluster), &c)).To(Succeed())
+			return c
+		}
+		bootstrapPodExists = func() bool {
+			return IsCreated(context.Background(), k8sClient, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: bootstrapName, Namespace: namespace}})
+		}
+	)
+	// Keep the cluster small: no dashboards, monitoring or extra volumes, just a 3-replica master pool.
+	cluster.Spec.General.AdditionalVolumes = nil
+	cluster.Spec.General.Monitoring = opensearchv1.MonitoringConfig{}
+	cluster.Spec.Dashboards = opensearchv1.DashboardsConfig{}
+	masterPool := cluster.Spec.NodePools[0]
+	expectedMasters := builders.ExpectedMasterNodeNames(&cluster)
+
+	BeforeAll(func() {
+		clusterURL := helpers.ClusterURL(&cluster)
+		for _, u := range []string{clusterURL, clusterURL + "/"} {
+			osTransport.RegisterResponder(http.MethodHead, u, httpmock.NewStringResponder(200, "OK"))
+			osTransport.RegisterResponder(http.MethodGet, u, httpmock.NewStringResponder(200, `{"name":"test","cluster_name":"test","version":{"number":"2.0.0"}}`))
+		}
+		registerCatNodes(bootstrapName, expectedMasters[0])
+
+		Expect(CreateNamespace(k8sClient, &cluster)).Should(Succeed())
+		Expect(k8sClient.Create(context.Background(), &cluster)).Should(Succeed())
+		Eventually(func() bool {
+			return IsCreated(context.Background(), k8sClient, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: builders.StsName(&cluster, &masterPool), Namespace: namespace}})
+		}, timeout, interval).Should(BeTrue())
+		Eventually(bootstrapPodExists, timeout, interval).Should(BeTrue())
+
+		// envtest runs no StatefulSet controller or kubelet: create the master pods and mark them Ready ourselves.
+		Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&cluster), &cluster)).To(Succeed())
+		for _, name := range expectedMasters {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    map[string]string{helpers.ClusterLabel: clusterName, helpers.NodePoolLabel: masterPool.Component},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "opensearch", Image: "opensearchproject/opensearch:2.0.0"}}},
+			}
+			// Owned by the cluster so pod events trigger a reconcile.
+			Expect(ctrl.SetControllerReference(&cluster, pod, k8sClient.Scheme())).To(Succeed())
+			Expect(k8sClient.Create(context.Background(), pod)).To(Succeed())
+			pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+			Expect(k8sClient.Status().Update(context.Background(), pod)).To(Succeed())
+		}
+	})
+
+	It("should keep the bootstrap pod while only some masters have joined the cluster", func() {
+		// Wait until the controller has consulted _cat/nodes at least once with all master pods Ready.
+		Eventually(func() int {
+			return osTransport.GetCallCountInfo()["GET "+catNodesRoute]
+		}, timeout, interval).Should(BeNumerically(">", 0))
+		Consistently(func() bool { return getCluster().Status.Initialized }, 5*time.Second, interval).Should(BeFalse())
+		Expect(bootstrapPodExists()).To(BeTrue())
+	})
+
+	It("should mark the cluster initialized and remove the bootstrap pod once all masters have joined", func() {
+		registerCatNodes(append([]string{bootstrapName}, expectedMasters...)...)
+		// Nudge a reconcile instead of waiting for the periodic requeue.
+		Expect(k8sClient.Patch(context.Background(), &cluster, client.RawPatch(types.MergePatchType, []byte(`{"metadata":{"annotations":{"test/poke":"1"}}}`)))).To(Succeed())
+
+		Eventually(func() bool { return getCluster().Status.Initialized }, timeout, interval).Should(BeTrue())
+		Eventually(bootstrapPodExists, timeout, interval).Should(BeFalse())
+	})
+})

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -54,6 +55,8 @@ type OpenSearchClusterReconciler struct {
 	Recorder                         record.EventRecorder
 	SkipClusterRoleBindingManagement bool
 	NodeAttributesClusterRoleName    string
+	// osClientTransport overrides the OpenSearch HTTP transport; only set by tests.
+	osClientTransport http.RoundTripper
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchclusters,verbs=get;list;watch;create;update;patch;delete
@@ -273,13 +276,14 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context,
 			if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 				return err
 			}
-			// Check if all master pods are ready and the OpenSearch cluster has at least one real node
+			// Check if all master pods are ready and have actually joined the OpenSearch cluster
 			initialized := builders.AllMastersReady(ctx, r.Client, instance)
 			if initialized {
-				initialized = util.ClusterHasNonBootstrapNode(
+				initialized = util.ClusterHasAllMasters(
 					k8s.NewK8sClient(r.Client, ctx),
 					ctx,
 					instance,
+					r.osClientTransport,
 					logger,
 				)
 			}

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -271,11 +271,20 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 			if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
 				return err
 			}
-			allMastersReady := builders.AllMastersReady(ctx, r.Client, r.Instance)
-			k8sClient := k8s.NewK8sClient(r.Client, ctx)
-			health, _ := util.GetClusterHealth(k8sClient, ctx, r.Instance, r.Logger)
-			clusterReachable := health != opensearchv1.OpenSearchUnknownHealth
-			r.Instance.Status.Initialized = allMastersReady && clusterReachable
+			// Pod readiness is necessary but not sufficient: the bootstrap pod
+			// must remain until a real node has joined the OpenSearch cluster
+			// (#1486). Otherwise Initialized flips true, ClusterReconciler
+			// deletes bootstrap, and nodes stay seeded to <name>-bootstrap-0.
+			initialized := builders.AllMastersReady(ctx, r.Client, r.Instance)
+			if initialized {
+				initialized = util.ClusterHasNonBootstrapNode(
+					k8s.NewK8sClient(r.Client, ctx),
+					ctx,
+					r.Instance,
+					r.Logger,
+				)
+			}
+			r.Instance.Status.Initialized = initialized
 			return r.Status().Update(ctx, r.Instance)
 		}); err != nil {
 			return ctrl.Result{}, err

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -271,10 +271,7 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 			if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
 				return err
 			}
-			// Pod readiness is necessary but not sufficient: the bootstrap pod
-			// must remain until a real node has joined the OpenSearch cluster
-			// (#1486). Otherwise Initialized flips true, ClusterReconciler
-			// deletes bootstrap, and nodes stay seeded to <name>-bootstrap-0.
+			// Check if all master pods are ready and the OpenSearch cluster has at least one real node
 			initialized := builders.AllMastersReady(ctx, r.Client, r.Instance)
 			if initialized {
 				initialized = util.ClusterHasNonBootstrapNode(

--- a/opensearch-operator/controllers/suite_test.go
+++ b/opensearch-operator/controllers/suite_test.go
@@ -31,6 +31,7 @@ import (
 
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
+	"github.com/jarcoal/httpmock"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/phayes/freeport"
 
@@ -62,6 +63,8 @@ var (
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 	cancel    context.CancelFunc
+	// osTransport serves the OpenSearch API calls the cluster controller makes; tests register responders on it.
+	osTransport = httpmock.NewMockTransport()
 )
 
 func TestAPIs(t *testing.T) {
@@ -113,7 +116,8 @@ var _ = BeforeSuite(func() {
 		Client: k8sManager.GetClient(),
 		Scheme: scheme.Scheme,
 		//	Instance: &OpensearchCluster,
-		Recorder: record.NewFakeRecorder(20),
+		Recorder:          record.NewFakeRecorder(20),
+		osClientTransport: osTransport,
 		// Run the suite with several workers so that any per-request state that
 		// leaks between concurrently reconciled clusters surfaces in these tests.
 	}).SetupWithManager(k8sManager, 4)

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1673,28 +1673,36 @@ func NewSecurityconfigUpdateJob(
 
 func AllMastersReady(ctx context.Context, k8sClient client.Client, cr *opensearchv1.OpenSearchCluster) bool {
 	wrappedClient := k8s.NewK8sClient(k8sClient, ctx)
+	checkedMasterPool := false
 	for _, nodePool := range cr.Spec.NodePools {
 		masterRole := helpers.ResolveClusterManagerRole(cr.Spec.General.Version)
-		if helpers.ContainsString(helpers.MapClusterRoles(nodePool.Roles, cr.Spec.General.Version), masterRole) {
-			sts := &appsv1.StatefulSet{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      StsName(cr, &nodePool),
-				Namespace: cr.Namespace,
-			}, sts); err != nil {
-				return false
-			}
-			readyReplicas, err := helpers.ReadyReplicasForNodePool(wrappedClient, cr, &nodePool)
-			if err != nil {
-				return false
-			}
-			sts.Status.ReadyReplicas = readyReplicas
-			if sts.Status.ReadyReplicas != ptr.Deref(sts.Spec.Replicas, int32(1)) {
-				return false
-			}
-
+		if !helpers.ContainsString(helpers.MapClusterRoles(nodePool.Roles, cr.Spec.General.Version), masterRole) {
+			continue
+		}
+		checkedMasterPool = true
+		sts := &appsv1.StatefulSet{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      StsName(cr, &nodePool),
+			Namespace: cr.Namespace,
+		}, sts); err != nil {
+			return false
+		}
+		desiredReplicas := ptr.Deref(sts.Spec.Replicas, int32(1))
+		if desiredReplicas <= 0 {
+			return false
+		}
+		readyReplicas, err := helpers.ReadyReplicasForNodePool(wrappedClient, cr, &nodePool)
+		if err != nil {
+			return false
+		}
+		if readyReplicas != desiredReplicas {
+			return false
 		}
 	}
-	return true
+	// Fail closed when the spec has no cluster-manager pool: returning true here
+	// previously flipped status.initialized immediately and deleted the bootstrap
+	// pod before the cluster could form (#1486).
+	return checkedMasterPool
 }
 
 func NewServiceMonitor(cr *opensearchv1.OpenSearchCluster) *monitoring.ServiceMonitor {

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1687,20 +1687,32 @@ func AllMastersReady(ctx context.Context, k8sClient client.Client, cr *opensearc
 		}, sts); err != nil {
 			return false
 		}
-		desiredReplicas := ptr.Deref(sts.Spec.Replicas, int32(1))
-		if desiredReplicas <= 0 {
-			return false
-		}
 		readyReplicas, err := helpers.ReadyReplicasForNodePool(wrappedClient, cr, &nodePool)
 		if err != nil {
 			return false
 		}
-		if readyReplicas != desiredReplicas {
+		if readyReplicas != ptr.Deref(sts.Spec.Replicas, int32(1)) {
 			return false
 		}
 	}
 	// If there is no cluster-manager node pool defined in the spec, return false.
 	return checkedMasterPool
+}
+
+// ExpectedMasterNodeNames returns the pod names of all cluster-manager-eligible replicas.
+// Node names default to the pod hostname, so these match the names reported by _cat/nodes.
+func ExpectedMasterNodeNames(cr *opensearchv1.OpenSearchCluster) []string {
+	masterRole := helpers.ResolveClusterManagerRole(cr.Spec.General.Version)
+	var names []string
+	for _, pool := range cr.Spec.NodePools {
+		if !helpers.ContainsString(helpers.MapClusterRoles(pool.Roles, cr.Spec.General.Version), masterRole) {
+			continue
+		}
+		for i := int32(0); i < pool.Replicas; i++ {
+			names = append(names, fmt.Sprintf("%s-%d", StsName(cr, &pool), i))
+		}
+	}
+	return names
 }
 
 func NewServiceMonitor(cr *opensearchv1.OpenSearchCluster) *monitoring.ServiceMonitor {

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1699,9 +1699,7 @@ func AllMastersReady(ctx context.Context, k8sClient client.Client, cr *opensearc
 			return false
 		}
 	}
-	// Fail closed when the spec has no cluster-manager pool: returning true here
-	// previously flipped status.initialized immediately and deleted the bootstrap
-	// pod before the cluster could form (#1486).
+	// If there is no cluster-manager node pool defined in the spec, return false.
 	return checkedMasterPool
 }
 

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1073,6 +1073,123 @@ var _ = Describe("Builders", func() {
 			result := AllMastersReady(context.Background(), k8sClient, &clusterObject)
 			Expect(result).To(BeFalse())
 		})
+
+		It("should return false when no cluster-manager node pool exists", func() {
+			clusterObject := ClusterDescWithVersion("3.7.0")
+			clusterObject.Namespace = "default"
+			clusterObject.Name = "no-masters"
+			clusterObject.Spec.NodePools = []opensearchv1.NodePool{{
+				Replicas:  1,
+				Component: "data",
+				Roles:     []string{"data"},
+			}}
+			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeFalse())
+		})
+
+		It("should return false when the STS exists but no pods are ready", func() {
+			namespaceName := "allmastersready-unready"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			clusterObject := ClusterDescWithVersion("3.7.0")
+			clusterObject.Namespace = namespaceName
+			clusterObject.Name = "unready"
+			clusterObject.Spec.General.ServiceName = "unready"
+			nodePool := opensearchv1.NodePool{
+				Replicas:  1,
+				Component: "master",
+				Roles:     []string{"cluster_manager", "data"},
+			}
+			clusterObject.Spec.NodePools = append(clusterObject.Spec.NodePools, nodePool)
+
+			sts := NewSTSForNodePool("unready", &clusterObject, nodePool, "hash", nil, nil)
+			Expect(k8sClient.Create(context.Background(), sts)).To(Not(HaveOccurred()))
+			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeFalse())
+		})
+
+		It("should return false when only a mislabeled bootstrap pod is ready", func() {
+			namespaceName := "allmastersready-bootstrap"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			clusterObject := ClusterDescWithVersion("3.7.0")
+			clusterObject.Namespace = namespaceName
+			clusterObject.Name = "bootstrapped"
+			clusterObject.Spec.General.ServiceName = "bootstrapped"
+			nodePool := opensearchv1.NodePool{
+				Replicas:  1,
+				Component: "master",
+				Roles:     []string{"cluster_manager", "data"},
+			}
+			clusterObject.Spec.NodePools = append(clusterObject.Spec.NodePools, nodePool)
+
+			sts := NewSTSForNodePool("bootstrapped", &clusterObject, nodePool, "hash", nil, nil)
+			Expect(k8sClient.Create(context.Background(), sts)).To(Not(HaveOccurred()))
+
+			bootstrap := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BootstrapPodName(&clusterObject),
+					Namespace: namespaceName,
+					Labels: map[string]string{
+						helpers.ClusterLabel:  clusterObject.Name,
+						helpers.NodePoolLabel: nodePool.Component,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "opensearch",
+						Image: "opensearchproject/opensearch:3.7.0",
+					}},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), bootstrap)).To(Not(HaveOccurred()))
+			bootstrap.Status.Conditions = []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}}
+			Expect(k8sClient.Status().Update(context.Background(), bootstrap)).To(Succeed())
+
+			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeFalse())
+		})
+
+		It("should return true when all cluster-manager pods are ready", func() {
+			namespaceName := "allmastersready-ready"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			clusterObject := ClusterDescWithVersion("3.7.0")
+			clusterObject.Namespace = namespaceName
+			clusterObject.Name = "ready"
+			clusterObject.Spec.General.ServiceName = "ready"
+			nodePool := opensearchv1.NodePool{
+				Replicas:  1,
+				Component: "master",
+				Roles:     []string{"cluster_manager", "data"},
+			}
+			clusterObject.Spec.NodePools = append(clusterObject.Spec.NodePools, nodePool)
+
+			sts := NewSTSForNodePool("ready", &clusterObject, nodePool, "hash", nil, nil)
+			Expect(k8sClient.Create(context.Background(), sts)).To(Not(HaveOccurred()))
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-0", sts.Name),
+					Namespace: namespaceName,
+					Labels: map[string]string{
+						helpers.ClusterLabel:  clusterObject.Name,
+						helpers.NodePoolLabel: nodePool.Component,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "opensearch",
+						Image: "opensearchproject/opensearch:3.7.0",
+					}},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), pod)).To(Not(HaveOccurred()))
+			pod.Status.Conditions = []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}}
+			Expect(k8sClient.Status().Update(context.Background(), pod)).To(Succeed())
+
+			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeTrue())
+		})
 	})
 
 	When("Using custom command for OpenSearch startup", func() {

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1105,49 +1105,6 @@ var _ = Describe("Builders", func() {
 			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeFalse())
 		})
 
-		It("should return false when only a mislabeled bootstrap pod is ready", func() {
-			namespaceName := "allmastersready-bootstrap"
-			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
-			clusterObject := ClusterDescWithVersion("3.7.0")
-			clusterObject.Namespace = namespaceName
-			clusterObject.Name = "bootstrapped"
-			clusterObject.Spec.General.ServiceName = "bootstrapped"
-			nodePool := opensearchv1.NodePool{
-				Replicas:  1,
-				Component: "master",
-				Roles:     []string{"cluster_manager", "data"},
-			}
-			clusterObject.Spec.NodePools = append(clusterObject.Spec.NodePools, nodePool)
-
-			sts := NewSTSForNodePool("bootstrapped", &clusterObject, nodePool, "hash", nil, nil)
-			Expect(k8sClient.Create(context.Background(), sts)).To(Not(HaveOccurred()))
-
-			bootstrap := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      BootstrapPodName(&clusterObject),
-					Namespace: namespaceName,
-					Labels: map[string]string{
-						helpers.ClusterLabel:  clusterObject.Name,
-						helpers.NodePoolLabel: nodePool.Component,
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "opensearch",
-						Image: "opensearchproject/opensearch:3.7.0",
-					}},
-				},
-			}
-			Expect(k8sClient.Create(context.Background(), bootstrap)).To(Not(HaveOccurred()))
-			bootstrap.Status.Conditions = []corev1.PodCondition{{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			}}
-			Expect(k8sClient.Status().Update(context.Background(), bootstrap)).To(Succeed())
-
-			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeFalse())
-		})
-
 		It("should return true when all cluster-manager pods are ready", func() {
 			namespaceName := "allmastersready-ready"
 			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
@@ -1189,6 +1146,21 @@ var _ = Describe("Builders", func() {
 			Expect(k8sClient.Status().Update(context.Background(), pod)).To(Succeed())
 
 			Expect(AllMastersReady(context.Background(), k8sClient, &clusterObject)).To(BeTrue())
+		})
+	})
+
+	When("Listing expected master node names", func() {
+		It("should return one pod name per replica of each cluster-manager pool", func() {
+			clusterObject := ClusterDescWithVersion("3.7.0")
+			clusterObject.Name = "names"
+			clusterObject.Spec.NodePools = []opensearchv1.NodePool{
+				{Replicas: 2, Component: "masters", Roles: []string{"cluster_manager"}},
+				{Replicas: 3, Component: "data", Roles: []string{"data"}},
+				{Replicas: 1, Component: "mixed", Roles: []string{"master", "data"}},
+			}
+			Expect(ExpectedMasterNodeNames(&clusterObject)).To(Equal([]string{
+				"names-masters-0", "names-masters-1", "names-mixed-0",
+			}))
 		})
 	})
 

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -714,9 +714,16 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenS
 	if err != nil {
 		return 0, err
 	}
+	bootstrapName := fmt.Sprintf("%s-bootstrap-0", cr.Name)
 	numReadyPods := 0
 	for _, pod := range pods {
 		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		// The bootstrap pod only has the cluster label by default, but a user
+		// (or a copied label set) can attach the node-pool label. Never treat
+		// it as a ready replica of a real node pool (#1486).
+		if pod.Name == bootstrapName {
 			continue
 		}
 		podReady := false

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -728,16 +728,9 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenS
 	if err != nil {
 		return 0, err
 	}
-	bootstrapName := fmt.Sprintf("%s-bootstrap-0", cr.Name)
 	numReadyPods := 0
 	for _, pod := range pods {
 		if pod.DeletionTimestamp != nil {
-			continue
-		}
-		// By default, the bootstrap pod is labeled only with the cluster label.
-		// However, users or automated processes might add the node-pool label to it.
-		// This pod should never be counted as a ready replica for any node pool.
-		if pod.Name == bootstrapName {
 			continue
 		}
 		podReady := false

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -720,9 +720,9 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenS
 		if pod.DeletionTimestamp != nil {
 			continue
 		}
-		// The bootstrap pod only has the cluster label by default, but a user
-		// (or a copied label set) can attach the node-pool label. Never treat
-		// it as a ready replica of a real node pool (#1486).
+		// By default, the bootstrap pod is labeled only with the cluster label.
+		// However, users or automated processes might add the node-pool label to it.
+		// This pod should never be counted as a ready replica for any node pool.
 		if pod.Name == bootstrapName {
 			continue
 		}

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -922,17 +922,4 @@ var _ = Describe("CountRunningPodsForNodePool", func() {
 		Expect(count).To(Equal(1))
 	})
 
-	It("does not count a ready bootstrap pod as a node-pool replica", func() {
-		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
-		mockClient.EXPECT().ListPods(mock.Anything).Return(corev1.PodList{
-			Items: []corev1.Pod{readyPod("cluster-bootstrap-0")},
-		}, nil)
-
-		cr := &opensearchv1.OpenSearchCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
-		}
-		count, err := CountRunningPodsForNodePool(mockClient, cr, &opensearchv1.NodePool{Component: "master"})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(count).To(Equal(0))
-	})
 })

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -786,3 +786,45 @@ var _ = Describe("Upgrade status helpers", func() {
 		})
 	})
 })
+
+var _ = Describe("CountRunningPodsForNodePool", func() {
+	readyPod := func(name string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		}
+	}
+
+	It("counts ready node-pool pods", func() {
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().ListPods(mock.Anything).Return(corev1.PodList{
+			Items: []corev1.Pod{readyPod("cluster-master-0")},
+		}, nil)
+
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+		}
+		count, err := CountRunningPodsForNodePool(mockClient, cr, &opensearchv1.NodePool{Component: "master"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("does not count a ready bootstrap pod as a node-pool replica", func() {
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().ListPods(mock.Anything).Return(corev1.PodList{
+			Items: []corev1.Pod{readyPod("cluster-bootstrap-0")},
+		}, nil)
+
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+		}
+		count, err := CountRunningPodsForNodePool(mockClient, cr, &opensearchv1.NodePool{Component: "master"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(0))
+	})
+})

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -403,11 +403,7 @@ func GetClusterHealth(k8sClient k8s.K8sClient, ctx context.Context, cluster *ope
 	return opensearchv1.OpenSearchHealth(healthResponse.Status), healthResponse
 }
 
-// ClusterHasNonBootstrapNode reports whether OpenSearch already contains at
-// least one node that is not the temporary bootstrap pod. Kubernetes pod
-// readiness is not enough to flip status.initialized: GET / returns 200 before
-// cluster state recovers, and AllMastersReady can race ahead of bootstrap
-// (#1486). Until a real node has joined, the bootstrap pod must stay.
+// ClusterHasNonBootstrapNode reports whether OpenSearch already contains at least one node that is not the temporary bootstrap pod.
 func ClusterHasNonBootstrapNode(k8sClient k8s.K8sClient, ctx context.Context, cluster *opensearchv1.OpenSearchCluster, lg logr.Logger) bool {
 	osClient, err := CreateClientForCluster(k8sClient, ctx, cluster, nil)
 	if err != nil {
@@ -424,8 +420,7 @@ func ClusterHasNonBootstrapNode(k8sClient k8s.K8sClient, ctx context.Context, cl
 	return HasNonBootstrapClusterNode(nodes, builders.BootstrapPodName(cluster))
 }
 
-// HasNonBootstrapClusterNode reports whether any listed OpenSearch node is not
-// the temporary bootstrap pod.
+// HasNonBootstrapClusterNode reports whether any listed OpenSearch node is not the temporary bootstrap pod.
 func HasNonBootstrapClusterNode(nodes []responses.CatNodesResponse, bootstrapName string) bool {
 	for _, node := range nodes {
 		if node.Name != "" && node.Name != bootstrapName {

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -403,6 +403,38 @@ func GetClusterHealth(k8sClient k8s.K8sClient, ctx context.Context, cluster *ope
 	return opensearchv1.OpenSearchHealth(healthResponse.Status), healthResponse
 }
 
+// ClusterHasNonBootstrapNode reports whether OpenSearch already contains at
+// least one node that is not the temporary bootstrap pod. Kubernetes pod
+// readiness is not enough to flip status.initialized: GET / returns 200 before
+// cluster state recovers, and AllMastersReady can race ahead of bootstrap
+// (#1486). Until a real node has joined, the bootstrap pod must stay.
+func ClusterHasNonBootstrapNode(k8sClient k8s.K8sClient, ctx context.Context, cluster *opensearchv1.OpenSearchCluster, lg logr.Logger) bool {
+	osClient, err := CreateClientForCluster(k8sClient, ctx, cluster, nil)
+	if err != nil {
+		lg.V(1).Info(fmt.Sprintf("Failed to create OS client while checking bootstrap membership: %v", err))
+		return false
+	}
+
+	nodes, err := osClient.CatNodes()
+	if err != nil {
+		lg.V(1).Info(fmt.Sprintf("Failed to list OpenSearch nodes while checking bootstrap membership: %v", err))
+		return false
+	}
+
+	return HasNonBootstrapClusterNode(nodes, builders.BootstrapPodName(cluster))
+}
+
+// HasNonBootstrapClusterNode reports whether any listed OpenSearch node is not
+// the temporary bootstrap pod.
+func HasNonBootstrapClusterNode(nodes []responses.CatNodesResponse, bootstrapName string) bool {
+	for _, node := range nodes {
+		if node.Name != "" && node.Name != bootstrapName {
+			return true
+		}
+	}
+	return false
+}
+
 // GetAvailableOpenSearchNodes returns the sum of ready pods for all node pools
 func GetAvailableOpenSearchNodes(k8sClient k8s.K8sClient, ctx context.Context, cluster *opensearchv1.OpenSearchCluster, lg logr.Logger) int32 {
 	clusterName := cluster.Name

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -403,31 +403,35 @@ func GetClusterHealth(k8sClient k8s.K8sClient, ctx context.Context, cluster *ope
 	return opensearchv1.OpenSearchHealth(healthResponse.Status), healthResponse
 }
 
-// ClusterHasNonBootstrapNode reports whether OpenSearch already contains at least one node that is not the temporary bootstrap pod.
-func ClusterHasNonBootstrapNode(k8sClient k8s.K8sClient, ctx context.Context, cluster *opensearchv1.OpenSearchCluster, lg logr.Logger) bool {
-	osClient, err := CreateClientForCluster(k8sClient, ctx, cluster, nil)
+// ClusterHasAllMasters reports whether every expected cluster-manager pod has joined the OpenSearch cluster according to _cat/nodes.
+func ClusterHasAllMasters(k8sClient k8s.K8sClient, ctx context.Context, cluster *opensearchv1.OpenSearchCluster, transport http.RoundTripper, lg logr.Logger) bool {
+	osClient, err := CreateClientForCluster(k8sClient, ctx, cluster, transport)
 	if err != nil {
-		lg.V(1).Info(fmt.Sprintf("Failed to create OS client while checking bootstrap membership: %v", err))
+		lg.V(1).Info(fmt.Sprintf("Failed to create OS client while checking cluster membership: %v", err))
 		return false
 	}
 
 	nodes, err := osClient.CatNodes()
 	if err != nil {
-		lg.V(1).Info(fmt.Sprintf("Failed to list OpenSearch nodes while checking bootstrap membership: %v", err))
+		lg.V(1).Info(fmt.Sprintf("Failed to list OpenSearch nodes while checking cluster membership: %v", err))
 		return false
 	}
 
-	return HasNonBootstrapClusterNode(nodes, builders.BootstrapPodName(cluster))
+	return AllMastersJoinedCluster(nodes, builders.ExpectedMasterNodeNames(cluster))
 }
 
-// HasNonBootstrapClusterNode reports whether any listed OpenSearch node is not the temporary bootstrap pod.
-func HasNonBootstrapClusterNode(nodes []responses.CatNodesResponse, bootstrapName string) bool {
-	for _, node := range nodes {
-		if node.Name != "" && node.Name != bootstrapName {
-			return true
+// AllMastersJoinedCluster reports whether every expected node name is present in the listed OpenSearch nodes.
+func AllMastersJoinedCluster(nodes []responses.CatNodesResponse, expected []string) bool {
+	joined := map[string]bool{}
+	for _, n := range nodes {
+		joined[n.Name] = true
+	}
+	for _, name := range expected {
+		if !joined[name] {
+			return false
 		}
 	}
-	return false
+	return len(expected) > 0
 }
 
 // GetAvailableOpenSearchNodes returns the sum of ready pods for all node pools

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -822,23 +822,29 @@ var _ = Describe("loadOperatorClientTLSConfig", func() {
 	})
 })
 
-var _ = Describe("HasNonBootstrapClusterNode", func() {
-	bootstrap := "opensearch-bootstrap-0"
+var _ = Describe("AllMastersJoinedCluster", func() {
+	expected := []string{"opensearch-masters-0", "opensearch-masters-1"}
 
 	It("returns false when the cluster has no nodes", func() {
-		Expect(HasNonBootstrapClusterNode(nil, bootstrap)).To(BeFalse())
+		Expect(AllMastersJoinedCluster(nil, expected)).To(BeFalse())
 	})
 
-	It("returns false when only the bootstrap pod has joined", func() {
-		Expect(HasNonBootstrapClusterNode([]responses.CatNodesResponse{
-			{Name: bootstrap},
-		}, bootstrap)).To(BeFalse())
+	It("returns false when no masters are expected", func() {
+		Expect(AllMastersJoinedCluster([]responses.CatNodesResponse{{Name: "opensearch-bootstrap-0"}}, nil)).To(BeFalse())
 	})
 
-	It("returns true when a real node has joined alongside bootstrap", func() {
-		Expect(HasNonBootstrapClusterNode([]responses.CatNodesResponse{
-			{Name: bootstrap},
-			{Name: "opensearch-master-0"},
-		}, bootstrap)).To(BeTrue())
+	It("returns false when only some masters have joined", func() {
+		Expect(AllMastersJoinedCluster([]responses.CatNodesResponse{
+			{Name: "opensearch-bootstrap-0"},
+			{Name: "opensearch-masters-0"},
+		}, expected)).To(BeFalse())
+	})
+
+	It("returns true when every expected master has joined", func() {
+		Expect(AllMastersJoinedCluster([]responses.CatNodesResponse{
+			{Name: "opensearch-bootstrap-0"},
+			{Name: "opensearch-masters-0"},
+			{Name: "opensearch-masters-1"},
+		}, expected)).To(BeTrue())
 	})
 })

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	opsterTLS "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/tls"
 	appsv1 "k8s.io/api/apps/v1"
@@ -818,5 +819,26 @@ var _ = Describe("loadOperatorClientTLSConfig", func() {
 			Expect(cfg).NotTo(BeNil())
 			Expect(cfg.ServerName).To(BeEmpty())
 		})
+	})
+})
+
+var _ = Describe("HasNonBootstrapClusterNode", func() {
+	bootstrap := "opensearch-bootstrap-0"
+
+	It("returns false when the cluster has no nodes", func() {
+		Expect(HasNonBootstrapClusterNode(nil, bootstrap)).To(BeFalse())
+	})
+
+	It("returns false when only the bootstrap pod has joined", func() {
+		Expect(HasNonBootstrapClusterNode([]responses.CatNodesResponse{
+			{Name: bootstrap},
+		}, bootstrap)).To(BeFalse())
+	})
+
+	It("returns true when a real node has joined alongside bootstrap", func() {
+		Expect(HasNonBootstrapClusterNode([]responses.CatNodesResponse{
+			{Name: bootstrap},
+			{Name: "opensearch-master-0"},
+		}, bootstrap)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
### Description
status.initialized was derived from Kubernetes pod readiness alone, so the bootstrap pod was deleted before cluster state recovered and nodes stayed seeded to <name>-bootstrap-0

fix #1486

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
