### PR TITLE
fix: default confMgmt block so smartScaler defaults to true when omitted

### DIFF
--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.10
+version: 3.0.11
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -158,4 +158,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `3.0.10`
+Opensearch-operator Helm Chart version: `3.0.11`

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -1271,6 +1271,8 @@ spec:
                     type: array
                 type: object
               confMgmt:
+                default:
+                  smartScaler: true
                 description: ConfMgmt defines which additional services will be deployed
                 properties:
                   VerUpdate:

--- a/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
@@ -1273,6 +1273,8 @@ spec:
                     type: array
                 type: object
               confMgmt:
+                default:
+                  smartScaler: true
                 description: ConfMgmt defines which additional services will be deployed
                 properties:
                   VerUpdate:

--- a/docs/designs/crd/opensearch.opster.io.md
+++ b/docs/designs/crd/opensearch.opster.io.md
@@ -196,7 +196,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `general` _[GeneralConfig](#generalconfig)_ | INSERT ADDITIONAL SPEC FIELDS - desired state of cluster<br />Important: Run "make" to regenerate code after modifying this file |  |  |
-| `confMgmt` _[ConfMgmt](#confmgmt)_ |  |  |  |
+| `confMgmt` _[ConfMgmt](#confmgmt)_ |  | \{ smartScaler:true \} |  |
 | `bootstrap` _[BootstrapConfig](#bootstrapconfig)_ |  |  |  |
 | `dashboards` _[DashboardsConfig](#dashboardsconfig)_ |  |  |  |
 | `security` _[Security](#security)_ |  |  |  |

--- a/docs/designs/crd/opensearch.org.md
+++ b/docs/designs/crd/opensearch.org.md
@@ -193,7 +193,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `general` _[GeneralConfig](#generalconfig)_ | INSERT ADDITIONAL SPEC FIELDS - desired state of cluster<br />Important: Run "make" to regenerate code after modifying this file |  |  |
-| `confMgmt` _[ConfMgmt](#confmgmt)_ |  |  |  |
+| `confMgmt` _[ConfMgmt](#confmgmt)_ |  | \{ smartScaler:true \} |  |
 | `bootstrap` _[BootstrapConfig](#bootstrapconfig)_ |  |  |  |
 | `dashboards` _[DashboardsConfig](#dashboardsconfig)_ |  |  |  |
 | `security` _[Security](#security)_ |  |  |  |

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -446,7 +446,9 @@ SmartScaler is a mechanism built into the Operator that enables nodes to be safe
 
 During the safe drain process, the node being removed is marked as "draining", which means that it will no longer receive any new requests. Instead, it will only process outstanding requests until its workload has been completed. Once all requests have been processed, the node will begin transferring its data to other nodes in the cluster. The safe drain process will continue until all data has been transferred and the node is no longer part of the cluster. Only after that, the OMC will turn down the node.
 
-SmartScaler is enabled by default (`spec.confMgmt.smartScaler: true`), whether or not the `confMgmt` block is present in the manifest. Setting it to `false` removes nodes without draining, and the operator emits a `Warning` event each time it does so.
+SmartScaler is enabled by default (`spec.confMgmt.smartScaler: true`) for newly created clusters, whether or not the `confMgmt` block is present in the manifest. Setting it to `false` removes nodes without draining, and the operator emits a `Warning` event each time it does so.
+
+**Upgrade note:** Clusters that were created before this default was applied to the parent `confMgmt` object may already have `smartScaler: false` stored in etcd (for example after the operator added a finalizer and rewrote the spec). CRD defaulting does not override a present value. After upgrading the operator/CRDs, check `spec.confMgmt.smartScaler` on existing clusters and set it to `true` if safe draining was intended.
 
 ### Set Java heap size
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -446,6 +446,8 @@ SmartScaler is a mechanism built into the Operator that enables nodes to be safe
 
 During the safe drain process, the node being removed is marked as "draining", which means that it will no longer receive any new requests. Instead, it will only process outstanding requests until its workload has been completed. Once all requests have been processed, the node will begin transferring its data to other nodes in the cluster. The safe drain process will continue until all data has been transferred and the node is no longer part of the cluster. Only after that, the OMC will turn down the node.
 
+SmartScaler is enabled by default (`spec.confMgmt.smartScaler: true`), whether or not the `confMgmt` block is present in the manifest. Setting it to `false` removes nodes without draining, and the operator emits a `Warning` event each time it does so.
+
 ### Set Java heap size
 
 To configure the amount of memory allocated to the OpenSearch nodes, configure the heap size using the JVM args. This operation is expected to have no downtime and the cluster should be operational.

--- a/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
@@ -487,7 +487,8 @@ type GrpcConfig struct {
 type ClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	General    GeneralConfig    `json:"general,omitempty"`
+	General GeneralConfig `json:"general,omitempty"`
+	// +kubebuilder:default={smartScaler:true}
 	ConfMgmt   ConfMgmt         `json:"confMgmt,omitempty"`
 	Bootstrap  BootstrapConfig  `json:"bootstrap,omitempty"`
 	Dashboards DashboardsConfig `json:"dashboards,omitempty"`

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -423,7 +423,8 @@ type SnapshotRepoConfig struct {
 type ClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	General    GeneralConfig    `json:"general,omitempty"`
+	General GeneralConfig `json:"general,omitempty"`
+	// +kubebuilder:default={smartScaler:true}
 	ConfMgmt   ConfMgmt         `json:"confMgmt,omitempty"`
 	Bootstrap  BootstrapConfig  `json:"bootstrap,omitempty"`
 	Dashboards DashboardsConfig `json:"dashboards,omitempty"`

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchclusters.yaml
@@ -1273,6 +1273,8 @@ spec:
                     type: array
                 type: object
               confMgmt:
+                default:
+                  smartScaler: true
                 description: ConfMgmt defines which additional services will be deployed
                 properties:
                   VerUpdate:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -1271,6 +1271,8 @@ spec:
                     type: array
                 type: object
               confMgmt:
+                default:
+                  smartScaler: true
                 description: ConfMgmt defines which additional services will be deployed
                 properties:
                   VerUpdate:

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
@@ -1273,6 +1273,8 @@ spec:
                     type: array
                 type: object
               confMgmt:
+                default:
+                  smartScaler: true
                 description: ConfMgmt defines which additional services will be deployed
                 properties:
                   VerUpdate:

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -16,6 +16,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func ClusterDescWithVersion(version string) opensearchv1.OpenSearchCluster {
@@ -1007,6 +1009,29 @@ var _ = Describe("Builders", func() {
 				MountPath: "/tmp/keystoreSecrets/" + mockSecretName + "/" + newKey,
 				SubPath:   oldKey,
 			}))
+		})
+	})
+
+	When("Creating a cluster without a confMgmt block", func() {
+		It("should default smartScaler to true", func() {
+			namespaceName := "confmgmt-default"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			// A typed client always serializes confMgmt (smartScaler has no omitempty),
+			// so mimic a user manifest that omits the block entirely.
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "opensearch.org/v1",
+				"kind":       "OpenSearchCluster",
+				"metadata":   map[string]interface{}{"name": "no-confmgmt", "namespace": namespaceName},
+				"spec": map[string]interface{}{
+					"general":   map[string]interface{}{"version": "2.2.1", "serviceName": "no-confmgmt"},
+					"nodePools": []interface{}{map[string]interface{}{"component": "masters", "replicas": int64(1), "roles": []interface{}{"cluster_manager", "data"}}},
+				},
+			}}
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+
+			cluster := opensearchv1.OpenSearchCluster{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "no-confmgmt", Namespace: namespaceName}, &cluster)).To(Succeed())
+			Expect(cluster.Spec.ConfMgmt.SmartScaler).To(BeTrue())
 		})
 	})
 

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1033,6 +1033,74 @@ var _ = Describe("Builders", func() {
 			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "no-confmgmt", Namespace: namespaceName}, &cluster)).To(Succeed())
 			Expect(cluster.Spec.ConfMgmt.SmartScaler).To(BeTrue())
 		})
+
+		It("should keep smartScaler true after a typed Update (finalizer write path)", func() {
+			namespaceName := "confmgmt-finalizer"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "opensearch.org/v1",
+				"kind":       "OpenSearchCluster",
+				"metadata":   map[string]interface{}{"name": "confmgmt-update", "namespace": namespaceName},
+				"spec": map[string]interface{}{
+					"general":   map[string]interface{}{"version": "2.2.1", "serviceName": "confmgmt-update"},
+					"nodePools": []interface{}{map[string]interface{}{"component": "masters", "replicas": int64(1), "roles": []interface{}{"cluster_manager", "data"}}},
+				},
+			}}
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+
+			cluster := opensearchv1.OpenSearchCluster{}
+			key := types.NamespacedName{Name: "confmgmt-update", Namespace: namespaceName}
+			Expect(k8sClient.Get(context.Background(), key, &cluster)).To(Succeed())
+			Expect(cluster.Spec.ConfMgmt.SmartScaler).To(BeTrue())
+
+			// Mimic the cluster controller adding a finalizer and rewriting the object.
+			cluster.Finalizers = append(cluster.Finalizers, "Opensearch")
+			Expect(k8sClient.Update(context.Background(), &cluster)).To(Succeed())
+
+			updated := opensearchv1.OpenSearchCluster{}
+			Expect(k8sClient.Get(context.Background(), key, &updated)).To(Succeed())
+			Expect(updated.Spec.ConfMgmt.SmartScaler).To(BeTrue())
+		})
+
+		It("should keep an explicit smartScaler false", func() {
+			namespaceName := "confmgmt-explicit-false"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "opensearch.org/v1",
+				"kind":       "OpenSearchCluster",
+				"metadata":   map[string]interface{}{"name": "confmgmt-false", "namespace": namespaceName},
+				"spec": map[string]interface{}{
+					"general":   map[string]interface{}{"version": "2.2.1", "serviceName": "confmgmt-false"},
+					"confMgmt":  map[string]interface{}{"smartScaler": false},
+					"nodePools": []interface{}{map[string]interface{}{"component": "masters", "replicas": int64(1), "roles": []interface{}{"cluster_manager", "data"}}},
+				},
+			}}
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+
+			cluster := opensearchv1.OpenSearchCluster{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "confmgmt-false", Namespace: namespaceName}, &cluster)).To(Succeed())
+			Expect(cluster.Spec.ConfMgmt.SmartScaler).To(BeFalse())
+		})
+
+		It("should default smartScaler when confMgmt is an empty object", func() {
+			namespaceName := "confmgmt-empty-object"
+			Expect(CreateNamespace(k8sClient, namespaceName)).Should(Succeed())
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "opensearch.org/v1",
+				"kind":       "OpenSearchCluster",
+				"metadata":   map[string]interface{}{"name": "confmgmt-empty", "namespace": namespaceName},
+				"spec": map[string]interface{}{
+					"general":   map[string]interface{}{"version": "2.2.1", "serviceName": "confmgmt-empty"},
+					"confMgmt":  map[string]interface{}{},
+					"nodePools": []interface{}{map[string]interface{}{"component": "masters", "replicas": int64(1), "roles": []interface{}{"cluster_manager", "data"}}},
+				},
+			}}
+			Expect(k8sClient.Create(context.Background(), obj)).To(Succeed())
+
+			cluster := opensearchv1.OpenSearchCluster{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "confmgmt-empty", Namespace: namespaceName}, &cluster)).To(Succeed())
+			Expect(cluster.Spec.ConfMgmt.SmartScaler).To(BeTrue())
+		})
 	})
 
 	When("Checking for AllMastersReady", func() {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -181,7 +181,7 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opensearchv1.NodePool) (b
 			if !r.instance.Spec.ConfMgmt.SmartScaler {
 				lg.Info(fmt.Sprintf("SmartScaler is disabled, removing nodes from nodegroup %s without draining", nodePool.Component))
 				requeue, err := r.decreaseOneNode(currentStatus, currentSts, nodePool.Component, r.instance.Spec.ConfMgmt.SmartScaler)
-				r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Notice - your SmartScaler is not enabled")
+				r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "SmartScaler is disabled: removing node from %s without draining", nodePool.Component)
 				r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Starting to decrease node")
 				return requeue, err
 			}
@@ -495,12 +495,13 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	lg := log.FromContext(r.ctx)
 	lg.Info(fmt.Sprintf("Removing statefulset: %s", sts.Name))
 
+	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 	if !r.instance.Spec.ConfMgmt.SmartScaler {
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "SmartScaler is disabled: removing statefulset %s without draining", sts.Name)
 		return r.client.ReconcileResource(&sts, reconciler.StateAbsent)
 	}
 
 	// Gracefully remove nodes
