### PR TITLE
fix: recover from ImagePullBackOff on upgrade abort and stop scaler gate starving upgrade/restart reconcilers

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -912,47 +912,61 @@ func WorkingPodForRollingRestart(k8sClient k8s.K8sClient, sts *appsv1.StatefulSe
 	return "", errors.New("unable to calculate the working pod for rolling restart")
 }
 
-// DeleteStuckPodWithOlderRevision deletes a CrashLoopBackOff pod that is still on an older
-// StatefulSet revision so the update can proceed. Returns the deleted pod name when a delete occurs.
+// stuckWaitingReasons are container waiting reasons a pod does not recover from on its own.
+// A pod on a stale StatefulSet revision in one of these states is safe to delete because
+// the StatefulSet recreates it from the current template (issue #1531).
+var stuckWaitingReasons = map[string]bool{
+	"CrashLoopBackOff": true,
+	"ImagePullBackOff": true,
+	"ErrImagePull":     true,
+	"InvalidImageName": true,
+}
+
+// StuckContainerReason returns the waiting reason of the first non-ready container that is
+// stuck in a non-recoverable state, or "" if the pod is not stuck.
+func StuckContainerReason(pod *corev1.Pod) string {
+	for _, container := range pod.Status.ContainerStatuses {
+		if !container.Ready && container.State.Waiting != nil && stuckWaitingReasons[container.State.Waiting.Reason] {
+			return container.State.Waiting.Reason
+		}
+	}
+	return ""
+}
+
+// DeleteStuckPodWithOlderRevision deletes a stuck pod (see StuckContainerReason) that is still on an
+// older StatefulSet revision so the update can proceed. Returns the deleted pod name when a delete occurs.
 func DeleteStuckPodWithOlderRevision(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) (string, error) {
 	podWithOlderRevision, err := GetPodWithOlderRevision(k8sClient, sts)
 	if err != nil {
 		return "", err
 	}
-	if podWithOlderRevision != nil {
-		for _, container := range podWithOlderRevision.Status.ContainerStatuses {
-			// If any container is getting crashed, restart it by deleting the pod so that new update in sts can take place.
-			if !container.Ready && container.State.Waiting != nil && container.State.Waiting.Reason == "CrashLoopBackOff" {
-				err := k8sClient.DeletePod(&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podWithOlderRevision.Name,
-						Namespace: sts.Namespace,
-					},
-				})
-				if err != nil {
-					return "", err
-				}
-				return podWithOlderRevision.Name, nil
-			}
-		}
+	if podWithOlderRevision == nil || StuckContainerReason(podWithOlderRevision) == "" {
+		return "", nil
 	}
-	return "", nil
+	err = k8sClient.DeletePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podWithOlderRevision.Name,
+			Namespace: sts.Namespace,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return podWithOlderRevision.Name, nil
 }
 
