### PR TITLE
Make leader election lease/renew/retry durations configurable

### DIFF
--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address={{ .Values.manager.metricsBindAddress }}
         - --leader-elect
+        - --leader-elect-lease-duration={{ .Values.manager.leaderElectionLeaseDuration }}
+        - --leader-elect-renew-deadline={{ .Values.manager.leaderElectionRenewDeadline }}
+        - --leader-elect-retry-period={{ .Values.manager.leaderElectionRetryPeriod }}
         - --enable-webhooks={{ .Values.webhook.enabled }}
         - --enable-legacy-api={{ include "opensearch-operator.legacyAPIEnabled" . }}
         - --webhook-port={{ .Values.webhook.port }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -75,6 +75,16 @@ manager:
 
   metricsBindAddress: 127.0.0.1:8080
 
+  # -- Leader election lease duration. Increase alongside renewDeadline/retryPeriod if reconciles
+  # (rolling restarts, upgrades) are being interrupted by transient API server latency.
+  leaderElectionLeaseDuration: 60s
+
+  # -- Leader election renew deadline. Must be less than leaderElectionLeaseDuration.
+  leaderElectionRenewDeadline: 30s
+
+  # -- Leader election retry period.
+  leaderElectionRetryPeriod: 5s
+
 # Install the Custom Resource Definitions with Helm
 installCRDs: true
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -111,6 +111,13 @@ manager:
   #   opensearchcluster: 4
   maxConcurrentReconcilesPerController: {}
 
+  # Leader election tuning. Increase these if reconciles (rolling restarts, upgrades) are
+  # being interrupted by "leader election lost" caused by transient API server latency.
+  # leaderElectionRenewDeadline must be less than leaderElectionLeaseDuration.
+  leaderElectionLeaseDuration: 60s
+  leaderElectionRenewDeadline: 30s
+  leaderElectionRetryPeriod: 5s
+
   # Configure extra environment variables for the operator. You can also pull them from secrets or configmaps
   extraEnv: []
   #  - name: MY_ENV

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"strings"
 
@@ -77,6 +78,19 @@ func registerLegacyAPIComponents(enabled bool, register func()) {
 	}
 }
 
+// registerLeaderElectionFlags registers the leader election tuning flags on fs and returns
+// pointers to the parsed values, suitable for use as ctrl.Options.LeaseDuration/RenewDeadline/RetryPeriod.
+func registerLeaderElectionFlags(fs *flag.FlagSet) (leaseDuration, renewDeadline, retryPeriod *time.Duration) {
+	leaseDuration = fs.Duration("leader-elect-lease-duration", 60*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership.")
+	renewDeadline = fs.Duration("leader-elect-renew-deadline", 30*time.Second,
+		"The interval between attempts by the acting leader to renew its leadership before it stops leading. "+
+			"Must be less than the lease duration.")
+	retryPeriod = fs.Duration("leader-elect-retry-period", 5*time.Second,
+		"The duration the leader election clients should wait between tries of actions.")
+	return
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(opsterv1.AddToScheme(scheme))
@@ -116,6 +130,7 @@ func main() {
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Global default max concurrent reconciles for all controllers")
 	flag.StringVar(&maxConcurrentReconcilesPerController, "max-concurrent-reconciles-per-controller", "",
 		"Per-controller max concurrent reconciles overrides (format: controller1=N,controller2=M)")
+	leaseDuration, renewDeadline, retryPeriod := registerLeaderElectionFlags(flag.CommandLine)
 
 	opts := zap.Options{
 		Development: false,
@@ -179,6 +194,9 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "a867c7dc.opensearch.org",
+		LeaseDuration:          leaseDuration,
+		RenewDeadline:          renewDeadline,
+		RetryPeriod:            retryPeriod,
 		Cache:                  cacheOpts,
 		WebhookServer:          webhookServer,
 	})

--- a/opensearch-operator/main_test.go
+++ b/opensearch-operator/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"flag"
 	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestParseWatchNamespacesSingle(t *testing.T) {
@@ -72,5 +76,61 @@ func TestRegisterLegacyAPIComponents(t *testing.T) {
 				t.Fatalf("expected %d registrations, got %d", test.expectedCalls, calls)
 			}
 		})
+	}
+}
+
+func TestRegisterLeaderElectionFlagsDefaults(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	leaseDuration, renewDeadline, retryPeriod := registerLeaderElectionFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if *leaseDuration != 60*time.Second {
+		t.Fatalf("expected default lease duration 60s, got %s", *leaseDuration)
+	}
+	if *renewDeadline != 30*time.Second {
+		t.Fatalf("expected default renew deadline 30s, got %s", *renewDeadline)
+	}
+	if *retryPeriod != 5*time.Second {
+		t.Fatalf("expected default retry period 5s, got %s", *retryPeriod)
+	}
+
+	opts := ctrl.Options{
+		LeaseDuration: leaseDuration,
+		RenewDeadline: renewDeadline,
+		RetryPeriod:   retryPeriod,
+	}
+	if opts.LeaseDuration == nil || *opts.LeaseDuration != 60*time.Second {
+		t.Fatalf("expected ctrl.Options.LeaseDuration to be 60s, got %v", opts.LeaseDuration)
+	}
+	if opts.RenewDeadline == nil || *opts.RenewDeadline != 30*time.Second {
+		t.Fatalf("expected ctrl.Options.RenewDeadline to be 30s, got %v", opts.RenewDeadline)
+	}
+	if opts.RetryPeriod == nil || *opts.RetryPeriod != 5*time.Second {
+		t.Fatalf("expected ctrl.Options.RetryPeriod to be 5s, got %v", opts.RetryPeriod)
+	}
+}
+
+func TestRegisterLeaderElectionFlagsOverride(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	leaseDuration, renewDeadline, retryPeriod := registerLeaderElectionFlags(fs)
+	err := fs.Parse([]string{
+		"-leader-elect-lease-duration=90s",
+		"-leader-elect-renew-deadline=45s",
+		"-leader-elect-retry-period=10s",
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if *leaseDuration != 90*time.Second {
+		t.Fatalf("expected lease duration 90s, got %s", *leaseDuration)
+	}
+	if *renewDeadline != 45*time.Second {
+		t.Fatalf("expected renew deadline 45s, got %s", *renewDeadline)
+	}
+	if *retryPeriod != 10*time.Second {
+		t.Fatalf("expected retry period 10s, got %s", *retryPeriod)
 	}
 }


### PR DESCRIPTION
### Description
The manager is created with `LeaderElection: true` but no `LeaseDuration`/`RenewDeadline`/`RetryPeriod`, so controller-runtime's defaults apply (15s/10s/2s). That gives only a 10s renew budget with a 5s per-attempt timeout, so a single slow API server response is enough to lose the lease and `os.Exit(1)`, aborting any in-flight multi-minute reconcile (drain, upgrade step).

This adds three flags, `--leader-elect-lease-duration` (default 60s), `--leader-elect-renew-deadline` (default 30s) and `--leader-elect-retry-period` (default 5s), and wires them into `ctrl.Options`, giving a 6x larger renew budget by default. The same knobs are exposed as `manager.leaderElectionLeaseDuration`/`RenewDeadline`/`RetryPeriod` Helm values, following the chart's existing one-value-per-flag convention (there is no `extraArgs` passthrough in this chart family), and documented in the operator configuration section of the user guide.

### Issues Resolved
Closes #1545

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).