### PR TITLE
fix: make cluster reconciler concurrency configurable

### DIFF
--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.9
+version: 3.0.10
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -158,4 +158,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `3.0.9`
+Opensearch-operator Helm Chart version: `3.0.10`

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -97,6 +97,8 @@ The following table lists the configurable parameters of the Helm chart.
 | `manager.dnsBase` | string | `"cluster.local"` |  |
 | `manager.loglevel` | string | `"info"` |  |
 | `manager.watchNamespace` | string | `nil` |  |
+| `manager.maxConcurrentReconciles` | int | `1` | Global default max concurrent reconciles for all controllers. Keep at 1 unless a controller is known to be concurrency-safe. Only the cluster controller currently stores no per-request state on the reconciler. |
+| `manager.maxConcurrentReconcilesPerController` | object | `{}` | Per-controller overrides (controller name -> max concurrent reconciles). Only raise above 1 for controllers that do not store per-request state on the reconciler. The cluster controller (`opensearchcluster`) is safe; other controllers currently are not. |
 | `manager.metricsBindAddress` | string | `"127.0.0.1:8080"` |  |
 | `installCRDs` | bool | `true` |  |
 | `legacyAPI.enabled` | bool | `true` | Enable support for the deprecated `opensearch.opster.io/v1` API group. When false, deprecated CRDs, webhooks, RBAC rules, and manager watches are skipped. |

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -97,8 +97,8 @@ The following table lists the configurable parameters of the Helm chart.
 | `manager.dnsBase` | string | `"cluster.local"` |  |
 | `manager.loglevel` | string | `"info"` |  |
 | `manager.watchNamespace` | string | `nil` |  |
-| `manager.maxConcurrentReconciles` | int | `1` | Global default max concurrent reconciles for all controllers. Keep at 1 unless a controller is known to be concurrency-safe. Only the cluster controller currently stores no per-request state on the reconciler. |
-| `manager.maxConcurrentReconcilesPerController` | object | `{}` | Per-controller overrides (controller name -> max concurrent reconciles). Only raise above 1 for controllers that do not store per-request state on the reconciler. The cluster controller (`opensearchcluster`) is safe; other controllers currently are not. |
+| `manager.maxConcurrentReconciles` | int | `1` | Global default max concurrent reconciles for all controllers. |
+| `manager.maxConcurrentReconcilesPerController` | object | `{}` | Per-controller overrides (controller name -> max concurrent reconciles). Example: `{opensearchcluster: 4}`. |
 | `manager.metricsBindAddress` | string | `"127.0.0.1:8080"` |  |
 | `installCRDs` | bool | `true` |  |
 | `legacyAPI.enabled` | bool | `true` | Enable support for the deprecated `opensearch.opster.io/v1` API group. When false, deprecated CRDs, webhooks, RBAC rules, and manager watches are skipped. |

--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -32,6 +32,14 @@ spec:
         - --enable-legacy-api={{ include "opensearch-operator.legacyAPIEnabled" . }}
         - --webhook-port={{ .Values.webhook.port }}
         - --manage-cluster-role-bindings={{ not .Values.useRoleBindings }}
