### PR TITLE
fix: allow cluster to initialize when http tls is disabled but transport tls is enabled

### DIFF
--- a/docs/designs/security.md
+++ b/docs/designs/security.md
@@ -63,7 +63,29 @@ plugins.security.ssl.http.pemtrustedcas_filepath: tls-http/ca.crt
 plugins.security.allow_unsafe_democertificates: false
 plugins.security.nodes_dn: ["CN=my-cluster"]
 plugins.security.admin_dn: ["CN=my-cluster-admin"]
+plugins.security.allow_default_init_securityindex: true # Only when the securityconfig is applied via default init, see below
 ```
+
+## Applying the securityconfig
+
+The security plugin is considered enabled when TLS is enabled for either the transport or the HTTP endpoint (`IsSecurityPluginEnabled`). Whether the operator can use `securityadmin.sh` to apply the securityconfig is a separate question (`CanRunSecurityAdmin`), because `securityadmin.sh` authenticates with the admin client certificate and therefore needs TLS on the port it connects to:
+
+* OpenSearch >= 2.0: the HTTP port, so HTTP TLS must be enabled
+* OpenSearch < 2.0: the transport port, so transport TLS is sufficient
+
+This yields two paths for getting the securityconfig into the cluster:
+
+| Situation                                                                               | How the securityconfig is applied                                                                                                                                                                                                                                                              |
+|-----------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `securityadmin.sh` can run                                                              | The operator runs the `<cluster-name>-securityconfig-update` job, which invokes `securityadmin.sh` with the admin client certificate. The job is rerun whenever the securityconfig changes.                                                                                                    |
+| Security plugin enabled but `securityadmin.sh` cannot run (HTTP TLS disabled on >= 2.0) | The operator sets `plugins.security.allow_default_init_securityindex: true`, mounts the generated securityconfig secret into the nodes, and lets the security plugin load it into the security index itself when the cluster first forms. No admin certificate and no update job are involved. |
+| Security plugin disabled (no TLS at all)                                                | Securityconfig reconciliation is skipped entirely.                                                                                                                                                                                                                                             |
+
+Consequences of the default-init path:
+
+* The admin certificate is not generated or required, and the webhook does not demand an `adminSecret` or `http.tls.generate: true`.
+* The securityconfig is only read at initial cluster formation. Later changes to the securityconfig secret are not applied automatically, because there is no update job to rerun.
+* The `plugins.security.allow_default_init_securityindex` flag is added before any early return in the securityconfig reconciler, so the node configuration is deterministic from the first reconciliation and does not cause a rolling restart later.
 
 ## Features for Phase 1
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1533,6 +1533,32 @@ If you provided your own certificate for SSL/TLS HTTP, then you must also provid
 
 To apply the securityconfig to the OpenSearch cluster, the Operator uses a separate Kubernetes job (named `<cluster-name>-securityconfig-update`). This job is run during the initial provisioning of the cluster. The Operator also monitors the secret with the securityconfig for any changes and then reruns the update job to apply the new config. Note that the Operator only checks for changes in certain intervals, so it might take a minute or two for the changes to be applied. If the changes are not applied after a few minutes, please use 'kubectl' to check the logs of the pod of the `<cluster-name>-securityconfig-update` job. If you have an error in your configuration it will be reported there.
 
+#### Applying the securityconfig without HTTP TLS
+
+Clusters that enable transport TLS but disable HTTP TLS (`security.tls.http.enabled: false`) are supported, for example when TLS is terminated by a service mesh:
+
+```yaml
+# ...
+spec:
+  general:
+    version: 2.19.4
+  security:
+    tls:
+      transport:
+        generate: true
+        perNode: true
+      http:
+        enabled: false
+# ...
+```
+
+On OpenSearch 2.0 and later `securityadmin.sh` needs TLS on the HTTP port, so in this mode the Operator cannot run the `<cluster-name>-securityconfig-update` job. Instead it sets `plugins.security.allow_default_init_securityindex: true` and mounts the generated securityconfig into the nodes, and the security plugin loads it into the security index itself when the cluster first forms. The admin and `kibanaserver` credentials are generated and hashed into the securityconfig as usual, no admin certificate is required, and the Operator talks to the cluster over plain HTTP.
+
+Limitations of this mode:
+
+- **Changes to the securityconfig secret after the cluster is created are not applied automatically.** The securityconfig is only read once, when the security index is first initialized. To manage users, roles, tenants and action groups on a running cluster use the [Kubernetes resources](#managing-security-configurations-with-kubernetes-resources) or the security plugin REST API. `config.yml` (authentication backends) has no CRD equivalent, so plan for a cluster recreation or keep HTTP TLS enabled if you expect to change it later.
+- There is no `<cluster-name>-securityconfig-update` job to inspect. The `Securityconfig` entry in the cluster's `status.componentsStatus` reports `securityconfig applied via default init`.
+
 ### Authenticating the operator to OpenSearch with mTLS (client certificate)
 
 By default the operator uses HTTP basic auth (`adminCredentialsSecret`) when calling the OpenSearch REST API for tasks like health checks, ISM policy / role / user reconciliation, snapshot management, and node-draining during scale operations. You can instead authenticate the operator's runtime client using a TLS client certificate (mTLS) by setting `security.config.operatorClientCert`.

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -184,7 +184,21 @@ func IsTransportTlsEnabled(cluster *opensearchv1.OpenSearchCluster) bool {
 	return true
 }
 
+// IsSecurityPluginEnabled determines if the security plugin is active in the cluster.
+// The plugin handles both transport and HTTP TLS, so it is active if either is enabled.
+// Note that this does not imply securityadmin can run; see CanRunSecurityAdmin.
 func IsSecurityPluginEnabled(cr *opensearchv1.OpenSearchCluster) bool {
+	return IsHttpTlsEnabled(cr) || IsTransportTlsEnabled(cr)
+}
+
+// CanRunSecurityAdmin determines if securityadmin.sh can be used to manage the
+// securityconfig. securityadmin authenticates with the admin client certificate,
+// which requires TLS on the port it connects to: the HTTP port for OpenSearch >= 2.0,
+// the transport port for earlier versions. When the security plugin is enabled but
+// securityadmin cannot run (HTTP TLS disabled on >= 2.0), the securityconfig is
+// applied through the security plugin's default init instead (see the
+// securityconfig reconciler).
+func CanRunSecurityAdmin(cr *opensearchv1.OpenSearchCluster) bool {
 	if SecurityChangeVersion(cr) {
 		return IsHttpTlsEnabled(cr)
 	}

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -786,3 +786,59 @@ var _ = Describe("Upgrade status helpers", func() {
 		})
 	})
 })
+
+var _ = Describe("IsSecurityPluginEnabled and CanRunSecurityAdmin", func() {
+	makeCluster := func(version string, transport *opensearchv1.TlsConfigTransport, http *opensearchv1.TlsConfigHttp) *opensearchv1.OpenSearchCluster {
+		return &opensearchv1.OpenSearchCluster{
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{Version: version},
+				Security: &opensearchv1.Security{
+					Tls: &opensearchv1.TlsConfig{
+						Transport: transport,
+						Http:      http,
+					},
+				},
+			},
+		}
+	}
+
+	It("should report both disabled without any TLS", func() {
+		cluster := &opensearchv1.OpenSearchCluster{
+			Spec: opensearchv1.ClusterSpec{General: opensearchv1.GeneralConfig{Version: "2.19.4"}},
+		}
+		Expect(IsSecurityPluginEnabled(cluster)).To(BeFalse())
+		Expect(CanRunSecurityAdmin(cluster)).To(BeFalse())
+	})
+
+	It("should report the plugin enabled but securityadmin unavailable with transport TLS only on >= 2.0", func() {
+		cluster := makeCluster("2.19.4", &opensearchv1.TlsConfigTransport{Generate: true}, nil)
+		Expect(IsSecurityPluginEnabled(cluster)).To(BeTrue())
+		Expect(CanRunSecurityAdmin(cluster)).To(BeFalse())
+	})
+
+	It("should report the plugin enabled but securityadmin unavailable with HTTP TLS explicitly disabled on >= 2.0", func() {
+		cluster := makeCluster(
+			"2.19.4",
+			&opensearchv1.TlsConfigTransport{Generate: true},
+			&opensearchv1.TlsConfigHttp{Enabled: ptr.To(false)},
+		)
+		Expect(IsSecurityPluginEnabled(cluster)).To(BeTrue())
+		Expect(CanRunSecurityAdmin(cluster)).To(BeFalse())
+	})
+
+	It("should report both enabled with transport and HTTP TLS on >= 2.0", func() {
+		cluster := makeCluster(
+			"2.19.4",
+			&opensearchv1.TlsConfigTransport{Generate: true},
+			&opensearchv1.TlsConfigHttp{Generate: true},
+		)
+		Expect(IsSecurityPluginEnabled(cluster)).To(BeTrue())
+		Expect(CanRunSecurityAdmin(cluster)).To(BeTrue())
+	})
+
+	It("should report both enabled with transport TLS only on < 2.0 (securityadmin uses the transport port)", func() {
+		cluster := makeCluster("1.3.0", &opensearchv1.TlsConfigTransport{Generate: true}, nil)
+		Expect(IsSecurityPluginEnabled(cluster)).To(BeTrue())
+		Expect(CanRunSecurityAdmin(cluster)).To(BeTrue())
+	})
+})

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -181,6 +181,55 @@ var _ = Describe("Configuration Controller", func() {
 		})
 	})
 
+	Context("When Reconciling with transport TLS enabled but HTTP TLS disabled", func() {
+		It("should configure the security plugin instead of disabling it", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			httpTlsDisabled := false
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{Version: "2.19.4"},
+					Security: &opensearchv1.Security{
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{Generate: true},
+							Http:      &opensearchv1.TlsConfigHttp{Enabled: &httpTlsDisabled},
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles:     []string{"master", "data"},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			mockClient.On("CreateConfigMap", mock.Anything).Return(&ctrl.Result{}, nil)
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+			reconcilerContext.AddConfig("foo", "bar")
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(reconcilerContext.OpenSearchConfig).ToNot(HaveKey("plugins.security.disabled"))
+			Expect(reconcilerContext.OpenSearchConfig).To(HaveKeyWithValue("plugins.security.audit.type", "internal_opensearch"))
+		})
+	})
+
 	Context("When Reconciling with General.Grpc enabled", func() {
 		It("should render valid gRPC settings in opensearch.yml", func() {
 			mockClient := k8s.NewMockK8sClient(GinkgoT())

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -124,25 +124,28 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 		r.logger.Info("Security plugin is disabled, skipping securityconfig reconciliation")
 		return ctrl.Result{}, nil
 	}
+
+	// When securityadmin cannot run (see CanRunSecurityAdmin), the securityconfig is applied
+	// by the security plugin itself when the cluster first forms: the generated securityconfig
+	// secret is mounted into the nodes below, and default init loads it into the security index.
+	// The flag is added before any early return so the node config is deterministic from the
+	// first reconciliation.
+	applyViaDefaultInit := !helpers.CanRunSecurityAdmin(r.instance)
+	if applyViaDefaultInit {
+		r.reconcilerContext.AddConfig("plugins.security.allow_default_init_securityindex", "true")
+	}
+
 	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 
 	var configSecretName string
 	var checksumval string
 	var cmdArg string
 
-	adminCertName := r.determineAdminSecret()
 	namespace := r.instance.Namespace
 	clusterName := r.instance.Name
 	jobName := clusterName + "-securityconfig-update"
 
 	configSecretName = helpers.GeneratedSecurityConfigSecretName(r.instance)
-
-	// TODO(joseb): Check if admin certificate is provided or generated in webhook
-	if adminCertName == "" {
-		err := errors.New("admin certificate neither provided nor generation is enabled")
-		r.logger.Error(err, "Skipping securityconfig reconciliation")
-		return ctrl.Result{}, err
-	}
 
 	adminCredentialsSecret, managedByOperator, err := helpers.EnsureAdminCredentialsSecret(r.client, r.instance)
 	if err != nil {
@@ -201,6 +204,23 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 	if err := r.securityconfigSubpaths(r.instance, &configSecret); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	if applyViaDefaultInit {
+		if err := r.updateSecurityConfigComponentStatus(securityConfigStatusReady, "securityconfig applied via default init", nil); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	adminCertName := r.determineAdminSecret()
+
+	// TODO(joseb): Check if admin certificate is provided or generated in webhook
+	if adminCertName == "" {
+		err := errors.New("admin certificate neither provided nor generation is enabled")
+		r.logger.Error(err, "Skipping securityconfig reconciliation")
+		return ctrl.Result{}, err
+	}
+
 	cmdArg = BuildCmdArg(r.instance, &configSecret, r.logger)
 
 	job, err := r.client.GetJob(jobName, namespace)
@@ -339,12 +359,12 @@ func (r *SecurityconfigReconciler) determineAdminSecret() string {
 			return r.instance.Spec.Security.Config.AdminSecret.Name
 		}
 	}
-	// Webhook validation ensures that if security plugin is enabled and no AdminSecret is provided,
+	// Webhook validation ensures that if securityadmin can run and no AdminSecret is provided,
 	// then TLS Generate must be true. So we can safely return the default admin cert name.
-	if helpers.IsSecurityPluginEnabled(r.instance) {
+	if helpers.CanRunSecurityAdmin(r.instance) {
 		return fmt.Sprintf("%s-admin-cert", r.instance.Name)
 	}
-	// Security plugin is not enabled, no admin cert needed
+	// securityadmin is not used, no admin cert needed
 	return ""
 }
 

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -706,4 +706,80 @@ done;`
 			Expect(cmdArg).To(ContainSubstring("-key /certs/tls.key"))
 		})
 	})
