### PR TITLE
fix: keep CRDs on helm uninstall by default

### DIFF
--- a/charts/opensearch-operator/templates/crds.yaml
+++ b/charts/opensearch-operator/templates/crds.yaml
@@ -12,6 +12,11 @@
 				{{- $labels := include "opensearch-operator.labels" $ | fromYaml }}
 				{{- $md := default (dict) $obj.metadata }}
 				{{- $_ := set $md "labels" (merge (default (dict) $obj.metadata.labels) $labels) }}
+				{{- if $.Values.crds.keep }}
+				{{- $ann := default (dict) $md.annotations }}
+				{{- $_ := set $ann "helm.sh/resource-policy" "keep" }}
+				{{- $_ := set $md "annotations" $ann }}
+				{{- end }}
 				{{- $_ := set $obj "metadata" $md }}
 {{ $obj | toYaml }}
 ---

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -78,8 +78,12 @@ manager:
 # Install the Custom Resource Definitions with Helm
 installCRDs: true
 
+crds:
+  # -- Keep CRDs (and thus all custom resources stored under them) when the release is uninstalled or upgraded with installCRDs=false, by annotating them with helm.sh/resource-policy: keep. Set to false to let Helm delete the CRDs on uninstall, e.g. for CI/dev environments that want full teardown. Existing CRDs must be deleted manually with `kubectl delete crd`.
+  keep: true
+
 legacyAPI:
-  # -- Enable support for the deprecated `opensearch.opster.io/v1` API group. When false, deprecated CRDs, webhooks, RBAC rules, and manager watches are skipped.
+  # -- Enable support for the deprecated `opensearch.opster.io/v1` API group. When false, deprecated CRDs, webhooks, RBAC rules, and manager watches are skipped. WARNING: disabling this while opensearch.opster.io resources still exist deletes those CRDs and all remaining custom resources stored under them, unless crds.keep is true.
   enabled: true
 
 serviceAccount:

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -21,6 +21,16 @@ A few notes on operator releases:
 - The userguide in the repository corresponds to the current development state of the code. To view the documentation for a specific released version switch to that tag in the Github menu.
 - We track feature requests as Github Issues. If you are missing a feature and find an issue for it, please be aware that an issue ticket closed as completed only means that feature has been implemented in the development version. After that it might still take some for the feature to be contained in a release. If you are unsure, please check the list of releases in our Github project if your feature is mentioned in the release notes.
 
+### Uninstalling
+
+Running `helm uninstall opensearch-operator` removes the operator, but by default it **keeps** the `opensearch.org`/`opensearch.opster.io` CRDs (they are annotated with `helm.sh/resource-policy: keep`). This is deliberate: Kubernetes cascade-deletes every `OpenSearchCluster` (and other custom resource) in the cluster when its CRD is removed, so keeping the CRDs on uninstall protects any clusters still managed by the operator.
+
+If you are sure no custom resources under these CRDs still exist and you want a full teardown (e.g. in CI or a throwaway dev environment), either install/upgrade with `--set crds.keep=false` so the `keep` annotation is never applied, or remove the CRDs manually after uninstalling:
+
+```console
+kubectl delete crd $(kubectl get crd -o name | grep -E 'opensearch\.(org|opster\.io)')
+```
+
 ## Quickstart
 
 After you have successfully installed the Operator, you can deploy your first OpenSearch cluster. This is done by creating an `OpenSearchCluster` custom object in Kubernetes or using Helm.
@@ -129,11 +139,13 @@ legacyAPI:
 ```
 
 > **Warning:** Do not disable legacy API support while
-> `opensearch.opster.io` resources still exist. The legacy CRDs are managed as
-> regular Helm release resources, so disabling the legacy API during an upgrade
-> removes those CRDs and deletes all remaining custom resources stored under
-> them. Follow the [migration guide](./migration-guide.md) to migrate, verify,
-> and delete every legacy resource before changing this setting.
+> `opensearch.opster.io` resources still exist. Disabling the legacy API
+> during an upgrade removes the legacy CRDs from the release. By default they
+> are kept (`crds.keep=true`, see [Uninstalling](#uninstalling)), but if you
+> have set `crds.keep=false`, Kubernetes deletes all remaining custom
+> resources stored under those CRDs as soon as they are removed. Follow the
+> [migration guide](./migration-guide.md) to migrate, verify, and delete
+> every legacy resource before changing this setting.
 
 ### Pprof endpoints
 

--- a/docs/userguide/migration-guide.md
+++ b/docs/userguide/migration-guide.md
@@ -181,10 +181,12 @@ Complete this step only after every legacy resource has migrated, its
 `opensearch.org` replacement has been verified, and the legacy resource has
 been deleted.
 
-> **Warning:** Helm manages the legacy CRDs as regular Helm resources.
-> Setting `legacyAPI.enabled=false` during an upgrade removes the
-> `opensearch.opster.io` CRDs. Kubernetes then deletes every remaining custom
-> resource stored under those CRDs across the cluster.
+> **Warning:** Setting `legacyAPI.enabled=false` during an upgrade removes
+> the `opensearch.opster.io` CRDs from the rendered release. By default the
+> CRDs are annotated with `helm.sh/resource-policy: keep` (`crds.keep=true`),
+> so Helm leaves them in place; if you have set `crds.keep=false`, Kubernetes
+> deletes every remaining custom resource stored under those CRDs across the
+> cluster as soon as they are removed.
 
 Check every legacy resource type and namespace before disabling support:
 


### PR DESCRIPTION
### Description
`charts/opensearch-operator/templates/crds.yaml` rendered CRDs as regular Helm resources with no `helm.sh/resource-policy: keep` annotation. `helm uninstall` therefore deleted every `opensearch.org`/`opensearch.opster.io` CRD, and Kubernetes cascade-deleted every `OpenSearchCluster` (and other custom resource) across the cluster. The same mechanism could drop `opensearch.opster.io` CRDs (and any not-yet-migrated legacy custom resources) when upgrading with `legacyAPI.enabled=false`.

This PR annotates the rendered CRDs with `helm.sh/resource-policy: keep`, mirroring the existing `$md.labels` rewrite pattern in that template for `$md.annotations`. A new `crds.keep` value (default `true`) lets CI/dev environments opt back into the old destructive teardown behavior. Documentation is updated:
- `docs/userguide/main.md`: new "Uninstalling" section explaining CRDs are kept by default and how to remove them deliberately.
- `docs/userguide/main.md` / `docs/userguide/migration-guide.md`: the `legacyAPI.enabled=false` warnings now reflect that `crds.keep=true` protects against the destructive CRD removal by default.
- `charts/opensearch-operator/values.yaml`: the `legacyAPI.enabled` comment now calls out the destructive behavior directly, not only in the migration guide.

Verified by rendering the chart with `helm template charts/opensearch-operator --set crds.keep=true` and `--set crds.keep=false`: the annotation appears on all 20 CRDs in the former and is entirely absent in the latter, with no other diff between the two renders. `helm lint` passes.

### Issues Resolved
Closes #1539

### Check List
- [x] Commits are signed per the DCO using --signoff
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).