### PR TITLE
fix: use RequeueAfter for scaler drain-wait polling instead of bare Requeue

### DIFF
--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -30,6 +30,8 @@ const (
 	// observed emptiness before a Warning event and DrainStalled condition are
 	// recorded. The drain itself is not aborted.
 	drainStallWarningAfter = 15 * time.Minute
+	// drainPollInterval is the fixed cadence for waiting on a scale-down drain
+	drainPollInterval = 15 * time.Second
 )
 
 type ScalerReconciler struct {
@@ -93,14 +95,10 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 			requeue, poolErr := r.reconcileNodePool(&nodePool)
 			res := ctrl.Result{Requeue: requeue}
 			if requeue {
-				// Same cadence as removeStatefulSet's drain wait. A bare Requeue
-				// (no RequeueAfter) is treated by controller-runtime as a
-				// rate-limited re-add using the default exponential backoff
-				// (5ms doubling, capped at 1000s), which can delay noticing a
-				// completed or stalled drain by many minutes. RequeueAfter is
+				// Same cadence as removeStatefulSet's drain wait. RequeueAfter is
 				// dropped by controller-runtime whenever poolErr != nil, so
 				// actual error retries still back off as before.
-				res.RequeueAfter = 15 * time.Second
+				res.RequeueAfter = drainPollInterval
 			}
 			results.Combine(&res, poolErr)
 		}
@@ -118,7 +116,7 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 		// Not all node pools are ready yet: skip cleanup and retry later. Deliberately
 		// RequeueAfter-only (no Requeue=true) so the main chain still runs the upgrade
 		// and rolling-restart reconcilers, which own recovery of stuck pods (issue #1531).
-		results.Combine(&ctrl.Result{RequeueAfter: 15 * time.Second}, nil)
+		results.Combine(&ctrl.Result{RequeueAfter: drainPollInterval}, nil)
 	} else {
 		// Clean up old node pools (all current nodePools are ready)
 		r.cleanupStatefulSets(results)
@@ -552,7 +550,7 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 		lg.Info(fmt.Sprintf("Waiting for shards to drain from node %s", lastReplicaNodeName))
 		return &ctrl.Result{
 			Requeue:      true,
-			RequeueAfter: 15 * time.Second,
+			RequeueAfter: drainPollInterval,
 		}, nil
 	}
 

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -91,7 +91,18 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 		// the main reconcile chain before upgrade/restart.
 		for _, nodePool := range r.instance.Spec.NodePools {
 			requeue, poolErr := r.reconcileNodePool(&nodePool)
-			results.Combine(&ctrl.Result{Requeue: requeue}, poolErr)
+			res := ctrl.Result{Requeue: requeue}
+			if requeue {
+				// Same cadence as removeStatefulSet's drain wait. A bare Requeue
+				// (no RequeueAfter) is treated by controller-runtime as a
+				// rate-limited re-add using the default exponential backoff
+				// (5ms doubling, capped at 1000s), which can delay noticing a
+				// completed or stalled drain by many minutes. RequeueAfter is
+				// dropped by controller-runtime whenever poolErr != nil, so
+				// actual error retries still back off as before.
+				res.RequeueAfter = 15 * time.Second
+			}
+			results.Combine(&res, poolErr)
 		}
 	} else {
 		lg.V(1).Info("Upgrade in progress, skipping replica scaling")

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -673,6 +673,40 @@ var _ = Describe("Scaler Controller", func() {
 			mockClient.AssertNotCalled(GinkgoT(), "UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything)
 		})
 
+		It("Should requeue with a short fixed interval instead of exponential backoff while still draining (issue #1533)", func() {
+			// A bare Requeue=true with no RequeueAfter is treated by controller-runtime
+			// as a rate-limited re-add on the default exponential backoff limiter (5ms
+			// doubling, capped at 1000s), which can delay noticing a stalled or completed
+			// drain by many minutes. The still-draining case must set RequeueAfter instead.
+			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
+			started := time.Now().UTC().Add(-time.Minute)
+			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, []string{
+				drainStartedConditionPrefix + started.Format(time.RFC3339),
+			})
+			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+
+			transport := httpmock.NewMockTransport()
+			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
+			registerOsPingResponders(transport, &spec)
+			registerCatShardsResponder(transport, http.StatusOK, fmt.Sprintf(
+				`[{"index":"idx","shard":"0","prirep":"p","state":"STARTED","node":"%s"}]`, targetNodeName,
+			))
+			registerClusterSettingsResponders(transport)
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
+			mockClient.On("GetStatefulSet", clusterName+"-"+nodePoolComponent, clusterNamespace).Return(currentSts, nil)
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			underTest.osClientTransport = transport
+			result, err := underTest.Reconcile()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+		})
+
 		It("Should mark the node drained only when it has no shards", func() {
 			targetNodeName := fmt.Sprintf("%s-%s-2", clusterName, nodePoolComponent)
 			spec := scalerDrainTestCluster(clusterName, clusterNamespace, nodePoolComponent, "Excluded", targetNodeName, nil)

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -158,7 +158,8 @@ func scalerDrainTestSts(clusterName, namespace, nodePoolComponent string, replic
 			Replicas: ptr.To(replicas),
 		},
 		Status: appsv1.StatefulSetStatus{
-			ReadyReplicas: replicas,
+			ReadyReplicas:     replicas,
+			AvailableReplicas: replicas,
 		},
 	}
 }
@@ -562,7 +563,7 @@ var _ = Describe("Scaler Controller", func() {
 			result, err := underTest.Reconcile()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+			Expect(result.RequeueAfter).To(Equal(drainPollInterval))
 			mockClient.AssertExpectations(GinkgoT())
 		})
 	})