+        - --max-concurrent-reconciles={{ .Values.manager.maxConcurrentReconciles | default 1 }}
+        {{- $perControllerPairs := list }}
+        {{- range $controller, $count := .Values.manager.maxConcurrentReconcilesPerController }}
+        {{- $perControllerPairs = append $perControllerPairs (printf "%s=%v" $controller $count) }}
+        {{- end }}
+        {{- if $perControllerPairs }}
+        - --max-concurrent-reconciles-per-controller={{ $perControllerPairs | join "," }}
+        {{- end }}
         {{- if .Values.manager.watchNamespace }}
         {{- if kindIs "slice" .Values.manager.watchNamespace }}
         - --watch-namespace={{ .Values.manager.watchNamespace | join "," }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -67,10 +67,10 @@ manager:
   # watchNamespace: [ns1, ns2]
   watchNamespace:
 
-  # -- Global default max concurrent reconciles for all controllers. Keep at 1 unless a controller is known to be concurrency-safe. Only the cluster controller currently stores no per-request state on the reconciler.
+  # -- Global default max concurrent reconciles for all controllers.
   maxConcurrentReconciles: 1
 
-  # -- Per-controller overrides (controller name -> max concurrent reconciles). Only raise above 1 for controllers that do not store per-request state on the reconciler. The cluster controller (`opensearchcluster`) is safe; other controllers currently are not.
+  # -- Per-controller overrides (controller name -> max concurrent reconciles). Example: `{opensearchcluster: 4}`.
   maxConcurrentReconcilesPerController: {}
 
   metricsBindAddress: 127.0.0.1:8080

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -67,6 +67,12 @@ manager:
   # watchNamespace: [ns1, ns2]
   watchNamespace:
 
+  # -- Global default max concurrent reconciles for all controllers. Keep at 1 unless a controller is known to be concurrency-safe. Only the cluster controller currently stores no per-request state on the reconciler.
+  maxConcurrentReconciles: 1
+
+  # -- Per-controller overrides (controller name -> max concurrent reconciles). Only raise above 1 for controllers that do not store per-request state on the reconciler. The cluster controller (`opensearchcluster`) is safe; other controllers currently are not.
+  maxConcurrentReconcilesPerController: {}
+
   metricsBindAddress: 127.0.0.1:8080
 
 # Install the Custom Resource Definitions with Helm

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -102,14 +102,11 @@ manager:
   # watchNamespace: [ns1, ns2]
   watchNamespace:
 
-  # Global default max concurrent reconciles for all controllers. Keep at 1
-  # unless a controller is known to be concurrency-safe.
+  # Global default max concurrent reconciles for all controllers.
   maxConcurrentReconciles: 1
 
-  # Per-controller overrides. Only the cluster controller (opensearchcluster)
-  # currently stores no per-request state on the reconciler and is safe to raise.
-  # Other controllers still mutate shared Instance/Logger fields and must stay at 1.
-  # Example to raise cluster concurrency:
+  # Per-controller overrides (controller name -> max concurrent reconciles).
+  # Example:
   # maxConcurrentReconcilesPerController:
   #   opensearchcluster: 4
   maxConcurrentReconcilesPerController: {}

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -102,6 +102,18 @@ manager:
   # watchNamespace: [ns1, ns2]
   watchNamespace:
 
+  # Global default max concurrent reconciles for all controllers. Keep at 1
+  # unless a controller is known to be concurrency-safe.
+  maxConcurrentReconciles: 1
+
+  # Per-controller overrides. Only the cluster controller (opensearchcluster)
+  # currently stores no per-request state on the reconciler and is safe to raise.
+  # Other controllers still mutate shared Instance/Logger fields and must stay at 1.
+  # Example to raise cluster concurrency:
+  # maxConcurrentReconcilesPerController:
+  #   opensearchcluster: 4
+  maxConcurrentReconcilesPerController: {}
+
   # Configure extra environment variables for the operator. You can also pull them from secrets or configmaps
   extraEnv: []
   #  - name: MY_ENV

--- a/opensearch-operator/controllers/controller_settings.go
+++ b/opensearch-operator/controllers/controller_settings.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -22,6 +23,20 @@ const (
 	ControllerNameComponentTemplate = "opensearchcomponenttemplate"
 	ControllerNameSnapshotPolicy    = "opensearchsnapshotpolicy"
 )
+
+// knownControllers is the set of controller names accepted by --max-concurrent-reconciles-per-controller.
+var knownControllers = map[string]struct{}{
+	ControllerNameCluster:           {},
+	ControllerNameUser:              {},
+	ControllerNameRole:              {},
+	ControllerNameTenant:            {},
+	ControllerNameUserRoleBinding:   {},
+	ControllerNameActionGroup:       {},
+	ControllerNameISMPolicy:         {},
+	ControllerNameIndexTemplate:     {},
+	ControllerNameComponentTemplate: {},
+	ControllerNameSnapshotPolicy:    {},
+}
 
 // ControllerConcurrencyConfig holds concurrency settings for controllers.
 type ControllerConcurrencyConfig struct {
@@ -48,11 +63,12 @@ func (c *ControllerConcurrencyConfig) GetMaxConcurrentReconciles(controllerName 
 }
 
 // ParsePerControllerConcurrency parses a comma-separated list of controller=N pairs.
-// Invalid entries are skipped.
-func ParsePerControllerConcurrency(spec string) map[string]int {
+// Empty entries (e.g. trailing commas) are ignored. Unknown controller names,
+// malformed pairs, and non-positive or unparsable values return an error.
+func ParsePerControllerConcurrency(spec string) (map[string]int, error) {
 	perController := make(map[string]int)
 	if spec == "" {
-		return perController
+		return perController, nil
 	}
 	for _, pair := range strings.Split(spec, ",") {
 		pair = strings.TrimSpace(pair)
@@ -61,18 +77,24 @@ func ParsePerControllerConcurrency(spec string) map[string]int {
 		}
 		parts := strings.SplitN(pair, "=", 2)
 		if len(parts) != 2 {
-			continue
+			return nil, fmt.Errorf("invalid per-controller concurrency entry %q: expected controller=N", pair)
 		}
 		key := strings.ToLower(strings.TrimSpace(parts[0]))
 		val := strings.TrimSpace(parts[1])
 		if key == "" || val == "" {
-			continue
+			return nil, fmt.Errorf("invalid per-controller concurrency entry %q: expected controller=N", pair)
+		}
+		if _, ok := knownControllers[key]; !ok {
+			return nil, fmt.Errorf("unknown controller %q in per-controller concurrency config", key)
 		}
 		count, err := strconv.Atoi(val)
-		if err != nil || count < 1 {
-			continue
+		if err != nil {
+			return nil, fmt.Errorf("invalid concurrency value %q for controller %q: %w", val, key, err)
+		}
+		if count < 1 {
+			return nil, fmt.Errorf("concurrency for controller %q must be >= 1, got %d", key, count)
 		}
 		perController[key] = count
 	}
-	return perController
+	return perController, nil
 }

--- a/opensearch-operator/controllers/controller_settings.go
+++ b/opensearch-operator/controllers/controller_settings.go
@@ -1,5 +1,78 @@
 package controllers
 
+import (
+	"strconv"
+	"strings"
+)
+
 const (
 	OpensearchFinalizer = "opensearch.org/opensearch-data"
 )
+
+// Controller names for per-controller concurrency configuration.
+const (
+	ControllerNameCluster           = "opensearchcluster"
+	ControllerNameUser              = "opensearchuser"
+	ControllerNameRole              = "opensearchrole"
+	ControllerNameTenant            = "opensearchtenant"
+	ControllerNameUserRoleBinding   = "opensearchuserrolebinding"
+	ControllerNameActionGroup       = "opensearchactiongroup"
+	ControllerNameISMPolicy         = "opensearchismpolicy"
+	ControllerNameIndexTemplate     = "opensearchindextemplate"
+	ControllerNameComponentTemplate = "opensearchcomponenttemplate"
+	ControllerNameSnapshotPolicy    = "opensearchsnapshotpolicy"
+)
+
+// ControllerConcurrencyConfig holds concurrency settings for controllers.
+type ControllerConcurrencyConfig struct {
+	// Global default max concurrent reconciles for all controllers.
+	MaxConcurrentReconciles int
+	// Per-controller overrides (controller name -> max concurrent reconciles).
+	PerController map[string]int
+}
+
+// GetMaxConcurrentReconciles returns the max concurrent reconciles for a given controller.
+// Per-controller overrides take precedence over the global default. Values below 1 are clamped to 1.
+func (c *ControllerConcurrencyConfig) GetMaxConcurrentReconciles(controllerName string) int {
+	if c == nil {
+		return 1
+	}
+	n := c.MaxConcurrentReconciles
+	if override, exists := c.PerController[controllerName]; exists {
+		n = override
+	}
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// ParsePerControllerConcurrency parses a comma-separated list of controller=N pairs.
+// Invalid entries are skipped.
+func ParsePerControllerConcurrency(spec string) map[string]int {
+	perController := make(map[string]int)
+	if spec == "" {
+		return perController
+	}
+	for _, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.TrimSpace(parts[1])
+		if key == "" || val == "" {
+			continue
+		}
+		count, err := strconv.Atoi(val)
+		if err != nil || count < 1 {
+			continue
+		}
+		perController[key] = count
+	}
+	return perController
+}

--- a/opensearch-operator/controllers/controller_settings_test.go
+++ b/opensearch-operator/controllers/controller_settings_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -106,9 +107,10 @@ func TestParsePerControllerConcurrency(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		spec string
-		want map[string]int
+		name    string
+		spec    string
+		want    map[string]int
+		wantErr string
 	}{
 		{
 			name: "empty spec",
@@ -145,16 +147,68 @@ func TestParsePerControllerConcurrency(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid entries are skipped",
-			spec: "opensearchcluster=4,notapair,opensearchuser=abc,opensearchrole=0,opensearchtenant=-2,=3,opensearchismpolicy=",
-			want: map[string]int{ControllerNameCluster: 4},
+			name: "duplicate key: last value wins",
+			spec: "opensearchcluster=2,opensearchcluster=6",
+			want: map[string]int{ControllerNameCluster: 6},
+		},
+		{
+			name:    "malformed pair",
+			spec:    "notapair",
+			wantErr: `expected controller=N`,
+		},
+		{
+			name:    "unknown controller name",
+			spec:    "opensearchclusters=4",
+			wantErr: `unknown controller "opensearchclusters"`,
+		},
+		{
+			name:    "unparsable value",
+			spec:    "opensearchcluster=abc",
+			wantErr: `invalid concurrency value "abc"`,
+		},
+		{
+			name:    "zero value",
+			spec:    "opensearchrole=0",
+			wantErr: `must be >= 1`,
+		},
+		{
+			name:    "negative value",
+			spec:    "opensearchtenant=-2",
+			wantErr: `must be >= 1`,
+		},
+		{
+			name:    "empty key",
+			spec:    "=3",
+			wantErr: `expected controller=N`,
+		},
+		{
+			name:    "empty value",
+			spec:    "opensearchismpolicy=",
+			wantErr: `expected controller=N`,
+		},
+		{
+			name:    "fails on first invalid entry in mixed list",
+			spec:    "opensearchcluster=4,notapair",
+			wantErr: `expected controller=N`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := ParsePerControllerConcurrency(tt.spec)
+			got, err := ParsePerControllerConcurrency(tt.spec)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParsePerControllerConcurrency(%q) error = nil, want %q", tt.spec, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParsePerControllerConcurrency(%q) error = %v, want containing %q", tt.spec, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePerControllerConcurrency(%q) unexpected error: %v", tt.spec, err)
+			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("ParsePerControllerConcurrency(%q) = %#v, want %#v", tt.spec, got, tt.want)
 			}

--- a/opensearch-operator/controllers/controller_settings_test.go
+++ b/opensearch-operator/controllers/controller_settings_test.go
@@ -1,0 +1,163 @@
+package controllers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetMaxConcurrentReconciles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		cfg            *ControllerConcurrencyConfig
+		controllerName string
+		want           int
+	}{
+		{
+			name:           "nil config defaults to 1",
+			cfg:            nil,
+			controllerName: ControllerNameCluster,
+			want:           1,
+		},
+		{
+			name: "uses global default",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: 4,
+			},
+			controllerName: ControllerNameCluster,
+			want:           4,
+		},
+		{
+			name: "per-controller override wins",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: 1,
+				PerController: map[string]int{
+					ControllerNameCluster: 8,
+					ControllerNameUser:    2,
+				},
+			},
+			controllerName: ControllerNameCluster,
+			want:           8,
+		},
+		{
+			name: "missing override falls back to global",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: 3,
+				PerController: map[string]int{
+					ControllerNameUser: 2,
+				},
+			},
+			controllerName: ControllerNameCluster,
+			want:           3,
+		},
+		{
+			name: "zero global is clamped to 1",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: 0,
+			},
+			controllerName: ControllerNameCluster,
+			want:           1,
+		},
+		{
+			name: "negative global is clamped to 1",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: -5,
+			},
+			controllerName: ControllerNameCluster,
+			want:           1,
+		},
+		{
+			name: "zero override is clamped to 1",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: 4,
+				PerController: map[string]int{
+					ControllerNameUser: 0,
+				},
+			},
+			controllerName: ControllerNameUser,
+			want:           1,
+		},
+		{
+			name: "negative override is clamped to 1",
+			cfg: &ControllerConcurrencyConfig{
+				MaxConcurrentReconciles: 4,
+				PerController: map[string]int{
+					ControllerNameRole: -1,
+				},
+			},
+			controllerName: ControllerNameRole,
+			want:           1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.cfg.GetMaxConcurrentReconciles(tt.controllerName)
+			if got != tt.want {
+				t.Fatalf("GetMaxConcurrentReconciles(%q) = %d, want %d", tt.controllerName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePerControllerConcurrency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec string
+		want map[string]int
+	}{
+		{
+			name: "empty spec",
+			spec: "",
+			want: map[string]int{},
+		},
+		{
+			name: "single pair",
+			spec: "opensearchcluster=4",
+			want: map[string]int{ControllerNameCluster: 4},
+		},
+		{
+			name: "multiple pairs",
+			spec: "opensearchcluster=4,opensearchuser=1",
+			want: map[string]int{
+				ControllerNameCluster: 4,
+				ControllerNameUser:    1,
+			},
+		},
+		{
+			name: "trims whitespace and lowercases keys",
+			spec: " OpenSearchCluster = 4 , OpenSearchUser=2 ",
+			want: map[string]int{
+				ControllerNameCluster: 4,
+				ControllerNameUser:    2,
+			},
+		},
+		{
+			name: "trailing comma and empty entries are skipped",
+			spec: "opensearchcluster=4,,opensearchuser=1,",
+			want: map[string]int{
+				ControllerNameCluster: 4,
+				ControllerNameUser:    1,
+			},
+		},
+		{
+			name: "invalid entries are skipped",
+			spec: "opensearchcluster=4,notapair,opensearchuser=abc,opensearchrole=0,opensearchtenant=-2,=3,opensearchismpolicy=",
+			want: map[string]int{ControllerNameCluster: 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParsePerControllerConcurrency(tt.spec)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParsePerControllerConcurrency(%q) = %#v, want %#v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -45,14 +46,14 @@ import (
 
 // OpenSearchClusterReconciler reconciles a OpenSearchCluster object
 // Now reconciles opensearch.org/v1 API group (new API) instead of opensearch.opster.io/v1 (old API)
+// Per-request state (cluster instance and logger) is kept off this struct so
+// MaxConcurrentReconciles > 1 cannot leak state between in-flight reconciles.
 type OpenSearchClusterReconciler struct {
 	client.Client
 	Scheme                           *runtime.Scheme
 	Recorder                         record.EventRecorder
-	Instance                         *opensearchv1.OpenSearchCluster
 	SkipClusterRoleBindingManagement bool
 	NodeAttributesClusterRoleName    string
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchclusters,verbs=get;list;watch;create;update;patch;delete
@@ -86,13 +87,13 @@ type OpenSearchClusterReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("cluster", req.NamespacedName, "apiGroup", "opensearch.org/v1")
-	r.Info("Reconciling OpenSearchCluster (opensearch.org/v1)")
+	logger := log.FromContext(ctx).WithValues("cluster", req.NamespacedName, "apiGroup", "opensearch.org/v1")
+	logger.Info("Reconciling OpenSearchCluster (opensearch.org/v1)")
 	myFinalizerName := "Opensearch"
 
 	// Try to get new API group resource first
-	r.Instance = &opensearchv1.OpenSearchCluster{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpenSearchCluster{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// If new API group resource not found, check if old one exists (for backward compatibility during migration)
@@ -100,7 +101,7 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if err := r.Get(ctx, req.NamespacedName, oldInstance); err == nil {
 				// Old instance exists but new one doesn't - migration controller should handle this
 				// Just requeue to let migration controller create the new one
-				r.Info("Old API group resource exists, waiting for migration", "name", req.Name)
+				logger.Info("Old API group resource exists, waiting for migration", "name", req.Name)
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			}
 			return ctrl.Result{}, nil
@@ -109,24 +110,24 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	/// ------ check if CRD has been deleted ------ ///
 	///	if ns deleted, delete the associated resources ///
-	if r.Instance.DeletionTimestamp.IsZero() {
-		if !helpers.ContainsString(r.Instance.GetFinalizers(), myFinalizerName) {
+	if instance.DeletionTimestamp.IsZero() {
+		if !helpers.ContainsString(instance.GetFinalizers(), myFinalizerName) {
 			// Use RetryOnConflict to update finalizer to handle any changes to resource
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				if err := r.Get(ctx, req.NamespacedName, r.Instance); err != nil {
+				if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 					return err
 				}
-				controllerutil.AddFinalizer(r.Instance, myFinalizerName)
-				return r.Update(ctx, r.Instance)
+				controllerutil.AddFinalizer(instance, myFinalizerName)
+				return r.Update(ctx, instance)
 			})
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 		}
 	} else {
-		if helpers.ContainsString(r.Instance.GetFinalizers(), myFinalizerName) {
+		if helpers.ContainsString(instance.GetFinalizers(), myFinalizerName) {
 			// our finalizer is present, so lets handle any external dependency
-			if result, err := r.deleteExternalResources(ctx); err != nil {
+			if result, err := r.deleteExternalResources(ctx, instance, logger); err != nil {
 				// if fail to delete the external dependency here, return with error
 				// so that it can be retried
 				return result, err
@@ -134,31 +135,31 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			// remove our finalizer from the list and update it.
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				if err := r.Get(ctx, req.NamespacedName, r.Instance); err != nil {
+				if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 					return err
 				}
-				controllerutil.RemoveFinalizer(r.Instance, myFinalizerName)
-				return r.Update(ctx, r.Instance)
+				controllerutil.RemoveFinalizer(instance, myFinalizerName)
+				return r.Update(ctx, instance)
 			})
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 
-			helpers.DeleteClusterMetrics(req.Namespace, r.Instance.Name)
+			helpers.DeleteClusterMetrics(req.Namespace, instance.Name)
 		}
 		return ctrl.Result{}, nil
 	}
 
 	/// if crd not deleted started phase 1
-	if r.Instance.Status.Phase == "" {
-		r.Instance.Status.Phase = opensearchv1.PhasePending
+	if instance.Status.Phase == "" {
+		instance.Status.Phase = opensearchv1.PhasePending
 	}
 
-	switch r.Instance.Status.Phase {
+	switch instance.Status.Phase {
 	case opensearchv1.PhasePending:
-		return r.reconcilePhasePending(ctx)
+		return r.reconcilePhasePending(ctx, instance, logger)
 	case opensearchv1.PhaseRunning, opensearchv1.PhaseUpgrading:
-		return r.reconcilePhaseRunning(ctx)
+		return r.reconcilePhaseRunning(ctx, instance, logger)
 	default:
 		// NOTHING WILL HAPPEN - DEFAULT
 		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
@@ -166,7 +167,7 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpenSearchCluster{}). // Watch new API group
 		Owns(&corev1.Pod{}).
@@ -176,41 +177,42 @@ func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }
 
 // delete associated cluster resources //
-func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Context) (ctrl.Result, error) {
-	r.Info("Deleting resources")
+func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Context, instance *opensearchv1.OpenSearchCluster, logger logr.Logger) (ctrl.Result, error) {
+	logger.Info("Deleting resources")
 	// Run through all sub controllers to delete existing objects
-	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, r.Instance, r.Instance.Spec.NodePools)
+	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, instance, instance.Spec.NodePools)
 
 	tls := reconcilers.NewTLSReconciler(
 		r.Client,
 		ctx,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	securityconfig := reconcilers.NewSecurityconfigReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	config := reconcilers.NewConfigurationReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	cluster := reconcilers.NewClusterReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	if r.SkipClusterRoleBindingManagement {
 		cluster.DisableClusterRoleBindingManagement()
@@ -221,7 +223,7 @@ func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Contex
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 
 	componentReconcilers := []reconcilers.NamedComponentReconciler{
@@ -234,26 +236,26 @@ func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Contex
 	for _, rec := range componentReconcilers {
 		result, err := rec.Func()
 		if err != nil {
-			helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
+			helpers.ReconcileErrors.WithLabelValues(instance.Namespace, instance.Name, rec.Name).Inc()
 			return result, err
 		}
 		if result.Requeue {
 			return result, nil
 		}
 	}
-	r.Info("Finished deleting resources")
+	logger.Info("Finished deleting resources")
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context) (ctrl.Result, error) {
-	r.Info("Start reconcile - Phase: PENDING")
+func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context, instance *opensearchv1.OpenSearchCluster, logger logr.Logger) (ctrl.Result, error) {
+	logger.Info("Start reconcile - Phase: PENDING")
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
+		if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 			return err
 		}
-		r.Instance.Status.Phase = opensearchv1.PhaseRunning
-		r.Instance.Status.ComponentsStatus = make([]opensearchv1.ComponentStatus, 0)
-		return r.Status().Update(ctx, r.Instance)
+		instance.Status.Phase = opensearchv1.PhaseRunning
+		instance.Status.ComponentsStatus = make([]opensearchv1.ComponentStatus, 0)
+		return r.Status().Update(ctx, instance)
 	})
 	if err != nil {
 		return ctrl.Result{}, err
@@ -261,56 +263,56 @@ func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context)
 	return ctrl.Result{Requeue: true}, nil
 }
 
-func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context) (ctrl.Result, error) {
+func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context, instance *opensearchv1.OpenSearchCluster, logger logr.Logger) (ctrl.Result, error) {
 	// Update initialized status first. Only set Initialized when all master pods are ready
 	// and the OpenSearch cluster API is reachable (cluster has formed). This prevents
 	// deleting the bootstrap pod before the cluster has actually bootstrapped, which
 	// can happen with parallel pod management when pods report ready before quorum is formed.
-	if !r.Instance.Status.Initialized {
+	if !instance.Status.Initialized {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := r.Get(ctx, client.ObjectKeyFromObject(r.Instance), r.Instance); err != nil {
+			if err := r.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 				return err
 			}
-			allMastersReady := builders.AllMastersReady(ctx, r.Client, r.Instance)
+			allMastersReady := builders.AllMastersReady(ctx, r.Client, instance)
 			k8sClient := k8s.NewK8sClient(r.Client, ctx)
-			health, _ := util.GetClusterHealth(k8sClient, ctx, r.Instance, r.Logger)
+			health, _ := util.GetClusterHealth(k8sClient, ctx, instance, logger)
 			clusterReachable := health != opensearchv1.OpenSearchUnknownHealth
-			r.Instance.Status.Initialized = allMastersReady && clusterReachable
-			return r.Status().Update(ctx, r.Instance)
+			instance.Status.Initialized = allMastersReady && clusterReachable
+			return r.Status().Update(ctx, instance)
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
 	// Run through all sub controllers to create or update all needed objects
-	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, r.Instance, r.Instance.Spec.NodePools)
+	reconcilerContext := reconcilers.NewReconcilerContext(r.Recorder, instance, instance.Spec.NodePools)
 
 	tls := reconcilers.NewTLSReconciler(
 		r.Client,
 		ctx,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	securityconfig := reconcilers.NewSecurityconfigReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	config := reconcilers.NewConfigurationReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	cluster := reconcilers.NewClusterReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	if r.SkipClusterRoleBindingManagement {
 		cluster.DisableClusterRoleBindingManagement()
@@ -321,34 +323,34 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	dashboards := reconcilers.NewDashboardsReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	upgrade := reconcilers.NewUpgradeReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	restart := reconcilers.NewRollingRestartReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
 		&reconcilerContext,
-		r.Instance,
+		instance,
 	)
 	snapshotrepository := reconcilers.NewSnapshotRepositoryReconciler(
 		r.Client,
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
 	componentReconcilers := []reconcilers.NamedComponentReconciler{
@@ -372,11 +374,11 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 			if reconcilers.IsTerminal(err) {
 				// Permanent config/validation failure: surface via metrics/logs but
 				// keep running later reconcilers (e.g. bad version must not block restart).
-				helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
-				r.Info("terminal reconciler error, continuing chain", "reconciler", rec.Name, "error", err.Error())
+				helpers.ReconcileErrors.WithLabelValues(instance.Namespace, instance.Name, rec.Name).Inc()
+				logger.Info("terminal reconciler error, continuing chain", "reconciler", rec.Name, "error", err.Error())
 				continue
 			}
-			helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
+			helpers.ReconcileErrors.WithLabelValues(instance.Namespace, instance.Name, rec.Name).Inc()
 			return result, err
 		}
 		// Requeue=true short-circuits so in-progress scaler/upgrade work is exclusive.

--- a/opensearch-operator/controllers/opensearchController_concurrency_test.go
+++ b/opensearch-operator/controllers/opensearchController_concurrency_test.go
@@ -1,0 +1,120 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+)
+
+// Controllers are safe for MaxConcurrentReconciles > 1 only while no
+// per-request state lives on the shared reconciler struct, so guard the
+// struct shapes.
+func TestReconcilerStructsHaveNoPerRequestState(t *testing.T) {
+	forbidden := []reflect.Type{
+		reflect.TypeOf((*opensearchv1.OpenSearchCluster)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchUser)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchRole)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchTenant)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchUserRoleBinding)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchActionGroup)(nil)),
+		reflect.TypeOf((*opensearchv1.OpenSearchISMPolicy)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchIndexTemplate)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchComponentTemplate)(nil)),
+		reflect.TypeOf((*opensearchv1.OpensearchSnapshotPolicy)(nil)),
+		reflect.TypeOf(logr.Logger{}),
+	}
+
+	structs := []any{
+		OpenSearchClusterReconciler{},
+		OpensearchUserReconciler{},
+		OpensearchRoleReconciler{},
+		OpensearchTenantReconciler{},
+		OpensearchUserRoleBindingReconciler{},
+		OpensearchActionGroupReconciler{},
+		OpensearchISMPolicyReconciler{},
+		OpensearchIndexTemplateReconciler{},
+		OpensearchComponentTemplateReconciler{},
+		OpensearchSnapshotPolicyReconciler{},
+	}
+
+	for _, s := range structs {
+		rt := reflect.TypeOf(s)
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			for _, ft := range forbidden {
+				if f.Type == ft {
+					t.Errorf("%s.%s has type %s: per-request state on the shared reconciler is not safe with MaxConcurrentReconciles > 1", rt.Name(), f.Name, ft)
+				}
+			}
+		}
+	}
+}
+
+// Reconcile many distinct clusters at once through one reconciler and check
+// that every cluster ends up with its own finalizer and phase. With per-request
+// state on the shared struct, in-flight reconciles overwrite each other's
+// instance and some clusters never get updated (and `go test -race` flags it).
+func TestClusterReconcilerConcurrentReconcilesDoNotShareState(t *testing.T) {
+	const clusters = 32
+	scheme := runtime.NewScheme()
+	if err := opensearchv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	objs := make([]client.Object, 0, clusters)
+	for i := 0; i < clusters; i++ {
+		objs = append(objs, &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("cluster-%d", i), Namespace: "default"},
+		})
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&opensearchv1.OpenSearchCluster{}).
+		WithObjects(objs...).
+		Build()
+	r := &OpenSearchClusterReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(clusters)}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, clusters)
+	for i := 0; i < clusters; i++ {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}}
+			if _, err := r.Reconcile(context.Background(), req); err != nil {
+				errs <- fmt.Errorf("%s: %w", name, err)
+			}
+		}(objs[i].GetName())
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	for _, o := range objs {
+		got := &opensearchv1.OpenSearchCluster{}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(o), got); err != nil {
+			t.Fatal(err)
+		}
+		if !controllerutil.ContainsFinalizer(got, "Opensearch") {
+			t.Errorf("%s: finalizer missing", got.Name)
+		}
+		if got.Status.Phase != opensearchv1.PhaseRunning {
+			t.Errorf("%s: phase = %q, want %q", got.Name, got.Status.Phase, opensearchv1.PhaseRunning)
+		}
+	}
+}