+	When("When Reconciling the securityconfig reconciler with transport TLS enabled but HTTP TLS disabled", func() {
+		It("should apply the securityconfig via default init instead of a securityadmin job", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			var clusterName = "securityconfig-default-init"
+
+			adminCredSecret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: adminCredsName, Namespace: clusterName},
+				Data: map[string][]byte{
+					"username": []byte("admin"),
+					"password": []byte("changeme"),
+				},
+			}
+			httpTlsDisabled := false
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						ServiceName: clusterName,
+						Version:     "2.19.4",
+					},
+					Security: &opensearchv1.Security{
+						Config: &opensearchv1.SecurityConfig{
+							AdminCredentialsSecret: corev1.LocalObjectReference{Name: adminCredsName},
+						},
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{Generate: true},
+							Http:      &opensearchv1.TlsConfigHttp{Enabled: &httpTlsDisabled},
+						},
+					},
+				},
+			}
+			generatedConfigName := helpers.GeneratedSecurityConfigSecretName(&spec)
+			mockClient.EXPECT().GetSecret(adminCredsName, clusterName).Return(adminCredSecret, nil)
+			setupDashboardsCredentialsSecretMocks(mockClient, clusterName)
+			mockClient.On("GetSecret", generatedConfigName, clusterName).Return(corev1.Secret{}, NotFoundError()).Once()
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).Return(nil)
+
+			var generatedConfigSecret *corev1.Secret
+			mockClient.On("ReconcileResource", mock.AnythingOfType("*v1.Secret"), mock.Anything).
+				Return(&ctrl.Result{}, nil).
+				Run(func(args mock.Arguments) {
+					if secret, ok := args[0].(*corev1.Secret); ok && secret.Name == generatedConfigName {
+						generatedConfigSecret = secret.DeepCopy()
+					}
+				})
+			mockClient.On("GetSecret", generatedConfigName, clusterName).
+				Return(func(string, string) corev1.Secret {
+					Expect(generatedConfigSecret).ToNot(BeNil())
+					return *generatedConfigSecret
+				}, nil).Once()
+
+			reconcilerContext := NewReconcilerContext(&record.FakeRecorder{}, &spec, spec.Spec.NodePools)
+			underTest := newSecurityconfigReconciler(
+				mockClient,
+				context.Background(),
+				&reconcilerContext,
+				&spec,
+			)
+			result, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			Expect(reconcilerContext.OpenSearchConfig).To(HaveKeyWithValue("plugins.security.allow_default_init_securityindex", "true"))
+
+			Expect(generatedConfigSecret).ToNot(BeNil())
+			var mountPaths []string
+			for _, mount := range reconcilerContext.VolumeMounts {
+				if mount.Name == "securityconfig" {
+					mountPaths = append(mountPaths, mount.MountPath)
+				}
+			}
+			Expect(mountPaths).ToNot(BeEmpty())
+			Expect(mountPaths).To(ContainElement(ContainSubstring("internal_users.yml")))
+		})
+	})
 })

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -116,7 +116,9 @@ func (r *TLSReconciler) Reconcile() (ctrl.Result, error) {
 		r.reconcilerContext.AddConfig("plugins.security.ssl.certificates_hot_reload.enabled", "true")
 	}
 
