### PR TITLE
deprecate: mark 9 non-core CRDs for removal in v4

### DIFF
--- a/charts/opensearch-operator/CHANGELOG.md
+++ b/charts/opensearch-operator/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `enableHotReload` is now a tri-state pointer. Omitting it enables TLS certificate hot reload on OpenSearch 3.x+ (and leaves it off on older versions). Existing 3.x clusters that never set the field take one rolling restart on operator upgrade because `plugins.security.ssl.certificates_hot_reload.enabled` is added to `opensearch.yml`.
 - StatefulSets now use `Parallel` `podManagementPolicy` (was `OrderedReady`). On operator upgrade, existing STS objects are recreated once with orphan propagation; pods are retained and re-adopted. Scaling and rolling operations remain sequenced by the operator.
 ### Deprecated
+- `OpenSearchISMPolicy`, `OpensearchIndexTemplate`, `OpensearchComponentTemplate`, `OpensearchActionGroup`, `OpensearchSnapshotPolicy`, `OpensearchUserRoleBinding`, `OpensearchTenant`, `OpensearchRole`, and `OpensearchUser` CRDs are deprecated and will be removed in v4. The operator is narrowing its scope to core OpenSearch cluster lifecycle management; manage these auxiliary resources with a tool built for declarative OpenSearch config management (e.g. Terraform) instead. See the [migration guide](../../docs/userguide/deprecated-crds-migration.md).
 ### Removed
 - Experimental parallel recovery mode and related Helm/env config (`manager.parallelRecoveryEnabled` / `PARALLEL_RECOVERY_ENABLED`).
 ### Fixed

--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.11
+version: 3.0.12
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -158,4 +158,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `3.0.11`
+Opensearch-operator Helm Chart version: `3.0.12`

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchactiongroups.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchactiongroups.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchactiongroup
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchActionGroup is deprecated and will be removed in
+      v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchActionGroup is the Schema for the opensearchactiongroups

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchcomponenttemplates.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchcomponenttemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchcomponenttemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchComponentTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchComponentTemplate is the schema for the OpenSearch

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchindextemplates.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchindextemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchindextemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchIndexTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchIndexTemplate is the schema for the OpenSearch index

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchismpolicies.yaml
@@ -17,7 +17,10 @@ spec:
     singular: opensearchismpolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpenSearchISMPolicy is deprecated and will be removed in v4
+      of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchroles.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchroles.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchrole
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchRole is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchRole is the Schema for the opensearchroles API

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchsnapshotpolicies.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchsnapshotpolicies.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    deprecated: true
+    deprecationWarning: OpensearchSnapshotPolicy is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
     name: v1
     schema:
       openAPIV3Schema:

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchtenants.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchtenants.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchtenant
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchTenant is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchTenant is the Schema for the opensearchtenants API

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchuserrolebindings.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchuserrolebindings.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuserrolebinding
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUserRoleBinding is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchusers.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchusers.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuser
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUser is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUser is the Schema for the opensearchusers API

--- a/charts/opensearch-operator/files/opensearch.org_opensearchactiongroups.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchactiongroups.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchactiongroup
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchActionGroup is deprecated and will be removed in
+      v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchActionGroup is the Schema for the opensearchactiongroups

--- a/charts/opensearch-operator/files/opensearch.org_opensearchcomponenttemplates.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchcomponenttemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchcomponenttemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchComponentTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchComponentTemplate is the schema for the OpenSearch

--- a/charts/opensearch-operator/files/opensearch.org_opensearchindextemplates.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchindextemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchindextemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchIndexTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchIndexTemplate is the schema for the OpenSearch index

--- a/charts/opensearch-operator/files/opensearch.org_opensearchismpolicies.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchismpolicies.yaml
@@ -17,7 +17,10 @@ spec:
     singular: opensearchismpolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpenSearchISMPolicy is deprecated and will be removed in v4
+      of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/opensearch-operator/files/opensearch.org_opensearchroles.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchroles.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchrole
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchRole is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchRole is the Schema for the opensearchroles API

--- a/charts/opensearch-operator/files/opensearch.org_opensearchsnapshotpolicies.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchsnapshotpolicies.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    deprecated: true
+    deprecationWarning: OpensearchSnapshotPolicy is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
     name: v1
     schema:
       openAPIV3Schema:

--- a/charts/opensearch-operator/files/opensearch.org_opensearchtenants.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchtenants.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchtenant
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchTenant is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchTenant is the Schema for the opensearchtenants API