-	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 	clusterClient, err := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
 	if err != nil {
 		lg.Error(err, "failed to create os client")


### PR DESCRIPTION
### Description
`spec.confMgmt.smartScaler` is declared with `+kubebuilder:default=true`, but Kubernetes structural-schema defaulting does not descend into a parent object that is absent from the manifest. A cluster that omits the `confMgmt` block (which every bundled example does) is stored without `confMgmt` at all, the operator sees `SmartScaler == false`, and a later scale-down removes nodes without draining them. With `number_of_replicas: 0` indices that is data loss.

This PR:

- Adds `+kubebuilder:default={smartScaler:true}` on the `ConfMgmt` field of `ClusterSpec` in both API groups (`opensearch.org/v1` and the legacy `opensearch.opster.io/v1`), and regenerates the CRDs into `config/crd/bases`, the helm chart, and `bundle/manifests`. A bare `default: {}` as proposed in the issue does not work: the API server rejects the CRD at install time (`spec.validation.openAPIV3Schema.properties[spec].properties[confMgmt].default.smartScaler: Required value`) because `smartScaler` is a required property and defaults must validate against the schema, so the nested value is spelled out. Existing clusters stored without `confMgmt` pick up the default on read once the CRD is updated; clusters that explicitly set `smartScaler: false` are unaffected.
- Changes the "SmartScaler is not enabled" event on the scale-down path from `Normal` to `Warning`, and emits a matching `Warning` in `removeStatefulSet` when a node pool is removed without draining (that branch was silent).
- Adds an envtest in `pkg/builders` that creates an `OpenSearchCluster` from an unstructured object with no `confMgmt` key and asserts `spec.confMgmt.smartScaler` reads back as `true`. An unstructured object is needed because the typed client always serializes `smartScaler` (no `omitempty`), so it cannot reproduce the omitted-block case.
- Documents the default in the SmartScaler section of the user guide and regenerates the CRD reference docs.

Only the `opensearch.org` CRD is byte-for-byte copied into the chart; the chart's `opensearch.opster.io` CRD had already drifted from `config/crd/bases` before this change (unrelated `imagePullSecrets`/`image` fields), so only the `default` lines were applied there to keep the diff focused.

### Issues Resolved
Closes #1530

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`) — `go vet` is clean; golangci-lint could not be run locally, relying on CI

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