-	if helpers.IsSecurityPluginEnabled(r.instance) {
+	// The admin certificate is only used by securityadmin, which requires TLS
+	// on the port it connects to (see CanRunSecurityAdmin).
+	if helpers.CanRunSecurityAdmin(r.instance) {
 		res, err := r.handleAdminCertificate()
 		return lo.FromPtrOr(res, ctrl.Result{}), err
 	}

--- a/opensearch-operator/webhook/opensearch_cluster_webhook.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook.go
@@ -186,7 +186,9 @@ func (v *OpenSearchClusterValidator) validateTlsConfig(cluster *opensearchv1.Ope
 	}
 
 	// Validate admin secret name: if AdminSecret is empty, tls generate should be true.
-	if helpers.IsSecurityPluginEnabled(cluster) {
+	// The admin certificate is only needed when securityadmin is used; with default init
+	// (security plugin enabled but securityadmin unavailable) no admin cert is required.
+	if helpers.CanRunSecurityAdmin(cluster) {
 		if cluster.Spec.Security.Config != nil && cluster.Spec.Security.Config.AdminSecret.Name != "" {
 			return nil, nil
 		} else {

--- a/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
@@ -224,6 +224,71 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(BeEmpty())
 		})
+
+		It("should allow transport TLS with HTTP TLS explicitly disabled and no admin secret", func() {
+			transportEnabled := true
+			httpEnabled := false
+			cluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					Security: &opensearchv1.Security{
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{
+								Enabled:  &transportEnabled,
+								Generate: true,
+							},
+							Http: &opensearchv1.TlsConfigHttp{
+								Enabled: &httpEnabled,
+							},
+						},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should require an admin secret source when securityadmin can run", func() {
+			enabled := true
+			cluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					Security: &opensearchv1.Security{
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{
+								Enabled:  &enabled,
+								Generate: true,
+							},
+							Http: &opensearchv1.TlsConfigHttp{
+								Enabled: &enabled,
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									Secret: corev1.LocalObjectReference{Name: "my-http-tls-secret"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("admin secret name is not provided but http.tls generate is not true"))
+			Expect(warnings).To(BeEmpty())
+		})
 	})
 
 	Describe("ValidateUpdate", func() {


### PR DESCRIPTION
### Description

Builds on #1472 by @beschoenen (rebased onto current `main`, which had diverged after #1302, plus a regression test for the configuration reconciler).

With `security.tls.transport.generate: true` and `security.tls.http.enabled: false` on OpenSearch >= 2.0 the security plugin is active (transport TLS is a security-plugin feature), but `helpers.IsSecurityPluginEnabled` returned `IsHttpTlsEnabled`, i.e. "HTTP TLS off" was treated as "security plugin off". Since #1302 that makes the configuration reconciler write `plugins.security.disabled: true`, so the cluster silently starts with no transport TLS and no authentication. Before #1302 the cluster never initialized ("OpenSearch Security not initialized"), because `securityadmin.sh` needs TLS on the HTTP port on 2.x and the securityconfig job could not seed the security index.

This PR separates the two questions:

- `helpers.IsSecurityPluginEnabled`: transport TLS **or** HTTP TLS is enabled. Used by the configuration reconciler (security defaults vs. `plugins.security.disabled`), the securityconfig reconciler entry check and the Dashboards credentials generation.
- `helpers.CanRunSecurityAdmin` (new, carries the previous `IsSecurityPluginEnabled` logic): HTTP TLS on >= 2.0, transport TLS on < 2.0. Used wherever the admin certificate / `securityadmin.sh` is involved: TLS reconciler (`handleAdminCertificate`), webhook (`validateTlsConfig` admin secret check) and `determineAdminSecret`.

When the plugin is enabled but securityadmin cannot run, the securityconfig reconciler now:

- adds `plugins.security.allow_default_init_securityindex: true` to the node config (before any early return, so the config is stable from the first reconcile),
- generates the securityconfig secret (admin / `kibanaserver` password hashing unchanged) and mounts it into the nodes via the existing `securityconfigSubpaths` (subPath mounts under `<home>/config/opensearch-security/`; files not in the secret fall back to the image defaults, which covers everything default init reads),
- marks the `Securityconfig` component `Ready` with `securityconfig applied via default init` and does not create the update job or require an admin cert.

Existing configurations are unaffected: both TLS on, both off and no `security` block evaluate exactly as before for every caller. The only other combination that changes is HTTP TLS without transport TLS on < 2.0, which now enables the plugin config instead of disabling it; the security plugin requires transport TLS on 1.x, so that configuration was never functional.

Known limitation (documented in the user guide and design doc): in this mode later changes to the securityconfig secret are not re-applied, since there is no `securityadmin.sh` run. Users, roles etc. can still be managed through the CRDs or the REST API.

### Issues Resolved
Closes #1347

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
