### PR TITLE
fix: don't leak last-applied annotation into pod templates; pin dashboards rollingUpdate

### DIFF
--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 /// Package that declare and build all the resources that related to the OpenSearch-Dashboard ///
@@ -139,6 +140,12 @@ func NewDashboardsDeploymentForCR(cr *opensearchv1.OpenSearchCluster, volumes []
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				// Match the API server defaults explicitly; leaving rollingUpdate unset
+				// makes the three-way patch non-empty on every reconcile.
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       ptr.To(intstr.FromString("25%")),
+					MaxUnavailable: ptr.To(intstr.FromString("25%")),
+				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/opensearch-operator/pkg/builders/dashboards_envtest_test.go
+++ b/opensearch-operator/pkg/builders/dashboards_envtest_test.go
@@ -1,0 +1,46 @@
+package builders
+
+import (
+	"context"
+
+	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/patch"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Dashboards deployment against the API server", func() {
+	It("is in sync right after creation and keeps the pod template clean", func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dashboards-sync"}}
+		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "foobar", Namespace: ns.Name},
+			Spec: opensearchv1.ClusterSpec{
+				General:    opensearchv1.GeneralConfig{Version: "2.11.0"},
+				Dashboards: opensearchv1.DashboardsConfig{Enable: true, Version: "2.11.0", Replicas: 1},
+			},
+		}
+		build := func() *appsv1.Deployment {
+			return NewDashboardsDeploymentForCR(cr, nil, nil, map[string]string{"checksum": "abc"})
+		}
+
+		desired := build()
+		Expect(patch.DefaultAnnotator.SetLastAppliedAnnotation(desired)).To(Succeed())
+		Expect(desired.Spec.Template.Annotations).NotTo(HaveKey(patch.LastAppliedConfig))
+		Expect(k8sClient.Create(context.Background(), desired)).To(Succeed())
+
+		current := &appsv1.Deployment{}
+		Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(desired), current)).To(Succeed())
+		Expect(current.Spec.Template.Annotations).NotTo(HaveKey(patch.LastAppliedConfig))
+
+		result, err := patch.DefaultPatchMaker.Calculate(current, build(), patch.IgnoreStatusFields())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsEmpty()).To(BeTrue(), "unexpected patch: %s", string(result.Patch))
+	})
+})

--- a/opensearch-operator/pkg/patch/annotation.go
+++ b/opensearch-operator/pkg/patch/annotation.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
+	"maps"
 	"net/http"
 
 	json "github.com/json-iterator/go"
@@ -83,11 +84,14 @@ func (a *Annotator) SetOriginalConfiguration(obj runtime.Object, original []byte
 		return nil
 	}
 
-	annots, err := a.metadataAccessor.Annotations(obj)
+	existing, err := a.metadataAccessor.Annotations(obj)
 	if err != nil {
 		return err
 	}
 
+	// Never mutate the object's map in place: builders may share it with the pod
+	// template, and the annotation must not leak into the latter.
+	annots := maps.Clone(existing)
 	if annots == nil {
 		annots = map[string]string{}
 	}
@@ -117,27 +121,26 @@ func (a *Annotator) GetModifiedConfiguration(obj runtime.Object, annotate bool) 
 	var modified []byte
 
 	// Otherwise, use the server side version of the object.
-	// Get the current annotations from the object.
-	annots, err := a.metadataAccessor.Annotations(obj)
+	// Get the current annotations from the object. Work on a copy so the
+	// object's own map (possibly shared with a pod template) is never mutated.
+	originalAnnots, err := a.metadataAccessor.Annotations(obj)
 	if err != nil {
 		return nil, err
 	}
 
+	annots := maps.Clone(originalAnnots)
 	if annots == nil {
 		annots = map[string]string{}
 	}
-
-	original := annots[a.key]
 	delete(annots, a.key)