--- a/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,9 +71,10 @@ func (r *OpensearchComponentTemplateReconciler) Reconcile(ctx context.Context, r
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchComponentTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchComponentTemplateReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchComponentTemplate{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,13 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// OpensearchComponentTemplateReconciler reconciles a OpensearchComponentTemplate object
+// OpensearchComponentTemplateReconciler reconciles a OpensearchComponentTemplate object.
 type OpensearchComponentTemplateReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchComponentTemplate
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchcomponenttemplates,verbs=get;list;watch;create;update;patch;delete
@@ -33,11 +30,11 @@ type OpensearchComponentTemplateReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchComponentTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("componenttemplate", req.NamespacedName)
-	r.Info("Reconciling OpensearchComponentTemplate")
+	logger := log.FromContext(ctx).WithValues("componenttemplate", req.NamespacedName)
+	logger.Info("Reconciling OpensearchComponentTemplate")
 
-	r.Instance = &opensearchv1.OpensearchComponentTemplate{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchComponentTemplate{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -46,24 +43,24 @@ func (r *OpensearchComponentTemplateReconciler) Reconcile(ctx context.Context, r
 		ctx,
 		r.Client,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return componentTemplateReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = componentTemplateReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearch_indextemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_indextemplate_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,9 +71,10 @@ func (r *OpensearchIndexTemplateReconciler) Reconcile(ctx context.Context, req c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchIndexTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchIndexTemplateReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchIndexTemplate{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearch_indextemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_indextemplate_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,13 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// OpensearchIndexTemplateReconciler reconciles a OpensearchIndexTemplate object
+// OpensearchIndexTemplateReconciler reconciles a OpensearchIndexTemplate object.
 type OpensearchIndexTemplateReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchIndexTemplate
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchindextemplates,verbs=get;list;watch;create;update;patch;delete
@@ -33,11 +30,11 @@ type OpensearchIndexTemplateReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchIndexTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("indextemplate", req.NamespacedName)
-	r.Info("Reconciling OpensearchIndexTemplate")
+	logger := log.FromContext(ctx).WithValues("indextemplate", req.NamespacedName)
+	logger.Info("Reconciling OpensearchIndexTemplate")
 
-	r.Instance = &opensearchv1.OpensearchIndexTemplate{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchIndexTemplate{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -46,24 +43,24 @@ func (r *OpensearchIndexTemplateReconciler) Reconcile(ctx context.Context, req c
 		ctx,
 		r.Client,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return indexTemplateReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = indexTemplateReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearchactiongroup_controller.go
+++ b/opensearch-operator/controllers/opensearchactiongroup_controller.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -71,9 +72,10 @@ func (r *OpensearchActionGroupReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchActionGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchActionGroupReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchActionGroup{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchactiongroup_controller.go
+++ b/opensearch-operator/controllers/opensearchactiongroup_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
@@ -16,13 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// OpensearchActionGroupReconciler reconciles a OpensearchActionGroup object
+// OpensearchActionGroupReconciler reconciles a OpensearchActionGroup object.
 type OpensearchActionGroupReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchActionGroup
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchactiongroups,verbs=get;list;watch;create;update;patch;delete
@@ -34,11 +31,11 @@ type OpensearchActionGroupReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchActionGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("actiongroup", req.NamespacedName)
-	r.Info("Reconciling OpensearchActionGroup")
+	logger := log.FromContext(ctx).WithValues("actiongroup", req.NamespacedName)
+	logger.Info("Reconciling OpensearchActionGroup")
 
-	r.Instance = &opensearchv1.OpensearchActionGroup{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchActionGroup{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -47,24 +44,24 @@ func (r *OpensearchActionGroupReconciler) Reconcile(ctx context.Context, req ctr
 		k8s.NewK8sClient(r.Client, ctx),
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return actionGroupReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = actionGroupReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearchism_controller.go
+++ b/opensearch-operator/controllers/opensearchism_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -67,9 +68,10 @@ func (r *OpensearchISMPolicyReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchISMPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchISMPolicyReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpenSearchISMPolicy{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchism_controller.go
+++ b/opensearch-operator/controllers/opensearchism_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,13 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// OpensearchISMReconciler reconciles a ISMPolicy object
+// OpensearchISMPolicyReconciler reconciles a ISMPolicy object.
 type OpensearchISMPolicyReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpenSearchISMPolicy
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchismpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -33,10 +30,11 @@ type OpensearchISMPolicyReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchISMPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("tenant", req.NamespacedName)
-	r.Info("Reconciling OpensearchISMPolicy")
-	r.Instance = &opensearchv1.OpenSearchISMPolicy{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	logger := log.FromContext(ctx).WithValues("tenant", req.NamespacedName)
+	logger.Info("Reconciling OpensearchISMPolicy")
+
+	instance := &opensearchv1.OpenSearchISMPolicy{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -45,23 +43,23 @@ func (r *OpensearchISMPolicyReconciler) Reconcile(ctx context.Context, req ctrl.
 		ctx,
 		r.Client,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return ismReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = ismReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 	return ctrl.Result{}, nil

--- a/opensearch-operator/controllers/opensearchrole_controller.go
+++ b/opensearch-operator/controllers/opensearchrole_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -87,9 +88,10 @@ func (r *OpensearchRoleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchRoleReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchRole{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchrole_controller.go
+++ b/opensearch-operator/controllers/opensearchrole_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,13 +31,11 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 )
 
-// OpensearchRoleReconciler reconciles a OpensearchRole object
+// OpensearchRoleReconciler reconciles a OpensearchRole object.
 type OpensearchRoleReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchRole
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchroles,verbs=get;list;watch;create;update;patch;delete
@@ -50,11 +47,11 @@ type OpensearchRoleReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("role", req.NamespacedName)
-	r.Info("Reconciling OpensearchRole")
+	logger := log.FromContext(ctx).WithValues("role", req.NamespacedName)
+	logger.Info("Reconciling OpensearchRole")
 
-	r.Instance = &opensearchv1.OpensearchRole{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchRole{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -63,24 +60,24 @@ func (r *OpensearchRoleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.Client,
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return roleReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = roleReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
+++ b/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -95,9 +96,10 @@ func (r *OpensearchSnapshotPolicyReconciler) Reconcile(ctx context.Context, req 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchSnapshotPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchSnapshotPolicyReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchSnapshotPolicy{}).
 		Owns(&opensearchv1.OpenSearchCluster{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
+++ b/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
@@ -28,17 +28,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/go-logr/logr"
-
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 )
 
-// OpensearchSnapshotPolicyReconciler reconciles a OpensearchSnapshotPolicy object
+// OpensearchSnapshotPolicyReconciler reconciles a OpensearchSnapshotPolicy object.
 type OpensearchSnapshotPolicyReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
-	Instance *opensearchv1.OpensearchSnapshotPolicy
-	logr.Logger
 	Recorder record.EventRecorder
 }
 
@@ -58,11 +54,11 @@ type OpensearchSnapshotPolicyReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *OpensearchSnapshotPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("snapshotpolicy", req.NamespacedName)
-	r.Info("Reconciling OpensearchSnapshotPolicy")
+	logger := log.FromContext(ctx).WithValues("snapshotpolicy", req.NamespacedName)
+	logger.Info("Reconciling OpensearchSnapshotPolicy")
 
-	r.Instance = &opensearchv1.OpensearchSnapshotPolicy{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchSnapshotPolicy{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -71,24 +67,24 @@ func (r *OpensearchSnapshotPolicyReconciler) Reconcile(ctx context.Context, req 
 		ctx,
 		r.Client,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return snapshotPolicyReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = snapshotPolicyReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearchtenant_controller.go
+++ b/opensearch-operator/controllers/opensearchtenant_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,9 +71,10 @@ func (r *OpensearchTenantReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchTenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchTenantReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchTenant{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchtenant_controller.go
+++ b/opensearch-operator/controllers/opensearchtenant_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,13 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// OpensearchTenantReconciler reconciles a OpensearchTenant object
+// OpensearchTenantReconciler reconciles a OpensearchTenant object.
 type OpensearchTenantReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchTenant
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchtenants,verbs=get;list;watch;create;update;patch;delete
@@ -33,11 +30,11 @@ type OpensearchTenantReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchTenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("tenant", req.NamespacedName)
-	r.Info("Reconciling OpensearchTenant")
+	logger := log.FromContext(ctx).WithValues("tenant", req.NamespacedName)
+	logger.Info("Reconciling OpensearchTenant")
 
-	r.Instance = &opensearchv1.OpensearchTenant{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchTenant{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -46,24 +43,24 @@ func (r *OpensearchTenantReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.Client,
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return tenantReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = tenantReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearchuser_controller.go
+++ b/opensearch-operator/controllers/opensearchuser_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -140,7 +141,7 @@ func (r *OpensearchUserReconciler) handleSecretEvent(_ context.Context, secret c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchUserReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchUser{}).
 		// Get notified when opensearch clusters change
@@ -150,5 +151,6 @@ func (r *OpensearchUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.handleSecretEvent),
 		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchuser_controller.go
+++ b/opensearch-operator/controllers/opensearchuser_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,13 +36,11 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 )
 
-// OpensearchUserReconciler reconciles a OpensearchUser object
+// OpensearchUserReconciler reconciles a OpensearchUser object.
 type OpensearchUserReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchUser
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchusers,verbs=get;list;watch;create;update;patch;delete
@@ -56,11 +53,11 @@ type OpensearchUserReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("user", req.NamespacedName)
-	r.Logger.V(4).Info("Reconciling OpensearchUser")
+	logger := log.FromContext(ctx).WithValues("user", req.NamespacedName)
+	logger.V(4).Info("Reconciling OpensearchUser")
 
-	r.Instance = &opensearchv1.OpensearchUser{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchUser{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -69,24 +66,24 @@ func (r *OpensearchUserReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.Client,
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return userReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = userReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
+++ b/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -87,9 +88,10 @@ func (r *OpensearchUserRoleBindingReconciler) Reconcile(ctx context.Context, req
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpensearchUserRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpensearchUserRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opensearchv1.OpensearchUserRoleBinding{}).
 		Owns(&opensearchv1.OpenSearchCluster{}). // Get notified when opensearch clusters change
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
+++ b/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,13 +31,11 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers"
 )
 
-// OpensearchUserRoleBindingReconciler reconciles a OpensearchUserRoleBinding object
+// OpensearchUserRoleBindingReconciler reconciles a OpensearchUserRoleBinding object.
 type OpensearchUserRoleBindingReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	Instance *opensearchv1.OpensearchUserRoleBinding
-	logr.Logger
 }
 
 //+kubebuilder:rbac:groups=opensearch.org,resources=opensearchuserrolebindings,verbs=get;list;watch;create;update;patch;delete
@@ -50,11 +47,11 @@ type OpensearchUserRoleBindingReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *OpensearchUserRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx).WithValues("userrolebinding", req.NamespacedName)
-	r.Info("Reconciling OpensearchUserRoleBinding")
+	logger := log.FromContext(ctx).WithValues("userrolebinding", req.NamespacedName)
+	logger.Info("Reconciling OpensearchUserRoleBinding")
 
-	r.Instance = &opensearchv1.OpensearchUserRoleBinding{}
-	err := r.Get(ctx, req.NamespacedName, r.Instance)
+	instance := &opensearchv1.OpensearchUserRoleBinding{}
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -63,24 +60,24 @@ func (r *OpensearchUserRoleBindingReconciler) Reconcile(ctx context.Context, req
 		r.Client,
 		ctx,
 		r.Recorder,
-		r.Instance,
+		instance,
 	)
 
-	if r.Instance.DeletionTimestamp.IsZero() {
-		controllerutil.AddFinalizer(r.Instance, OpensearchFinalizer)
-		err = r.Update(ctx, r.Instance)
+	if instance.DeletionTimestamp.IsZero() {
+		controllerutil.AddFinalizer(instance, OpensearchFinalizer)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		return userRoleBindingReconciler.Reconcile()
 	} else {
-		if controllerutil.ContainsFinalizer(r.Instance, OpensearchFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, OpensearchFinalizer) {
 			err = userRoleBindingReconciler.Delete()
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(r.Instance, OpensearchFinalizer)
-			return ctrl.Result{}, r.Update(ctx, r.Instance)
+			controllerutil.RemoveFinalizer(instance, OpensearchFinalizer)
+			return ctrl.Result{}, r.Update(ctx, instance)
 		}
 	}
 

--- a/opensearch-operator/controllers/suite_test.go
+++ b/opensearch-operator/controllers/suite_test.go
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func() {
 		Scheme: scheme.Scheme,
 		//	Instance: &OpensearchCluster,
 		Recorder: record.NewFakeRecorder(20),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, 1)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/opensearch-operator/controllers/suite_test.go
+++ b/opensearch-operator/controllers/suite_test.go
@@ -114,7 +114,9 @@ var _ = BeforeSuite(func() {
 		Scheme: scheme.Scheme,
 		//	Instance: &OpensearchCluster,
 		Recorder: record.NewFakeRecorder(20),
-	}).SetupWithManager(k8sManager, 1)
+		// Run the suite with several workers so that any per-request state that
+		// leaks between concurrently reconciled clusters surfaces in these tests.
+	}).SetupWithManager(k8sManager, 4)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -115,7 +115,7 @@ func main() {
 		"The shared ClusterRole name that grants OpenSearch node-attribute init containers get access to nodes.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Global default max concurrent reconciles for all controllers")
 	flag.StringVar(&maxConcurrentReconcilesPerController, "max-concurrent-reconciles-per-controller", "",
-		"Per-controller max concurrent reconciles overrides (format: controller1=N,controller2=M). Only raise above 1 for controllers that do not store per-request state on the reconciler.")
+		"Per-controller max concurrent reconciles overrides (format: controller1=N,controller2=M)")
 
 	opts := zap.Options{
 		Development: false,
@@ -189,9 +189,14 @@ func main() {
 
 	helpers.RegisterMetrics()
 
+	perController, err := controllers.ParsePerControllerConcurrency(maxConcurrentReconcilesPerController)
+	if err != nil {
+		setupLog.Error(err, "invalid --max-concurrent-reconciles-per-controller")
+		os.Exit(1)
+	}
 	concurrencyConfig := &controllers.ControllerConcurrencyConfig{
 		MaxConcurrentReconciles: maxConcurrentReconciles,
-		PerController:           controllers.ParsePerControllerConcurrency(maxConcurrentReconcilesPerController),
+		PerController:           perController,
 	}
 
 	// Controllers now watch opensearch.org/v1 (new API group)

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -96,6 +96,8 @@ func main() {
 	var logLevel string
 	var manageClusterRoleBindings bool
 	var nodeAttributesClusterRoleName string
+	var maxConcurrentReconciles int
+	var maxConcurrentReconcilesPerController string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -111,6 +113,9 @@ func main() {
 		"Allow the operator to create and delete ClusterRoleBindings for optional features that need cluster-scoped RBAC.")
 	flag.StringVar(&nodeAttributesClusterRoleName, "node-attributes-cluster-role-name", builders.NodeAttributesClusterRoleName,
 		"The shared ClusterRole name that grants OpenSearch node-attribute init containers get access to nodes.")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Global default max concurrent reconciles for all controllers")
+	flag.StringVar(&maxConcurrentReconcilesPerController, "max-concurrent-reconciles-per-controller", "",
+		"Per-controller max concurrent reconciles overrides (format: controller1=N,controller2=M). Only raise above 1 for controllers that do not store per-request state on the reconciler.")
 
 	opts := zap.Options{
 		Development: false,
@@ -184,6 +189,11 @@ func main() {
 
 	helpers.RegisterMetrics()
 
+	concurrencyConfig := &controllers.ControllerConcurrencyConfig{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+		PerController:           controllers.ParsePerControllerConcurrency(maxConcurrentReconcilesPerController),
+	}
+
 	// Controllers now watch opensearch.org/v1 (new API group)
 	// Migration controller handles creating new CRs from old ones
 	if err = (&controllers.OpenSearchClusterReconciler{
@@ -192,7 +202,7 @@ func main() {
 		Recorder:                         mgr.GetEventRecorderFor("containerset-controller"),
 		SkipClusterRoleBindingManagement: !manageClusterRoleBindings,
 		NodeAttributesClusterRoleName:    nodeAttributesClusterRoleName,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameCluster)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenSearchCluster")
 		os.Exit(1)
 	}
@@ -201,7 +211,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("user-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameUser)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchUser")
 		os.Exit(1)
 	}
@@ -209,7 +219,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("role-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameRole)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchRole")
 		os.Exit(1)
 	}
@@ -217,7 +227,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("ism-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameISMPolicy)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchISM")
 		os.Exit(1)
 	}
@@ -225,7 +235,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("tenant-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameTenant)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchTenant")
 		os.Exit(1)
 	}
@@ -233,7 +243,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("userrolebinding-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameUserRoleBinding)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchUserRoleBinding")
 		os.Exit(1)
 	}
@@ -241,7 +251,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("actiongroup-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameActionGroup)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchActionGroup")
 		os.Exit(1)
 	}
@@ -249,7 +259,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("indextemplate-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameIndexTemplate)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchIndexTemplate")
 		os.Exit(1)
 	}
@@ -257,7 +267,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("componenttemplate-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameComponentTemplate)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchComponentTemplate")
 		os.Exit(1)
 	}
@@ -265,7 +275,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("snapshotpolicy-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, concurrencyConfig.GetMaxConcurrentReconciles(controllers.ControllerNameSnapshotPolicy)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpensearchSnapshotPolicy")
 		os.Exit(1)
 	}


### PR DESCRIPTION
### Description
Move per-request cluster/logger state off the shared reconciler struct so MaxConcurrentReconciles > 1 is safe, and add global plus per-controller worker flags. Defaults stay at 1 because the other controllers still store per-request state.

### Issues Resolved
fixes #1333

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