-// CrashLoopBackOffPods returns names of pods in the StatefulSet that have a container in CrashLoopBackOff.
-func CrashLoopBackOffPods(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) ([]string, error) {
-	var pods []string
+// StuckPods returns the pods in the StatefulSet that have a stuck container (see
+// StuckContainerReason), keyed by pod name with the waiting reason as value.
+func StuckPods(k8sClient k8s.K8sClient, sts *appsv1.StatefulSet) (map[string]string, error) {
+	pods := map[string]string{}
 	for i := int32(0); i < lo.FromPtrOr(sts.Spec.Replicas, 1); i++ {
 		podName := ReplicaHostName(*sts, i)
 		pod, err := k8sClient.GetPod(podName, sts.Namespace)
 		if err != nil {
 			return nil, err
 		}
-		for _, container := range pod.Status.ContainerStatuses {
-			if !container.Ready && container.State.Waiting != nil && container.State.Waiting.Reason == "CrashLoopBackOff" {
-				pods = append(pods, pod.Name)
-				break
-			}
+		if reason := StuckContainerReason(&pod); reason != "" {
+			pods[pod.Name] = reason
 		}
 	}
 	return pods, nil

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	k8smocks "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/stretchr/testify/mock"
 	"gopkg.in/yaml.v2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -784,5 +785,56 @@ var _ = Describe("Upgrade status helpers", func() {
 			}
 			Expect(IsUpgradeInProgress(status)).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("Stuck pod handling (issue #1531)", func() {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "c-nodes", Namespace: "ns"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](2)},
+		Status:     appsv1.StatefulSetStatus{UpdateRevision: "rev-new"},
+	}
+	pod := func(name, revision, waitingReason string) corev1.Pod {
+		p := corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "ns", Labels: map[string]string{stsRevisionLabel: revision},
+		}}
+		if waitingReason != "" {
+			p.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Ready: false,
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: waitingReason}},
+			}}
+		} else {
+			p.Status.ContainerStatuses = []corev1.ContainerStatus{{Ready: true}}
+		}
+		return p
+	}
+
+	It("deletes an older-revision pod stuck in ImagePullBackOff", func() {
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().GetPod("c-nodes-0", "ns").Return(pod("c-nodes-0", "rev-old", "ImagePullBackOff"), nil)
+		mockClient.EXPECT().DeletePod(mock.MatchedBy(func(p *corev1.Pod) bool { return p.Name == "c-nodes-0" })).Return(nil)
+
+		deleted, err := DeleteStuckPodWithOlderRevision(mockClient, sts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(Equal("c-nodes-0"))
+	})
+
+	It("does not delete an older-revision pod that is merely starting", func() {
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().GetPod("c-nodes-0", "ns").Return(pod("c-nodes-0", "rev-old", "ContainerCreating"), nil)
+
+		deleted, err := DeleteStuckPodWithOlderRevision(mockClient, sts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeEmpty())
+	})
+
+	It("reports every stuck pod with its waiting reason", func() {
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().GetPod("c-nodes-0", "ns").Return(pod("c-nodes-0", "rev-new", "ErrImagePull"), nil)
+		mockClient.EXPECT().GetPod("c-nodes-1", "ns").Return(pod("c-nodes-1", "rev-new", ""), nil)
+
+		stuck, err := StuckPods(mockClient, sts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stuck).To(Equal(map[string]string{"c-nodes-0": "ErrImagePull"}))
 	})
 })

--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -421,30 +421,30 @@ func (r *RollingRestartReconciler) findStatus() *opensearchv1.ComponentStatus {
 	return nil
 }
 
-// handleUnreadyPods tries to unblock rolling restarts stalled by CrashLoopBackOff pods and emits Warning events.
+// handleUnreadyPods tries to unblock rolling restarts stalled by stuck (CrashLoopBackOff/ImagePullBackOff/...) pods and emits Warning events.
 func (r *RollingRestartReconciler) handleUnreadyPods(pool opensearchv1.NodePool, sts *appsv1.StatefulSet) {
 	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 	deletedPod, err := helpers.DeleteStuckPodWithOlderRevision(r.client, sts)
 	if err != nil {
 		r.logger.Error(err, "Could not delete stuck pod with older revision", "pool", pool.Component)
 	} else if deletedPod != "" {
-		r.logger.Info("Deleted stuck CrashLoopBackOff pod with older revision", "pod", deletedPod, "pool", pool.Component)
+		r.logger.Info("Deleted stuck pod with older revision", "pod", deletedPod, "pool", pool.Component)
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "RollingRestart",
-			"Deleted stuck CrashLoopBackOff pod '%s' in node pool '%s' to allow the rolling restart to proceed", deletedPod, pool.Component)
+			"Deleted stuck pod '%s' in node pool '%s' to allow the rolling restart to proceed", deletedPod, pool.Component)
 	}
 
-	crashPods, err := helpers.CrashLoopBackOffPods(r.client, sts)
+	stuckPods, err := helpers.StuckPods(r.client, sts)
 	if err != nil {
-		r.logger.Error(err, "Could not list CrashLoopBackOff pods", "pool", pool.Component)
+		r.logger.Error(err, "Could not list stuck pods", "pool", pool.Component)
 		return
 	}
