### PR TITLE
fix: detect stuck pods repeatedly killed while Running-but-not-ready

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -936,12 +936,25 @@ var stuckWaitingReasons = map[string]bool{
 	"InvalidImageName": true,
 }
 
-// StuckContainerReason returns the waiting reason of the first non-ready container that is
+// stuckRestartThreshold is the number of restarts a non-ready container must accumulate,
+// with a recorded last-terminated state, before it is treated as stuck even though it never
+// sits in one of stuckWaitingReasons. This catches a container that is repeatedly killed while
+// Running-but-not-ready (e.g. by a failing startup probe) and immediately restarted, so kubelet
+// only reports it as Waiting/CrashLoopBackOff for brief moments between attempts.
+const stuckRestartThreshold = 3
+
+// StuckContainerReason returns the reason the first non-ready container of the pod is
 // stuck in a non-recoverable state, or "" if the pod is not stuck.
 func StuckContainerReason(pod *corev1.Pod) string {
 	for _, container := range pod.Status.ContainerStatuses {
-		if !container.Ready && container.State.Waiting != nil && stuckWaitingReasons[container.State.Waiting.Reason] {
+		if container.Ready {
+			continue
+		}
+		if container.State.Waiting != nil && stuckWaitingReasons[container.State.Waiting.Reason] {
 			return container.State.Waiting.Reason
+		}
+		if container.RestartCount >= stuckRestartThreshold && container.LastTerminationState.Terminated != nil {
+			return "RepeatedlyFailing"
 		}
 	}
 	return ""

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -837,6 +837,49 @@ var _ = Describe("Stuck pod handling (issue #1531)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stuck).To(Equal(map[string]string{"c-nodes-0": "ErrImagePull"}))
 	})
+
+	// A container whose startup probe kills it (e.g. exit code 143) spends most of its time
+	// Running/not-ready and only briefly passes through a Waiting state, so it never matches
+	// stuckWaitingReasons. See issue #1537.
+	runningNotReady := func(name, revision string, restartCount int32, withLastTerminated bool) corev1.Pod {
+		status := corev1.ContainerStatus{
+			Ready:        false,
+			RestartCount: restartCount,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		}
+		if withLastTerminated {
+			status.LastTerminationState = corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 143, Reason: "Error"},
+			}
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: "ns", Labels: map[string]string{stsRevisionLabel: revision},
+			},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{status}},
+		}
+	}
+
+	It("flags a Running-but-not-ready container repeatedly killed by its startup probe", func() {
+		p := runningNotReady("c-nodes-0", "rev-new", stuckRestartThreshold, true)
+		Expect(StuckContainerReason(&p)).To(Equal("RepeatedlyFailing"))
+	})
+
+	It("does not flag a Running-but-not-ready container below the restart threshold", func() {
+		p := runningNotReady("c-nodes-0", "rev-new", stuckRestartThreshold-1, true)
+		Expect(StuckContainerReason(&p)).To(BeEmpty())
+	})
+
+	It("does not flag a Running-but-not-ready container with no recorded last-terminated state", func() {
+		p := runningNotReady("c-nodes-0", "rev-new", stuckRestartThreshold+2, false)
+		Expect(StuckContainerReason(&p)).To(BeEmpty())
+	})
+
+	It("does not flag a ready container regardless of restart count", func() {
+		p := runningNotReady("c-nodes-0", "rev-new", stuckRestartThreshold+2, true)
+		p.Status.ContainerStatuses[0].Ready = true
+		Expect(StuckContainerReason(&p)).To(BeEmpty())
+	})
 })
 
 var _ = Describe("IsSecurityPluginEnabled and CanRunSecurityAdmin", func() {


### PR DESCRIPTION
### Description
`StuckContainerReason` (used by both the rolling restart and upgrade reconcilers to detect and surface stuck pods) only inspected `container.State.Waiting` against a fixed set of reasons (`CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`). A container that is alive but failing its startup probe stays `Running`/not-ready and gets killed with SIGTERM on a loop; it only passes through a brief `Waiting`/`CrashLoopBackOff` state between restarts, so it never matched. Rolling restart and upgrade would requeue forever with no Warning event and no visible status.

This extends `StuckContainerReason` to also flag a non-ready container once `RestartCount >= 3` with a recorded `LastTerminationState.Terminated`, regardless of its current `State`. The threshold clears as soon as the container becomes ready, so a pod that is merely slow to start is never flagged.

Because both `DeleteStuckPodWithOlderRevision` and `StuckPods` route through this single predicate, both the rolling restart (`rollingRestart.go`) and upgrade (`upgrade.go`) reconcilers pick up the new detection automatically — no per-caller changes needed. As before, a pod stuck on the *current* StatefulSet revision only gets the Warning event (deletion only applies to stale-revision pods where the StatefulSet controller will recreate it from the current template).

### Issues Resolved
Fixes #1537

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).