@@ -684,6 +685,10 @@ var _ = Describe("Scaler Controller", func() {
 				drainStartedConditionPrefix + started.Format(time.RFC3339),
 			})
 			currentSts := scalerDrainTestSts(clusterName, clusterNamespace, nodePoolComponent, 3)
+			currentSts.Labels = map[string]string{
+				helpers.ClusterLabel:  clusterName,
+				helpers.NodePoolLabel: nodePoolComponent,
+			}
 
 			transport := httpmock.NewMockTransport()
 			transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
@@ -697,6 +702,11 @@ var _ = Describe("Scaler Controller", func() {
 			mockScalerAdminSecret(mockClient, clusterName, clusterNamespace)
 			mockClient.On("GetStatefulSet", clusterName+"-"+nodePoolComponent, clusterNamespace).Return(currentSts, nil)
 			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+			mockClient.On("ListStatefulSets",
+				client.InNamespace(clusterNamespace),
+				client.MatchingLabels{helpers.ClusterLabel: clusterName}).Return(appsv1.StatefulSetList{
+				Items: []appsv1.StatefulSet{currentSts},
+			}, nil)
 
 			underTest := newScalerReconciler(mockClient, &spec)
 			underTest.osClientTransport = transport
@@ -704,7 +714,8 @@ var _ = Describe("Scaler Controller", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue())
-			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+			Expect(result.RequeueAfter).To(Equal(drainPollInterval))
+			mockClient.AssertExpectations(GinkgoT())
 		})
 
 		It("Should mark the node drained only when it has no shards", func() {


### PR DESCRIPTION
### Description
While a smart scale-down waits for a node to drain, the scaler returned `ctrl.Result{Requeue: true}` with no `RequeueAfter`. controller-runtime treats a bare `Requeue` as a rate-limited re-add using the default per-item exponential backoff rate limiter (5ms base, doubling, capped at 1000s), instead of a fixed polling interval.

This delayed:
1. The `DrainStalled` condition/Warning event, documented to fire at 15 minutes but actually firing around 22 minutes in.
2. Noticing drain *completion*, by up to ~17 minutes once the backoff reached its cap.

This change sets `RequeueAfter` to 15s (matching `removeStatefulSet`'s existing drain-wait cadence) whenever a node pool requests a requeue from `reconcileNodePool`. controller-runtime drops `RequeueAfter` whenever an error is also returned (it rate-limits on the error instead), so this only changes the "no error, still draining, check again soon" case — actual error retries keep their existing backoff behavior unchanged.

### Issues Resolved
Closes #1533

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.