-	for _, podName := range crashPods {
+	for podName, reason := range stuckPods {
 		if podName == deletedPod {
 			continue
 		}
-		r.logger.Info("Rolling restart stalled by CrashLoopBackOff pod", "pod", podName, "pool", pool.Component)
+		r.logger.Info("Rolling restart stalled by stuck pod", "pod", podName, "reason", reason, "pool", pool.Component)
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "RollingRestart",
-			"Pod '%s' in node pool '%s' is in CrashLoopBackOff; rolling restart is stalled until the pod becomes ready", podName, pool.Component)
+			"Pod '%s' in node pool '%s' is in %s; rolling restart is stalled until the pod becomes ready", podName, pool.Component, reason)
 	}
 }
 

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -104,8 +104,10 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	if err != nil {
 		results.Combine(&ctrl.Result{}, err)
 	} else if !ready {
-		// Not all node pools are ready yet, requeue and skip cleanup
-		results.Combine(&ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil)
+		// Not all node pools are ready yet: skip cleanup and retry later. Deliberately
+		// RequeueAfter-only (no Requeue=true) so the main chain still runs the upgrade
+		// and rolling-restart reconcilers, which own recovery of stuck pods (issue #1531).
+		results.Combine(&ctrl.Result{RequeueAfter: 15 * time.Second}, nil)
 	} else {
 		// Clean up old node pools (all current nodePools are ready)
 		r.cleanupStatefulSets(results)

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -534,6 +534,39 @@ var _ = Describe("Scaler Controller", func() {
 		})
 	})
 
+	Context("When a node pool is not fully available", func() {
+		It("Should skip cleanup without short-circuiting the reconciler chain (issue #1531)", func() {
+			// Requeue=true here would stop the main chain before the upgrade and
+			// rolling-restart reconcilers run, so a stuck pod could never be recovered.
+			clusterName := "test-cluster"
+			clusterNamespace := "test-namespace"
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterNamespace},
+				Spec: opensearchv1.ClusterSpec{
+					General:   opensearchv1.GeneralConfig{Version: "2.12.0"},
+					NodePools: []opensearchv1.NodePool{{Component: "masters", Replicas: 3}},
+				},
+				Status: opensearchv1.ClusterStatus{Version: "2.11.0"},
+			}
+			mastersSts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName + "-masters", Namespace: clusterNamespace},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](3)},
+				Status:     appsv1.StatefulSetStatus{AvailableReplicas: 2},
+			}
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockClient.On("GetStatefulSet", clusterName+"-masters", clusterNamespace).Return(mastersSts, nil)
+			// No ListStatefulSets expectation: cleanup must be skipped.
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			result, err := underTest.Reconcile()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+			mockClient.AssertExpectations(GinkgoT())
+		})
+	})
+
 	Context("When accumulating requeue across node pools", func() {
 		It("Should keep Requeue when an earlier pool requested it (regression #1454)", func() {
 			// Previously only the last pool's requeue was combined on the success

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -561,29 +561,29 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opensearchv1.NodePool) error 
 	return nil
 }
 
-// handleUnreadyPods tries to unblock upgrades stalled by CrashLoopBackOff pods and emits Warning events.
+// handleUnreadyPods tries to unblock upgrades stalled by stuck (CrashLoopBackOff/ImagePullBackOff/...) pods and emits Warning events.
 func (r *UpgradeReconciler) handleUnreadyPods(pool opensearchv1.NodePool, sts *appsv1.StatefulSet, annotations map[string]string) {
 	deletedPod, err := helpers.DeleteStuckPodWithOlderRevision(r.client, sts)
 	if err != nil {
 		r.logger.Error(err, "Could not delete stuck pod with older revision", "pool", pool.Component)
 	} else if deletedPod != "" {
-		r.logger.Info("Deleted stuck CrashLoopBackOff pod with older revision", "pod", deletedPod, "pool", pool.Component)
+		r.logger.Info("Deleted stuck pod with older revision", "pod", deletedPod, "pool", pool.Component)
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
-			"Deleted stuck CrashLoopBackOff pod '%s' in node pool '%s' to allow the upgrade to proceed", deletedPod, pool.Component)
+			"Deleted stuck pod '%s' in node pool '%s' to allow the upgrade to proceed", deletedPod, pool.Component)
 	}
 
-	crashPods, err := helpers.CrashLoopBackOffPods(r.client, sts)
+	stuckPods, err := helpers.StuckPods(r.client, sts)
 	if err != nil {
-		r.logger.Error(err, "Could not list CrashLoopBackOff pods", "pool", pool.Component)
+		r.logger.Error(err, "Could not list stuck pods", "pool", pool.Component)
 		return
 	}
-	for _, podName := range crashPods {
+	for podName, reason := range stuckPods {
 		if podName == deletedPod {
 			continue
 		}
-		r.logger.Info("Upgrade stalled by CrashLoopBackOff pod", "pod", podName, "pool", pool.Component)
+		r.logger.Info("Upgrade stalled by stuck pod", "pod", podName, "reason", reason, "pool", pool.Component)
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade",
-			"Pod '%s' in node pool '%s' is in CrashLoopBackOff; upgrade is stalled until the pod becomes ready", podName, pool.Component)
+			"Pod '%s' in node pool '%s' is in %s; upgrade is stalled until the pod becomes ready", podName, pool.Component, reason)
 	}
 }
 