--- a/charts/opensearch-operator/files/opensearch.org_opensearchuserrolebindings.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchuserrolebindings.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuserrolebinding
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUserRoleBinding is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings

--- a/charts/opensearch-operator/files/opensearch.org_opensearchusers.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchusers.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuser
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUser is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUser is the Schema for the opensearchusers API

--- a/docs/userguide/cluster-chart.md
+++ b/docs/userguide/cluster-chart.md
@@ -38,3 +38,5 @@ By default, the installation will deploy a node pool consisting of three master 
 
 To further customize your OpenSearchCluster installation, you can utilize configuration overrides and modify your `values.yaml`, this allows you to tailor various aspects of the installation to meet your specific requirements.
 Version 3 of the helm chart is designed to have configuration options with the same format and naming as it is defined in the operator doc.
+
+The `users`, `roles`, `usersRoleBinding`, `actionGroups`, `tenants`, `ismPolicies`, `indexTemplates` and `componentTemplates` values render CRDs that are deprecated and will be removed in v4 of the operator. See [Migrating away from the deprecated auxiliary CRDs](deprecated-crds-migration.md).

--- a/docs/userguide/deprecated-crds-migration.md
+++ b/docs/userguide/deprecated-crds-migration.md
@@ -1,0 +1,59 @@
+# Migrating away from the deprecated auxiliary CRDs
+
+The following CRDs are deprecated and will be removed in v4 of the operator:
+`OpensearchUser`, `OpensearchRole`, `OpensearchUserRoleBinding`, `OpensearchActionGroup`, `OpensearchTenant`,
+`OpenSearchISMPolicy`, `OpensearchIndexTemplate`, `OpensearchComponentTemplate` and `OpensearchSnapshotPolicy`.
+
+The operator is narrowing its scope to OpenSearch cluster lifecycle management (`OpenSearchCluster`). Configuration that lives
+inside OpenSearch (security objects, ISM/snapshot policies, templates) is better managed by tools built for that job.
+
+Until v4 these CRDs keep working unchanged. `kubectl` prints a deprecation warning when you create or update them.
+
+## Replacements
+
+| Deprecated CRD | Terraform / OpenTofu ([`opensearch-project/opensearch`](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs)) | OpenSearch REST API | Operator securityconfig secret |
+|---|---|---|---|
+| `OpensearchUser` | `opensearch_user` | `PUT _plugins/_security/api/internalusers/<name>` | `internal_users.yml` |
+| `OpensearchRole` | `opensearch_role` | `PUT _plugins/_security/api/roles/<name>` | `roles.yml` |
+| `OpensearchUserRoleBinding` | `opensearch_roles_mapping` | `PUT _plugins/_security/api/rolesmapping/<role>` | `roles_mapping.yml` |
+| `OpensearchActionGroup` | none, use the REST API | `PUT _plugins/_security/api/actiongroups/<name>` | `action_groups.yml` |
+| `OpensearchTenant` | `opensearch_dashboard_tenant` | `PUT _plugins/_security/api/tenants/<name>` | `tenants.yml` |
+| `OpenSearchISMPolicy` | `opensearch_ism_policy` (+ `opensearch_ism_policy_mapping` for existing indices) | `PUT _plugins/_ism/policies/<id>` (+ `POST _plugins/_ism/add/<index>`) | - |
+| `OpensearchIndexTemplate` | `opensearch_composable_index_template` | `PUT _index_template/<name>` | - |
+| `OpensearchComponentTemplate` | `opensearch_component_template` | `PUT _component_template/<name>` | - |
+| `OpensearchSnapshotPolicy` | `opensearch_sm_policy` | `POST _plugins/_sm/policies/<name>` | - |
+
+- **Terraform / OpenTofu** is the recommended option for GitOps-style management. Every resource above supports
+  `terraform import`, so objects the operator already created can be adopted without recreating them, e.g.
+  `terraform import opensearch_role.sample sample-role`.
+- **REST API** calls can be scripted (e.g. from a Kubernetes `Job` or your CI pipeline). Note that the CRD specs use
+  camelCase field names while the API uses the native snake_case bodies.
+- **Securityconfig secret**: security objects can be defined in the securityconfig secret referenced by
+  `spec.security.config.securityConfigSecret` (see [Securityconfig](main.md#securityconfig)). The secret is applied as a whole,
+  so objects created through the API or Dashboards that are not in the secret are overwritten.
+
+If you still have resources in the legacy `opensearch.opster.io` API group, finish the [API group migration](migration-guide.md) first.
+
+## Handing an object over without deleting it from OpenSearch
+
+**Deleting one of these CRs makes the operator delete the corresponding object from OpenSearch** (unless it already existed
+before the CR was created). Once the replacement tool manages the object, detach the CR as follows.
+
+For `OpensearchRole`, `OpensearchActionGroup`, `OpensearchTenant`, `OpenSearchISMPolicy`, `OpensearchIndexTemplate`,
+`OpensearchComponentTemplate` and `OpensearchSnapshotPolicy`, mark the object as pre-existing (requires kubectl 1.24+). The
+operator then stops updating it and leaves it in place when the CR is deleted:
+
+```bash
+# status field per kind: existingRole, existingActionGroup, existingTenant, existingISMPolicy,
+# existingIndexTemplate, existingComponentTemplate, existingSnapshotPolicy
+kubectl patch opensearchroles.opensearch.org sample-role -n <namespace> \
+  --subresource=status --type=merge -p '{"status":{"existingRole":true}}'
+kubectl delete opensearchroles.opensearch.org sample-role -n <namespace>
+```
+
+`OpensearchUser` and `OpensearchUserRoleBinding` have no such flag: deleting them removes the user, or the binding's users and
+backend roles from the role mappings. Delete the CR and re-apply the object with the new tool right away (e.g. `terraform apply`).
+
+If you deploy clusters with the `opensearch-cluster` Helm chart, these CRs are rendered from the `users`, `roles`,
+`usersRoleBinding`, `actionGroups`, `tenants`, `ismPolicies`, `indexTemplates` and `componentTemplates` values. Removing
+those values deletes the CRs, so apply the steps above before running `helm upgrade` without them.

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1495,7 +1495,7 @@ An important part of any OpenSearch cluster is the user and role management to g
 There are two ways to do that with the operator:
 
 - Defining your own securityconfig
-- Managing users and roles via kubernetes resources
+- Managing users and roles via kubernetes resources (deprecated, see below)
 
 Note that currently a combination of both approaches is not possible. Once you use the CRDs you cannot provide your own securityconfig as those would overwrite each other. We are working on a feature to merge these options.
 
@@ -1641,6 +1641,8 @@ spec:
 - The operator only re-reads the secret on its next reconcile, so a cert rotation triggers a normal reconcile loop.
 
 ### Managing security configurations with kubernetes resources
+
+> **Deprecated:** `OpensearchUser`, `OpensearchRole`, `OpensearchUserRoleBinding`, `OpensearchActionGroup` and `OpensearchTenant` are deprecated and will be removed in v4. See [Migrating away from the deprecated auxiliary CRDs](deprecated-crds-migration.md).
 
 The operator provides custom kubernetes resources that allow you to create/update/manage security configuration resources such as users, roles, action groups etc. as kubernetes objects.
 
@@ -1919,6 +1921,8 @@ You can customize the generated Prometheus `ServiceMonitor` endpoint with relabe
 
 ### Managing ISM policies with Kubernetes resources
 
+> **Deprecated:** `OpenSearchISMPolicy` is deprecated and will be removed in v4. See [Migrating away from the deprecated auxiliary CRDs](deprecated-crds-migration.md).
+
 The operator provides a custom Kubernetes resource that allow you to create/update/manage ISM policies using Kubernetes objects.
 
 It is possible to manage OpenSearch ISM policies in Kubernetes with the operator. Fields in the CRD directly maps to the OpenSearch ISM Policy structure. The operator will not modify policies that already exist. You can create an example policy as follows:
@@ -1959,6 +1963,8 @@ spec:
 The namespace of the `OpenSearchISMPolicy` must be the namespace the OpenSearch cluster itself is deployed in. `policyId` is an optional field, and if not provided `metadata.name` is used as the default.
 
 ## Managing index and component templates
+
+> **Deprecated:** `OpensearchIndexTemplate` and `OpensearchComponentTemplate` are deprecated and will be removed in v4. See [Migrating away from the deprecated auxiliary CRDs](deprecated-crds-migration.md).
 
 The operator provides the OpensearchIndexTemplate and OpensearchComponentTemplate CRDs, which is used for managing index and component templates respectively.
 
@@ -2059,6 +2065,8 @@ Note that the default setting of `applyToExistingIndices` is false and it will b
 When the flag is true, any existing indices in the opensearch cluster with the specified index pattern will have this ism policy applied to it. If multiple ism policies use this with the same index pattern, the priority has to be different between the ism policies.
 
 ## Managing Snapshot Policies with Kubernetes Resources
+
+> **Deprecated:** `OpensearchSnapshotPolicy` is deprecated and will be removed in v4. See [Migrating away from the deprecated auxiliary CRDs](deprecated-crds-migration.md).
 
 The OpenSearch Operator provides a custom Kubernetes resource to create, update, and manage Snapshot Lifecycle Management (SLM) policies using Kubernetes manifests. This makes it possible to declaratively define and control snapshot policies alongside your cluster resources.
 

--- a/opensearch-operator/api/opensearch.org/v1/opensearch_componenttemplate_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_componenttemplate_types.go
@@ -21,6 +21,7 @@ const (
 //+kubebuilder:subresource:status
 
 // OpensearchComponentTemplate is the schema for the OpenSearch component templates API
+// +kubebuilder:deprecatedversion:warning="OpensearchComponentTemplate is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchComponentTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearch_indextemplate_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_indextemplate_types.go
@@ -21,6 +21,7 @@ const (
 //+kubebuilder:subresource:status
 
 // OpensearchIndexTemplate is the schema for the OpenSearch index templates API
+// +kubebuilder:deprecatedversion:warning="OpensearchIndexTemplate is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchIndexTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchactiongroup_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchactiongroup_types.go
@@ -36,6 +36,7 @@ type OpensearchActionGroupStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchActionGroup is the Schema for the opensearchactiongroups API
+// +kubebuilder:deprecatedversion:warning="OpensearchActionGroup is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchActionGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchism_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchism_types.go
@@ -30,6 +30,7 @@ type OpensearchISMPolicyStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=ismp;ismpolicy
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="OpenSearchISMPolicy is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpenSearchISMPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchrole_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchrole_types.go
@@ -65,6 +65,7 @@ type OpensearchRoleStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchRole is the Schema for the opensearchroles API
+// +kubebuilder:deprecatedversion:warning="OpensearchRole is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchsnapshotpolicy_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchsnapshotpolicy_types.go
@@ -117,6 +117,7 @@ type OpensearchSnapshotPolicyStatus struct {
 // +kubebuilder:printcolumn:name="policyName",type="string",JSONPath=".status.snapshotPolicyName",description="Snapshot policy name"
 // +kubebuilder:printcolumn:name="state",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion:warning="OpensearchSnapshotPolicy is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchSnapshotPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchtenant_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchtenant_types.go
@@ -34,6 +34,7 @@ type OpensearchTenantStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchTenant is the Schema for the opensearchtenants API
+// +kubebuilder:deprecatedversion:warning="OpensearchTenant is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchTenant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchuser_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchuser_types.go
@@ -51,6 +51,7 @@ type OpensearchUserStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchUser is the Schema for the opensearchusers API
+// +kubebuilder:deprecatedversion:warning="OpensearchUser is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/opensearch.org/v1/opensearchuserrolebinding_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearchuserrolebinding_types.go
@@ -53,6 +53,7 @@ type OpensearchUserRoleBindingStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings API
+// +kubebuilder:deprecatedversion:warning="OpensearchUserRoleBinding is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchUserRoleBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearch_componenttemplate_types.go
+++ b/opensearch-operator/api/v1/opensearch_componenttemplate_types.go
@@ -21,6 +21,7 @@ const (
 //+kubebuilder:subresource:status
 
 // OpensearchComponentTemplate is the schema for the OpenSearch component templates API
+// +kubebuilder:deprecatedversion:warning="OpensearchComponentTemplate is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchComponentTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearch_indextemplate_types.go
+++ b/opensearch-operator/api/v1/opensearch_indextemplate_types.go
@@ -21,6 +21,7 @@ const (
 //+kubebuilder:subresource:status
 
 // OpensearchIndexTemplate is the schema for the OpenSearch index templates API
+// +kubebuilder:deprecatedversion:warning="OpensearchIndexTemplate is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchIndexTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchactiongroup_types.go
+++ b/opensearch-operator/api/v1/opensearchactiongroup_types.go
@@ -36,6 +36,7 @@ type OpensearchActionGroupStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchActionGroup is the Schema for the opensearchactiongroups API
+// +kubebuilder:deprecatedversion:warning="OpensearchActionGroup is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchActionGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchism_types.go
+++ b/opensearch-operator/api/v1/opensearchism_types.go
@@ -30,6 +30,7 @@ type OpensearchISMPolicyStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=ismp;ismpolicy
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="OpenSearchISMPolicy is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpenSearchISMPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchrole_types.go
+++ b/opensearch-operator/api/v1/opensearchrole_types.go
@@ -65,6 +65,7 @@ type OpensearchRoleStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchRole is the Schema for the opensearchroles API
+// +kubebuilder:deprecatedversion:warning="OpensearchRole is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchsnapshotpolicy_types.go
+++ b/opensearch-operator/api/v1/opensearchsnapshotpolicy_types.go
@@ -117,6 +117,7 @@ type OpensearchSnapshotPolicyStatus struct {
 // +kubebuilder:printcolumn:name="policyName",type="string",JSONPath=".status.snapshotPolicyName",description="Snapshot policy name"
 // +kubebuilder:printcolumn:name="state",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:deprecatedversion:warning="OpensearchSnapshotPolicy is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchSnapshotPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchtenant_types.go
+++ b/opensearch-operator/api/v1/opensearchtenant_types.go
@@ -34,6 +34,7 @@ type OpensearchTenantStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchTenant is the Schema for the opensearchtenants API
+// +kubebuilder:deprecatedversion:warning="OpensearchTenant is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchTenant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchuser_types.go
+++ b/opensearch-operator/api/v1/opensearchuser_types.go
@@ -51,6 +51,7 @@ type OpensearchUserStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchUser is the Schema for the opensearchusers API
+// +kubebuilder:deprecatedversion:warning="OpensearchUser is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/api/v1/opensearchuserrolebinding_types.go
+++ b/opensearch-operator/api/v1/opensearchuserrolebinding_types.go
@@ -53,6 +53,7 @@ type OpensearchUserRoleBindingStatus struct {
 //+kubebuilder:subresource:status
 
 // OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings API
+// +kubebuilder:deprecatedversion:warning="OpensearchUserRoleBinding is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator."
 type OpensearchUserRoleBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchactiongroups.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchactiongroups.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchactiongroup
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchActionGroup is deprecated and will be removed in
+      v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchActionGroup is the Schema for the opensearchactiongroups

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchcomponenttemplates.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchcomponenttemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchcomponenttemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchComponentTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchComponentTemplate is the schema for the OpenSearch

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchindextemplates.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchindextemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchindextemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchIndexTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchIndexTemplate is the schema for the OpenSearch index

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchismpolicies.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchismpolicies.yaml
@@ -17,7 +17,10 @@ spec:
     singular: opensearchismpolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpenSearchISMPolicy is deprecated and will be removed in v4
+      of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchroles.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchroles.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchrole
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchRole is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchRole is the Schema for the opensearchroles API

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchsnapshotpolicies.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchsnapshotpolicies.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    deprecated: true
+    deprecationWarning: OpensearchSnapshotPolicy is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
     name: v1
     schema:
       openAPIV3Schema:

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchtenants.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchtenants.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchtenant
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchTenant is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchTenant is the Schema for the opensearchtenants API

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchuserrolebindings.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchuserrolebindings.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuserrolebinding
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUserRoleBinding is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchusers.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchusers.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuser
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUser is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUser is the Schema for the opensearchusers API

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchactiongroups.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchactiongroups.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchactiongroup
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchActionGroup is deprecated and will be removed in
+      v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchActionGroup is the Schema for the opensearchactiongroups

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchcomponenttemplates.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchcomponenttemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchcomponenttemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchComponentTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchComponentTemplate is the schema for the OpenSearch

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchindextemplates.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchindextemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchindextemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchIndexTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchIndexTemplate is the schema for the OpenSearch index

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
@@ -17,7 +17,10 @@ spec:
     singular: opensearchismpolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpenSearchISMPolicy is deprecated and will be removed in v4
+      of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchroles.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchroles.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchrole
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchRole is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchRole is the Schema for the opensearchroles API

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchsnapshotpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchsnapshotpolicies.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    deprecated: true
+    deprecationWarning: OpensearchSnapshotPolicy is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
     name: v1
     schema:
       openAPIV3Schema:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchtenants.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchtenants.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchtenant
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchTenant is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchTenant is the Schema for the opensearchtenants API

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchuserrolebindings.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchuserrolebindings.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuserrolebinding
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUserRoleBinding is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchusers.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchusers.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuser
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUser is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUser is the Schema for the opensearchusers API

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchactiongroups.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchactiongroups.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchactiongroup
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchActionGroup is deprecated and will be removed in
+      v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchActionGroup is the Schema for the opensearchactiongroups

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchcomponenttemplates.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchcomponenttemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchcomponenttemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchComponentTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchComponentTemplate is the schema for the OpenSearch

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchindextemplates.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchindextemplates.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchindextemplate
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchIndexTemplate is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchIndexTemplate is the schema for the OpenSearch index

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchismpolicies.yaml
@@ -17,7 +17,10 @@ spec:
     singular: opensearchismpolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpenSearchISMPolicy is deprecated and will be removed in v4
+      of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchroles.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchroles.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchrole
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchRole is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchRole is the Schema for the opensearchroles API

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchsnapshotpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchsnapshotpolicies.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    deprecated: true
+    deprecationWarning: OpensearchSnapshotPolicy is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
     name: v1
     schema:
       openAPIV3Schema:

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchtenants.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchtenants.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchtenant
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchTenant is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchTenant is the Schema for the opensearchtenants API

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchuserrolebindings.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchuserrolebindings.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuserrolebinding
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUserRoleBinding is deprecated and will be removed
+      in v4 of the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchusers.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchusers.yaml
@@ -16,7 +16,10 @@ spec:
     singular: opensearchuser
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: OpensearchUser is deprecated and will be removed in v4 of
+      the OpenSearch Kubernetes Operator.
+    name: v1
     schema:
       openAPIV3Schema:
         description: OpensearchUser is the Schema for the opensearchusers API

--- a/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_componenttemplate_controller.go
@@ -38,6 +38,7 @@ func (r *OpensearchComponentTemplateReconciler) Reconcile(ctx context.Context, r
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchComponentTemplate is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	componentTemplateReconciler := reconcilers.NewComponentTemplateReconciler(
 		ctx,

--- a/opensearch-operator/controllers/opensearch_indextemplate_controller.go
+++ b/opensearch-operator/controllers/opensearch_indextemplate_controller.go
@@ -38,6 +38,7 @@ func (r *OpensearchIndexTemplateReconciler) Reconcile(ctx context.Context, req c
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchIndexTemplate is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	indexTemplateReconciler := reconcilers.NewIndexTemplateReconciler(
 		ctx,

--- a/opensearch-operator/controllers/opensearchactiongroup_controller.go
+++ b/opensearch-operator/controllers/opensearchactiongroup_controller.go
@@ -39,6 +39,7 @@ func (r *OpensearchActionGroupReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchActionGroup is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	actionGroupReconciler := reconcilers.NewActionGroupReconciler(
 		k8s.NewK8sClient(r.Client, ctx),

--- a/opensearch-operator/controllers/opensearchism_controller.go
+++ b/opensearch-operator/controllers/opensearchism_controller.go
@@ -38,6 +38,7 @@ func (r *OpensearchISMPolicyReconciler) Reconcile(ctx context.Context, req ctrl.
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpenSearchISMPolicy is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	ismReconciler := reconcilers.NewIsmReconciler(
 		ctx,

--- a/opensearch-operator/controllers/opensearchrole_controller.go
+++ b/opensearch-operator/controllers/opensearchrole_controller.go
@@ -55,6 +55,7 @@ func (r *OpensearchRoleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchRole is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	roleReconciler := reconcilers.NewRoleReconciler(
 		r.Client,

--- a/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
+++ b/opensearch-operator/controllers/opensearchsnapshotpolicy_controller.go
@@ -62,6 +62,7 @@ func (r *OpensearchSnapshotPolicyReconciler) Reconcile(ctx context.Context, req 
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchSnapshotPolicy is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	snapshotPolicyReconciler := reconcilers.NewSnapshotPolicyReconciler(
 		ctx,

--- a/opensearch-operator/controllers/opensearchtenant_controller.go
+++ b/opensearch-operator/controllers/opensearchtenant_controller.go
@@ -38,6 +38,7 @@ func (r *OpensearchTenantReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchTenant is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	tenantReconciler := reconcilers.NewTenantReconciler(
 		r.Client,

--- a/opensearch-operator/controllers/opensearchuser_controller.go
+++ b/opensearch-operator/controllers/opensearchuser_controller.go
@@ -61,6 +61,7 @@ func (r *OpensearchUserReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchUser is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	userReconciler := reconcilers.NewUserReconciler(
 		r.Client,

--- a/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
+++ b/opensearch-operator/controllers/opensearchuserrolebinding_controller.go
@@ -55,6 +55,7 @@ func (r *OpensearchUserRoleBindingReconciler) Reconcile(ctx context.Context, req
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	logger.V(4).Info("OpensearchUserRoleBinding is deprecated and will be removed in v4 of the OpenSearch Kubernetes Operator")
 
 	userRoleBindingReconciler := reconcilers.NewUserRoleBindingReconciler(
 		r.Client,


### PR DESCRIPTION
## Summary

Marks the 9 non-core CRDs as deprecated, targeted for removal in v4 of the operator:
`OpenSearchISMPolicy`, `OpensearchIndexTemplate`, `OpensearchComponentTemplate`, `OpensearchActionGroup`, `OpensearchSnapshotPolicy`, `OpensearchUserRoleBinding`, `OpensearchTenant`, `OpensearchRole`, `OpensearchUser`.

- `spec.versions[].deprecated` / `deprecationWarning` set on each CRD version, in both the `opensearch.opster.io` (legacy) and `opensearch.org` (current) API groups. `kubectl`/API clients will now surface a deprecation warning whenever these resources are created or updated.
- Each of the 9 controllers now logs a deprecation warning on every reconcile.
- `CHANGELOG.md` updated with a `Deprecated` entry.

## Why

The operator is narrowing its scope to core OpenSearch cluster lifecycle management, following the pattern of most database operators, which manage only the core database resource and leave auxiliary/declarative config (index templates, users, roles, action groups, tenants, snapshot policies, etc.) to tools purpose-built for that job with better GitOps support (e.g. Terraform). Keeping these 9 CRDs in the operator makes it harder to focus and evolve the core cluster-management functionality.

## Issues/PRs to close once this merges

These are all open issues/PRs about the 9 CRDs being deprecated here — once this lands (and eventually the CRDs are removed in v4), they become moot and should be closed as won't-fix/superseded:

**OpenSearchISMPolicy**
- #1514 – OpenSearchISMPolicy: an explicitly declared empty `transitions: []` is dropped
- #1234 – opensearch-cluster Helm chart template missing support for applyToExistingIndices
- #732 – `OpenSearchISMPolicy` doesn't work
- #1443 – Operator ignores errorNotification channel in OpenSearchISMPolicy
- #1056 – CRD ISM policy blocks are not functional
- #829 – ISM CRD allocation action is broken
- #1392 – New ISM action convert_index_to_remote is not supported
- #946 – make OpenSearchISMPolicy support email channel notification
- #1517 – fix(ismpolicy): preserve an explicitly declared empty transitions list
- #1480 – fix(ismpolicy): allow errorNotification channel without destination
- #1412 – fix: ISM CRD allocation action types
- #1402 – fr: add convert_index_to_remote action support for ISM policies

**OpensearchIndexTemplate / OpensearchComponentTemplate**
- #869 – [PROPOSAL] Delete unmanaged indextemplates and ISM policies
- #1050 – name conflict in index/component template for multiple clusters

**OpensearchSnapshotPolicy**
- #1413 – SnapshotPolicy reconcile loop prevents scheduled snapshots from running

**OpensearchUser / OpensearchRole / OpensearchUserRoleBinding**
- #254 – OpensearchUser,Role,RoleBinding resources are not re-applied after SecurityConfig reconciliation
- #839 – Security config handling means either API/Dashboard-created Users are deleted or you're stuck with default admin credentials
- #1383 – Add `spec.username` field to OpensearchUser CR to decouple K8s resource name from OpenSearch username
- #1513 – Make the securityconfig-update job optional (loosely related — touches how Users/Roles get applied)

**Cross-cutting**
- #677 – Some CRDs has wrong names.kind (mostly about the peripheral CRDs' naming inconsistency)

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./controllers/... ./api/...` pass (envtest)
- [x] `make manifests` regenerated CRDs with `deprecated: true` / `deprecationWarning` set for all 18 (9 kinds × 2 API groups) affected CRD files
- [x] `charts/opensearch-operator/files/*.yaml` and `bundle/manifests/*.yaml` re-synced from `config/crd/bases/` and confirmed byte-identical