### PR TITLE
fix(ismpolicy): preserve an explicitly declared empty transitions list

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchismpolicies.yaml
@@ -365,9 +365,9 @@ spec:
                       description: The name of the state.
                       type: string
                     transitions:
-                      description: The next states and the conditions required to
-                        transition to those states. If no transitions exist, the policy
-                        assumes that it’s complete and can now stop managing the index
+                      description: |-
+                        The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it’s complete and can now stop managing the index.
+                        An explicitly declared empty list marks a terminal state and is preserved as such; omitting the field leaves it unset.
                       items:
                         properties:
                           conditions:

--- a/charts/opensearch-operator/files/opensearch.org_opensearchismpolicies.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchismpolicies.yaml
@@ -365,9 +365,9 @@ spec:
                       description: The name of the state.
                       type: string
                     transitions:
-                      description: The next states and the conditions required to
-                        transition to those states. If no transitions exist, the policy
-                        assumes that it's complete and can now stop managing the index
+                      description: |-
+                        The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it's complete and can now stop managing the index.
+                        An explicitly declared empty list marks a terminal state and is preserved as such; omitting the field leaves it unset.
                       items:
                         properties:
                           conditions:

--- a/opensearch-operator/api/opensearch.org/v1/opensearchism_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchism_types.go
@@ -89,8 +89,14 @@ type State struct {
 	Actions []Action `json:"actions"`
 	// The name of the state.
 	Name string `json:"name"`
-	// The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it's complete and can now stop managing the index
-	Transitions []Transition `json:"transitions,omitempty"`
+	// Pointer rather than a plain slice: with `omitempty` a plain slice cannot distinguish an
+	// explicitly declared empty list from an unset field, so the operator's own writes (it adds a
+	// finalizer and calls Update on the whole object) silently dropped `transitions: []`.
+
+	// The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it's complete and can now stop managing the index.
+	// An explicitly declared empty list marks a terminal state and is preserved as such; omitting the field leaves it unset.
+	// +optional
+	Transitions *[]Transition `json:"transitions,omitempty"`
 }
 
 // Actions are the steps that the policy sequentially executes on entering a specific state.