-	if err := a.metadataAccessor.SetAnnotations(obj, annots); err != nil {
-		return nil, err
-	}
 
 	// Do not include an empty annotation map
 	if len(annots) == 0 {
 		if err := a.metadataAccessor.SetAnnotations(obj, nil); err != nil {
 			return nil, err
 		}
+	} else if err := a.metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
 	}
 
 	modified, err = json.ConfigCompatibleWithStandardLibrary.Marshal(obj)
@@ -161,8 +164,7 @@ func (a *Annotator) GetModifiedConfiguration(obj runtime.Object, annotate bool) 
 	}
 
 	// Restore the object to its original condition.
-	annots[a.key] = original
-	if err := a.metadataAccessor.SetAnnotations(obj, annots); err != nil {
+	if err := a.metadataAccessor.SetAnnotations(obj, originalAnnots); err != nil {
 		return nil, err
 	}
 

--- a/opensearch-operator/pkg/patch/annotation_test.go
+++ b/opensearch-operator/pkg/patch/annotation_test.go
@@ -18,6 +18,9 @@ import (
 	"crypto/rand"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -102,5 +105,27 @@ func TestSetOriginalConfigurationSetsNormalSizedAnnotation(t *testing.T) {
 	}
 	if string(retrieved) != string(normalData) {
 		t.Fatalf("Expected retrieved data to match original, got: %s", string(retrieved))
+	}
+}
+
+func TestSetLastAppliedAnnotationDoesNotLeakIntoPodTemplate(t *testing.T) {
+	shared := map[string]string{"foo": "bar"}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: shared},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: shared}},
+		},
+	}
+	if err := DefaultAnnotator.SetLastAppliedAnnotation(d); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := d.Annotations[LastAppliedConfig]; !ok {
+		t.Fatal("expected annotation on object metadata")
+	}
+	if _, ok := d.Spec.Template.Annotations[LastAppliedConfig]; ok {
+		t.Fatal("annotation leaked into pod template")
+	}
+	if _, ok := shared[LastAppliedConfig]; ok {
+		t.Fatal("caller's annotations map was mutated")
 	}
 }


### PR DESCRIPTION
### Description

Fixes #1522. The Dashboards Deployment got two ReplicaSets within a second of cluster creation because the pod template changed between the first and second reconcile.

**Root cause**

1. `Annotator.GetModifiedConfiguration` / `SetOriginalConfiguration` (`pkg/patch/annotation.go`) mutated the object's annotations map in place. `NewDashboardsDeploymentForCR` and `NewSTSForNodePool` share the same map between `ObjectMeta.Annotations` and `Spec.Template.Annotations`, so `opensearch.org/last-applied` leaked into the created pod template. The next full `Update` rebuilt the object with a fresh map and dropped it, changing the template hash.
2. The Deployment set `Strategy.Type: RollingUpdate` without `rollingUpdate`. The API server defaults `maxSurge`/`maxUnavailable`, and since `DeploymentStrategy` uses `patchStrategy: retainKeys` the three-way patch was `{"spec":{"strategy":{"$retainKeys":["type"],"rollingUpdate":null}}}` on every reconcile, so an `Update` was issued every time.

**Fix**

- The annotator now works on a copy of the annotations map and restores the original map object afterwards. This fixes all builders at once (Deployment and every node-pool StatefulSet) rather than patching each call site. As a side effect it also no longer writes an empty `opensearch.org/last-applied: ""` key on restore when the object had none.
- The Dashboards Deployment sets `rollingUpdate.maxSurge/maxUnavailable` explicitly to the API defaults (`25%`), so the desired object matches the server state.

**Tests**

- `TestSetLastAppliedAnnotationDoesNotLeakIntoPodTemplate` (unit): a Deployment sharing one map between metadata and template gets the annotation on metadata only.
- New envtest case in `pkg/builders`: builds the Dashboards Deployment, sets the last-applied annotation, creates it against the API server, and asserts the stored pod template has no leaked annotation and `PatchMaker.Calculate` returns an empty patch. Verified each assertion fails without its half of the fix (reproducing the exact patch from the issue).
- Full `go test ./...` passes.

### Issues Resolved

Fixes #1522

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