### PR DESCRIPTION
### Description
An upgrade to a version whose image cannot be pulled could not be recovered by reverting `spec.general.version`: the already-recreated pod stayed in `ImagePullBackOff` on the old revision, the CR stayed in phase `UPGRADING` with the stale `__upgrade_target__` entry, and the cluster ran degraded until someone deleted the pod by hand. Two independent causes, both fixed here:

**1. The scaler readiness gate starved the upgrade and rolling-restart reconcilers.**
`ScalerReconciler.Reconcile` returned `Requeue: true` whenever any StatefulSet had `AvailableReplicas != Replicas`. The controller chain short-circuits on `Requeue: true`, so with a single pod unavailable `UpgradeReconciler` and `RollingRestartReconciler` never ran. That made the abort cleanup from #1473 (phase back to `RUNNING`, `Upgrader` entries cleared) and its stuck-pod recovery unreachable in practice, since a crashlooping or unpullable pod is also not Available.

The gate (added in #1190) only guards `cleanupStatefulSets`, i.e. removal of StatefulSets for node pools deleted from the spec. It now returns a `RequeueAfter: 15s`-only result, which the controller already treats as non-short-circuiting. Cleanup of removed pools is still skipped until all current pools are available, so the original #1190 protection is preserved; the only behavioural change is that the later reconcilers now run while a pod is down, which is exactly the state their own "waiting for pods to be ready" branches are written for.

**2. Stuck-pod detection only matched `CrashLoopBackOff`.**
`DeleteStuckPodWithOlderRevision` and `CrashLoopBackOffPods` compared the container waiting reason to the literal `CrashLoopBackOff`. With `updateStrategy: OnDelete` nothing else recreates an older-revision pod, so `ImagePullBackOff` / `ErrImagePull` / `InvalidImageName` pods were never deleted and no Warning event was emitted for them. The match now goes through a single shared set (`helpers.StuckContainerReason`), `CrashLoopBackOffPods` is renamed to `StuckPods` and returns the reason per pod, and the stall Warning event names the actual reason.

With both changes, reverting the version now results in: upgrade reconciler resets phase/status, rolling-restart reconciler sees the not-ready pool, deletes the stale-revision `ImagePullBackOff` pod, and the StatefulSet recreates it from the corrected template.

Tests added: older-revision pod in `ImagePullBackOff` is deleted, `ContainerCreating` is not, `StuckPods` reports the reason; scaler returns `RequeueAfter` without `Requeue` when a pool is not available and skips cleanup. No existing tests needed changes.

### Issues Resolved
Closes #1531

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented (no user-facing config change; event text now names the waiting reason)
- [ ] No linter warnings (`make lint`) (`go vet ./...` clean; golangci-lint not run locally)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