--- a/opensearch-operator/api/opensearch.org/v1/opensearchism_types_test.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchism_types_test.go
@@ -1,0 +1,96 @@
+package v1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression: plain slice + omitempty omitted an explicitly declared empty
+// transitions list, so the operator's own write-back (it adds a finalizer and
+// calls Update on the whole object) silently dropped it and GitOps tooling
+// reported the resource as permanently out of sync. Same class as issue #1172.
+func TestState_JSONRetainsExplicitEmptyTransitions(t *testing.T) {
+	state := State{
+		Name:        "delete",
+		Actions:     []Action{},
+		Transitions: &[]Transition{},
+	}
+
+	b, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	s := string(b)
+	if !strings.Contains(s, `"transitions":[]`) {
+		t.Fatalf(`expected JSON to contain "transitions":[], got: %s`, s)
+	}
+}
+
+func TestState_JSONOmitsUnsetTransitions(t *testing.T) {
+	state := State{
+		Name:    "hot",
+		Actions: []Action{},
+	}
+
+	b, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	s := string(b)
+	if strings.Contains(s, "transitions") {
+		t.Fatalf("expected JSON to omit transitions when unset, got: %s", s)
+	}
+}
+
+// A populated list must still round-trip, and an empty list must survive a
+// decode/encode cycle as an empty list rather than collapsing to unset -- that
+// round-trip is what the API server does on every write.
+func TestState_TransitionsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "explicit empty list survives",
+			in:   `{"actions":[],"name":"delete","transitions":[]}`,
+			want: `"transitions":[]`,
+		},
+		{
+			name: "populated list survives",
+			in:   `{"actions":[],"name":"hot","transitions":[{"stateName":"delete"}]}`,
+			want: `"stateName":"delete"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var state State
+			if err := json.Unmarshal([]byte(tt.in), &state); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			b, err := json.Marshal(state)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(b), tt.want) {
+				t.Fatalf("expected %q in %s", tt.want, b)
+			}
+		})
+	}
+}
+
+// An absent field must decode to nil, not to an empty list, or the distinction
+// the pointer exists to preserve is lost on the first read.
+func TestState_AbsentTransitionsDecodesToNil(t *testing.T) {
+	var state State
+	if err := json.Unmarshal([]byte(`{"actions":[],"name":"hot"}`), &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if state.Transitions != nil {
+		t.Fatalf("expected Transitions to be nil when absent, got %#v", *state.Transitions)
+	}
+}

--- a/opensearch-operator/api/opensearch.org/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/opensearch.org/v1/zz_generated.deepcopy.go
@@ -3208,9 +3208,13 @@ func (in *State) DeepCopyInto(out *State) {
 	}
 	if in.Transitions != nil {
 		in, out := &in.Transitions, &out.Transitions
-		*out = make([]Transition, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = new([]Transition)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]Transition, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
 		}
 	}
 }

--- a/opensearch-operator/api/v1/opensearchism_types.go
+++ b/opensearch-operator/api/v1/opensearchism_types.go
@@ -89,8 +89,14 @@ type State struct {
 	Actions []Action `json:"actions"`
 	// The name of the state.
 	Name string `json:"name"`
-	// The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it’s complete and can now stop managing the index
-	Transitions []Transition `json:"transitions,omitempty"`
+	// Pointer rather than a plain slice: with `omitempty` a plain slice cannot distinguish an
+	// explicitly declared empty list from an unset field, so the operator's own writes (it adds a
+	// finalizer and calls Update on the whole object) silently dropped `transitions: []`.
+
+	// The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it’s complete and can now stop managing the index.
+	// An explicitly declared empty list marks a terminal state and is preserved as such; omitting the field leaves it unset.
+	// +optional
+	Transitions *[]Transition `json:"transitions,omitempty"`
 }
 
 // Actions are the steps that the policy sequentially executes on entering a specific state.

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -3089,9 +3089,13 @@ func (in *State) DeepCopyInto(out *State) {
 	}
 	if in.Transitions != nil {
 		in, out := &in.Transitions, &out.Transitions
-		*out = make([]Transition, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = new([]Transition)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]Transition, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
 		}
 	}
 }

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
@@ -365,9 +365,9 @@ spec:
                       description: The name of the state.
                       type: string
                     transitions:
-                      description: The next states and the conditions required to
-                        transition to those states. If no transitions exist, the policy
-                        assumes that it’s complete and can now stop managing the index
+                      description: |-
+                        The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it’s complete and can now stop managing the index.
+                        An explicitly declared empty list marks a terminal state and is preserved as such; omitting the field leaves it unset.
                       items:
                         properties:
                           conditions:

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchismpolicies.yaml
@@ -365,9 +365,9 @@ spec:
                       description: The name of the state.
                       type: string
                     transitions:
-                      description: The next states and the conditions required to
-                        transition to those states. If no transitions exist, the policy
-                        assumes that it's complete and can now stop managing the index
+                      description: |-
+                        The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it's complete and can now stop managing the index.
+                        An explicitly declared empty list marks a terminal state and is preserved as such; omitting the field leaves it unset.
                       items:
                         properties:
                           conditions:

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -526,8 +526,12 @@ func (r *IsmPolicyReconciler) CreateISMPolicy() (*requests.ISMPolicySpec, error)
 					Alias:         alias,
 				})
 			}
-			transitions := make([]requests.Transition, 0, len(state.Transitions))
-			for _, transition := range state.Transitions {
+			var stateTransitions []opensearchv1.Transition
+			if state.Transitions != nil {
+				stateTransitions = *state.Transitions
+			}
+			transitions := make([]requests.Transition, 0, len(stateTransitions))
+			for _, transition := range stateTransitions {
 				conditions := requests.Condition{}
 				if transition.Conditions.MinDocCount != nil {
 					conditions.MinDocCount = transition.Conditions.MinDocCount


### PR DESCRIPTION
### Description

A state with no transitions is a *terminal* state, which is a different statement from leaving the field unset. `State.Transitions` was a plain slice with `omitempty`, so the two were indistinguishable and `transitions: []` was dropped whenever the object was marshalled through the Go type.

**The path that loses it is the operator's own.** `controllers/opensearchism_controller.go` adds a finalizer and calls `r.Update(ctx, r.Instance)`, which serialises the whole CR through this struct and replaces the stored object without the field. So `kubectl diff` against the original manifest reports a difference on every run, and ArgoCD/Flux report the resource as permanently `OutOfSync` — syncing doesn't help, because the next reconcile drops it again.

The same object has the opposite behaviour one field away: `actions: []` is required, so an empty list *is* stored and must be declared. Two adjacent empty lists, opposite treatment, and no way to tell which is which without applying one and reading it back.

### Why a pointer rather than removing `omitempty`

This mirrors the fix accepted in #1390 for the same class of bug on `SnapshotConfig`'s booleans (#1172).

I tried removing `omitempty` first. It doesn't work: `controller-gen` then marks `transitions` as **required** in the CRD schema, which would reject every existing manifest that omits it — a genuinely breaking change. `*[]Transition` keeps the field optional while making the empty list representable:

| Go value | JSON |
|---|---|
| `nil` | omitted |
| `&[]Transition{}` | `"transitions":[]` |
| populated | unchanged |

The regenerated CRD diff is **only the description text** — the schema is otherwise byte-identical and `transitions` stays out of `required`.

### Blast radius

- **Nothing changes in what is sent to OpenSearch.** The wire type in `opensearch-gateway/requests/IsmPolicy.go` has its own `omitempty` and is built from a freshly allocated slice in `ismpolicy.go`, so an empty list is still omitted from the ISM API request body exactly as before.
- **No spurious reconciles.** The existing-policy comparison at `ismpolicy.go:265` already uses `cmp.Equal(..., cmpopts.EquateEmpty())`, which treats nil and empty as equal.
- Both API groups (`opensearch.opster.io/v1` and `opensearch.org/v1`) are updated, deepcopy regenerated, and the CRD YAML copied into `charts/opensearch-operator/files/`.

### Testing

4 new unit tests in `api/opensearch.org/v1/opensearchism_types_test.go`, following the style of the tests #1390 added for #1172:

- an explicitly declared empty list marshals to `"transitions":[]`
- an unset field is still omitted
- both empty and populated lists survive a decode/encode round-trip (what the API server does on every write)
- an absent field decodes to `nil`, not to an empty list — otherwise the distinction is lost on first read

Verified locally: `go build ./...`, `make manifests`, `make generate`, and `go test ./api/... ./pkg/reconcilers/...` all pass (the ISM reconciler suite included). `golangci-lint` reports an identical set of 8 pre-existing issues on this branch and on unmodified `upstream/main`, none in the files touched here — I couldn't run `make lint` itself because its Docker image wouldn't start locally.

### Issues Resolved

Closes #1514

Worth noting that the same shape may exist elsewhere: `Aliases` at `opensearchism_types.go:146` is the only other `[]…,omitempty` in these types, and other management CRDs may have their own. I kept this PR to the one field that was reported; happy to follow up with a sweep if you'd like.

### Check List
- [x] Commits are signed per the DCO using `--signoff`
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented (CRD field description updated)
- [ ] No linter warnings (`make lint`) — see note above; verified equivalent instead

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented (field description explains that an empty list is preserved)
