### PR TITLE
fix: warn when a custom roles_mapping.yml leaves the Dashboards user unmapped

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1519,6 +1519,8 @@ Provide the name of the secret that contains your securityconfig yaml files as `
 
 **Important:** You no longer need to provide password hashes for the `admin` or `kibanaserver` users in your security config secret. The operator will automatically generate password hashes from the credentials secrets and override any hash values you provide in the security config secret for these users. This means you only need to manage passwords in one place (the credentials secrets), not in both the credentials secrets and the security config secret.
 
+**Important:** password hashes are the only thing the operator manages for you. If your security config secret includes its own `roles_mapping.yml`, it replaces the image's default file entirely, and you are responsible for keeping the Dashboards user mapped to a role that has cluster monitoring permissions (`kibana_server` by default). See [Custom Dashboards user](#custom-dashboards-user) below.
+
 Note that OpenSearch requires all the files to be applied when the cluster is first created. So, the files that you do not provide in the securityconfig secret, the operator will use the default files provided in the opensearch-security plugin. See [opensearch-security](https://github.com/opensearch-project/security/tree/main/config) for the list of all configuration files and their default values.
 
 If you don't want to use the default files, you must provide at least a minimum configuration for the file. Example:
@@ -1831,7 +1833,18 @@ spec:
 **Important:** Similar to the admin user, you do **not** need to include the password hash for the `kibanaserver` user in your security config secret. The operator will automatically:
 1. Read the password from your `opensearchCredentialsSecret` (or use the generated random password if not provided)
 2. Generate the bcrypt hash
-3. Override the `kibanaserver` user's hash in the generated security config secret
+3. Override the Dashboards user's hash in the generated security config secret (using the `username` from `opensearchCredentialsSecret` if you provided one, `kibanaserver` otherwise)
+
+**Important:** the operator only manages the password hash. If you supply your own `roles_mapping.yml`, it replaces the image's default file, and the default `kibana_server -> kibanaserver` mapping is gone with it. You must keep the Dashboards user mapped to a role with cluster monitoring permissions yourself, for example:
+
+```yaml
+roles_mapping.yml: |-
+  kibana_server:
+    users:
+      - "kibanaserver" # or the username from opensearchCredentialsSecret
+```
+
+If you also supply your own `roles.yml`, keep the `kibana_server` role (or an equivalent role with the same permissions) in it. Without this mapping, the Dashboards user authenticates successfully but has no permissions, and the Dashboards deployment crash-loops with authorization errors in its logs (e.g. `no permissions for [cluster:monitor/nodes/info]`) with no other signal from the operator besides a `DashboardsUserUnmapped` warning event on the `OpenSearchCluster`.
 
 ### Security Plugin Disabled
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1844,7 +1844,7 @@ roles_mapping.yml: |-
       - "kibanaserver" # or the username from opensearchCredentialsSecret
 ```
 
-If you also supply your own `roles.yml`, keep the `kibana_server` role (or an equivalent role with the same permissions) in it. Without this mapping, the Dashboards user authenticates successfully but has no permissions, and the Dashboards deployment crash-loops with authorization errors in its logs (e.g. `no permissions for [cluster:monitor/nodes/info]`) with no other signal from the operator besides a `DashboardsUserUnmapped` warning event on the `OpenSearchCluster`.
+If you also supply your own `roles.yml`, keep the `kibana_server` role (or an equivalent role with the same permissions) in it. If you use a custom Dashboards username via `opensearchCredentialsSecret`, you must map that username even when you do not supply `roles_mapping.yml` — the image default only maps `kibanaserver`. Without this mapping, the Dashboards user authenticates successfully but has no permissions, and the Dashboards deployment crash-loops with authorization errors in its logs (e.g. `no permissions for [cluster:monitor/nodes/info]`) with no other signal from the operator besides a `DashboardsUserUnmapped` warning event on the `OpenSearchCluster`.
 
 ### Security Plugin Disabled
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1844,7 +1844,7 @@ roles_mapping.yml: |-
       - "kibanaserver" # or the username from opensearchCredentialsSecret
 ```
 
-If you also supply your own `roles.yml`, keep the `kibana_server` role (or an equivalent role with the same permissions) in it. If you use a custom Dashboards username via `opensearchCredentialsSecret`, you must map that username even when you do not supply `roles_mapping.yml` — the image default only maps `kibanaserver`. Without this mapping, the Dashboards user authenticates successfully but has no permissions, and the Dashboards deployment crash-loops with authorization errors in its logs (e.g. `no permissions for [cluster:monitor/nodes/info]`) with no other signal from the operator besides a `DashboardsUserUnmapped` warning event on the `OpenSearchCluster`.
+`kibana_server` is a static role built into the security plugin, so you do not need to define it in `roles.yml` (a definition there is ignored in favor of the built-in one). If you use a custom Dashboards username via `opensearchCredentialsSecret`, you must map that username even when you do not supply `roles_mapping.yml` — the image default only maps `kibanaserver`. Without this mapping, the Dashboards user authenticates successfully but has no permissions, and the Dashboards deployment crash-loops with authorization errors in its logs (e.g. `no permissions for [cluster:monitor/nodes/info]`). The operator emits a `DashboardsUserUnmapped` warning event on the `OpenSearchCluster` when it detects this.
 
 ### Security Plugin Disabled
 

--- a/opensearch-operator/examples/2.x/opensearch-cluster-custom-admin-user.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-cluster-custom-admin-user.yaml
@@ -155,25 +155,6 @@ stringData:
         _meta:
           type: "roles"
           config_version: 2
-        kibana_server:
-          reserved: true
-          cluster_permissions:
-            - "cluster:monitor/main"
-            - "cluster:monitor/health"
-            - "cluster:monitor/state"
-            - "cluster:monitor/nodes/info"
-            - "cluster:monitor/nodes/stats"
-            - "cluster:monitor/nodes/hot_threads"
-          index_permissions:
-            - index_patterns:
-                - ".kibana"
-                - ".kibana-6"
-                - ".kibana_*"
-                - ".opensearch_dashboards"
-                - ".opensearch_dashboards-6"
-                - ".opensearch_dashboards_*"
-              allowed_actions:
-                - "indices_all"
         dashboard_read_only:
           reserved: true
         security_rest_api_access:

--- a/opensearch-operator/examples/2.x/opensearch-cluster-custom-admin-user.yaml
+++ b/opensearch-operator/examples/2.x/opensearch-cluster-custom-admin-user.yaml
@@ -147,7 +147,7 @@ stringData:
           reserved: false
           backend_roles:
           - "snapshotrestore"
-        dashboard_server:
+        kibana_server:
           reserved: true
           users:
           - "dashboarduser"
@@ -155,6 +155,25 @@ stringData:
         _meta:
           type: "roles"
           config_version: 2
+        kibana_server:
+          reserved: true
+          cluster_permissions:
+            - "cluster:monitor/main"
+            - "cluster:monitor/health"
+            - "cluster:monitor/state"
+            - "cluster:monitor/nodes/info"
+            - "cluster:monitor/nodes/stats"
+            - "cluster:monitor/nodes/hot_threads"
+          index_permissions:
+            - index_patterns:
+                - ".kibana"
+                - ".kibana-6"
+                - ".kibana_*"
+                - ".opensearch_dashboards"
+                - ".opensearch_dashboards-6"
+                - ".opensearch_dashboards_*"
+              allowed_actions:
+                - "indices_all"
         dashboard_read_only:
           reserved: true
         security_rest_api_access:

--- a/opensearch-operator/examples/securityconfig-secret.yaml
+++ b/opensearch-operator/examples/securityconfig-secret.yaml
@@ -62,7 +62,7 @@ stringData:
           reserved: false
           backend_roles:
           - "snapshotrestore"
-        dashboard_server:
+        kibana_server:
           reserved: true
           users:
           - "kibanaserver"
@@ -70,6 +70,25 @@ stringData:
         _meta:
           type: "roles"
           config_version: 2
+        kibana_server:
+          reserved: true
+          cluster_permissions:
+            - "cluster:monitor/main"
+            - "cluster:monitor/health"
+            - "cluster:monitor/state"
+            - "cluster:monitor/nodes/info"
+            - "cluster:monitor/nodes/stats"
+            - "cluster:monitor/nodes/hot_threads"
+          index_permissions:
+            - index_patterns:
+                - ".kibana"
+                - ".kibana-6"
+                - ".kibana_*"
+                - ".opensearch_dashboards"
+                - ".opensearch_dashboards-6"
+                - ".opensearch_dashboards_*"
+              allowed_actions:
+                - "indices_all"
         dashboard_read_only:
           reserved: true
         security_rest_api_access:

--- a/opensearch-operator/examples/securityconfig-secret.yaml
+++ b/opensearch-operator/examples/securityconfig-secret.yaml
@@ -70,25 +70,6 @@ stringData:
         _meta:
           type: "roles"
           config_version: 2
-        kibana_server:
-          reserved: true
-          cluster_permissions:
-            - "cluster:monitor/main"
-            - "cluster:monitor/health"
-            - "cluster:monitor/state"
-            - "cluster:monitor/nodes/info"
-            - "cluster:monitor/nodes/stats"
-            - "cluster:monitor/nodes/hot_threads"
-          index_permissions:
-            - index_patterns:
-                - ".kibana"
-                - ".kibana-6"
-                - ".kibana_*"
-                - ".opensearch_dashboards"
-                - ".opensearch_dashboards-6"
-                - ".opensearch_dashboards_*"
-              allowed_actions:
-                - "indices_all"
         dashboard_read_only:
           reserved: true
         security_rest_api_access:

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -1210,12 +1210,6 @@ func DashboardsUsername(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSearchClus
 	return "kibanaserver", nil
 }
 
-// RolesMappingHasUser reports whether the given username is listed under the
-// "users" list of any role defined in a roles_mapping.yml document.
-func RolesMappingHasUser(rolesMappingData []byte, username string) (bool, error) {
-	return RolesMappingAuthorizes(rolesMappingData, username, nil)
-}
-
 // DashboardsUserMapped reports whether the Dashboards user is authorized by a
 // roles_mapping.yml document: listed under any role's "users", or any of the
 // user's backend_roles (from internal_users.yml) is listed under a role's

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -556,6 +556,18 @@ func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOve
 		kibanaUser["description"] = "Demo user for the OpenSearch Dashboards server"
 	}
 
+	// The bundled default ships a kibanaserver entry with hash: "". We used to
+	// always overwrite that hash; with a custom Dashboards username it would
+	// otherwise be applied as an empty hash, which OpenSearch can reject.
+	if dashboardsUsername != "kibanaserver" {
+		if leftover, ok := data["kibanaserver"].(map[interface{}]interface{}); ok {
+			hash, _ := leftover["hash"].(string)
+			if strings.TrimSpace(hash) == "" {
+				delete(data, "kibanaserver")
+			}
+		}
+	}
+
 	// Marshal back to YAML, preserving all users (base + custom)
 	modifiedYaml, err := yaml.Marshal(data)
 	if err != nil {
@@ -1176,11 +1188,19 @@ func EnsureDashboardsCredentialsSecret(k8sClient k8s.K8sClient, cr *opensearchv1
 	return &createdSecret, true, nil
 }
 
+func dashboardsCredentialsSecretName(cr *opensearchv1.OpenSearchCluster) string {
+	if cr.Spec.Dashboards.OpensearchCredentialsSecret.Name != "" {
+		return cr.Spec.Dashboards.OpensearchCredentialsSecret.Name
+	}
+	return GeneratedDashboardsCredentialsSecretName(cr)
+}
+
 // DashboardsUsername returns the username Dashboards authenticates to
 // OpenSearch with, i.e. the "username" field of its credentials secret
 // (custom or operator-generated), defaulting to "kibanaserver" if absent.
+// This only reads an existing secret; it never creates one.
 func DashboardsUsername(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSearchCluster) (string, error) {
-	secret, _, err := EnsureDashboardsCredentialsSecret(k8sClient, cr)
+	secret, err := k8sClient.GetSecret(dashboardsCredentialsSecretName(cr), cr.Namespace)
 	if err != nil {
 		return "", err
 	}
@@ -1191,13 +1211,31 @@ func DashboardsUsername(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSearchClus
 }
 
 // RolesMappingHasUser reports whether the given username is listed under the
-// "users" list of any role defined in a roles_mapping.yml document. This is a
-// heuristic used only to flag a likely misconfiguration: a user can also be
-// authorized via backend_roles or hosts, which this does not check.
+// "users" list of any role defined in a roles_mapping.yml document.
 func RolesMappingHasUser(rolesMappingData []byte, username string) (bool, error) {
+	return RolesMappingAuthorizes(rolesMappingData, username, nil)
+}
+
+// DashboardsUserMapped reports whether the Dashboards user is authorized by a
+// roles_mapping.yml document: listed under any role's "users", or any of the
+// user's backend_roles (from internal_users.yml) is listed under a role's
+// backend_roles. Hosts-based mappings are not checked.
+func DashboardsUserMapped(rolesMappingData, internalUsersData []byte, username string) (bool, error) {
+	return RolesMappingAuthorizes(rolesMappingData, username, userBackendRoles(internalUsersData, username))
+}
+
+// RolesMappingAuthorizes reports whether username is listed under any role's
+// "users", or any of backendRoles is listed under any role's "backend_roles".
+func RolesMappingAuthorizes(rolesMappingData []byte, username string, backendRoles []string) (bool, error) {
 	var data map[string]interface{}
 	if err := yaml.Unmarshal(rolesMappingData, &data); err != nil {
 		return false, err
+	}
+	backendWant := make(map[string]struct{}, len(backendRoles))
+	for _, role := range backendRoles {
+		if role != "" {
+			backendWant[role] = struct{}{}
+		}
 	}
 	for key, value := range data {
 		if key == "_meta" {
@@ -1207,15 +1245,52 @@ func RolesMappingHasUser(rolesMappingData []byte, username string) (bool, error)
 		if !ok {
 			continue
 		}
-		users, ok := role["users"].([]interface{})
+		if users, ok := role["users"].([]interface{}); ok {
+			for _, u := range users {
+				if s, ok := u.(string); ok && s == username {
+					return true, nil
+				}
+			}
+		}
+		if len(backendWant) == 0 {
+			continue
+		}
+		mappedRoles, ok := role["backend_roles"].([]interface{})
 		if !ok {
 			continue
 		}
-		for _, u := range users {
-			if s, ok := u.(string); ok && s == username {
-				return true, nil
+		for _, br := range mappedRoles {
+			if s, ok := br.(string); ok {
+				if _, found := backendWant[s]; found {
+					return true, nil
+				}
 			}
 		}
 	}
 	return false, nil
+}
+
+func userBackendRoles(internalUsersData []byte, username string) []string {
+	if len(internalUsersData) == 0 || username == "" {
+		return nil
+	}
+	var data map[string]interface{}
+	if err := yaml.Unmarshal(internalUsersData, &data); err != nil {
+		return nil
+	}
+	user, ok := data[username].(map[interface{}]interface{})
+	if !ok {
+		return nil
+	}
+	roles, ok := user["backend_roles"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, role := range roles {
+		if s, ok := role.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -394,9 +394,13 @@ func BuildGeneratedSecurityConfigSecret(k8sClient k8s.K8sClient, cr *opensearchv
 		return nil, err
 	}
 	var dashboardsPassword []byte
+	dashboardsUsername := "kibanaserver"
 	if dashboardsSecret != nil {
 		if pwd, exists := dashboardsSecret.Data["password"]; exists {
 			dashboardsPassword = pwd
+		}
+		if username, exists := dashboardsSecret.Data["username"]; exists && len(username) > 0 {
+			dashboardsUsername = string(username)
 		}
 	}
 	if len(dashboardsPassword) == 0 {
@@ -420,21 +424,22 @@ func BuildGeneratedSecurityConfigSecret(k8sClient k8s.K8sClient, cr *opensearchv
 	var adminHashOverride, dashboardsHashOverride string
 	if existingGenerated != nil {
 		if existingInternal, exists := existingGenerated.Data["internal_users.yml"]; exists {
-			var existingConfig InternalUserConfig
+			// Generic map lookup rather than InternalUserConfig, since the Dashboards
+			// user entry can live under any username (dashboardsUsername), not just
+			// the hardcoded "kibanaserver" key.
+			var existingConfig map[string]interface{}
 			if err := yaml.Unmarshal(existingInternal, &existingConfig); err == nil {
-				if existingConfig.Admin.Hash != "" && bcrypt.CompareHashAndPassword([]byte(existingConfig.Admin.Hash), adminPassword) == nil {
-					adminHashOverride = existingConfig.Admin.Hash
+				if hash := existingUserHash(existingConfig, "admin"); hash != "" && bcrypt.CompareHashAndPassword([]byte(hash), adminPassword) == nil {
+					adminHashOverride = hash
 				}
-				if existingConfig.Kibanaserver != nil && existingConfig.Kibanaserver.Hash != "" {
-					if bcrypt.CompareHashAndPassword([]byte(existingConfig.Kibanaserver.Hash), dashboardsPassword) == nil {
-						dashboardsHashOverride = existingConfig.Kibanaserver.Hash
-					}
+				if hash := existingUserHash(existingConfig, dashboardsUsername); hash != "" && bcrypt.CompareHashAndPassword([]byte(hash), dashboardsPassword) == nil {
+					dashboardsHashOverride = hash
 				}
 			}
 		}
 	}
 
-	internalUsers, err = applyUserHashes(internalUsers, adminPassword, adminHashOverride, dashboardsPassword, dashboardsHashOverride)
+	internalUsers, err = applyUserHashes(internalUsers, adminPassword, adminHashOverride, dashboardsUsername, dashboardsPassword, dashboardsHashOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -452,10 +457,23 @@ func BuildGeneratedSecurityConfigSecret(k8sClient k8s.K8sClient, cr *opensearchv
 	return secret, nil
 }
 
-func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOverride string, dashboardsPassword []byte, dashboardsHashOverride string) ([]byte, error) {
+// existingUserHash returns the "hash" field of a user entry in an
+// internal_users.yml document already unmarshalled into a generic map, or ""
+// if the user or its hash field is not present.
+func existingUserHash(data map[string]interface{}, username string) string {
+	user, ok := data[username].(map[interface{}]interface{})
+	if !ok {
+		return ""
+	}
+	hash, _ := user["hash"].(string)
+	return hash
+}
+
+func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOverride string, dashboardsUsername string, dashboardsPassword []byte, dashboardsHashOverride string) ([]byte, error) {
 	// Use a generic map to preserve all users (including custom ones).
-	// Only "admin" and "kibanaserver" are modified; all other entries
-	// (including _meta and any custom users) pass through unchanged.
+	// Only "admin" and the Dashboards user (dashboardsUsername) are modified;
+	// all other entries (including _meta and any custom users) pass through
+	// unchanged.
 	var data map[string]interface{}
 	if err := yaml.Unmarshal(internalUserData, &data); err != nil {
 		return nil, err
@@ -510,12 +528,12 @@ func applyUserHashes(internalUserData []byte, adminPassword []byte, adminHashOve
 	}
 	adminUser["backend_roles"] = backendRoles
 
-	// Update kibanaserver user (same yaml.v2 map type as above)
-	kibanaUser, ok := data["kibanaserver"].(map[interface{}]interface{})
+	// Update the Dashboards user (same yaml.v2 map type as above)
+	kibanaUser, ok := data[dashboardsUsername].(map[interface{}]interface{})
 	if !ok {
-		// Create kibanaserver if it doesn't exist
+		// Create the Dashboards user if it doesn't exist
 		kibanaUser = make(map[interface{}]interface{})
-		data["kibanaserver"] = kibanaUser
+		data[dashboardsUsername] = kibanaUser
 	}
 
 	var dashboardsHash string
@@ -1156,4 +1174,48 @@ func EnsureDashboardsCredentialsSecret(k8sClient k8s.K8sClient, cr *opensearchv1
 		return nil, true, err
 	}
 	return &createdSecret, true, nil
+}
+
+// DashboardsUsername returns the username Dashboards authenticates to
+// OpenSearch with, i.e. the "username" field of its credentials secret
+// (custom or operator-generated), defaulting to "kibanaserver" if absent.
+func DashboardsUsername(k8sClient k8s.K8sClient, cr *opensearchv1.OpenSearchCluster) (string, error) {
+	secret, _, err := EnsureDashboardsCredentialsSecret(k8sClient, cr)
+	if err != nil {
+		return "", err
+	}
+	if username := secret.Data["username"]; len(username) > 0 {
+		return string(username), nil
+	}
+	return "kibanaserver", nil
+}
+
+// RolesMappingHasUser reports whether the given username is listed under the
+// "users" list of any role defined in a roles_mapping.yml document. This is a
+// heuristic used only to flag a likely misconfiguration: a user can also be
+// authorized via backend_roles or hosts, which this does not check.
+func RolesMappingHasUser(rolesMappingData []byte, username string) (bool, error) {
+	var data map[string]interface{}
+	if err := yaml.Unmarshal(rolesMappingData, &data); err != nil {
+		return false, err
+	}
+	for key, value := range data {
+		if key == "_meta" {
+			continue
+		}
+		role, ok := value.(map[interface{}]interface{})
+		if !ok {
+			continue
+		}
+		users, ok := role["users"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, u := range users {
+			if s, ok := u.(string); ok && s == username {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -382,6 +382,7 @@ snapshotrestore:
 			[]byte(inputYaml),
 			[]byte("adminpass"),
 			"",
+			"kibanaserver",
 			[]byte("dashboardspass"),
 			"",
 		)
@@ -439,6 +440,7 @@ customuser:
 			[]byte(inputYaml),
 			[]byte("adminpass"),
 			adminHashOverride,
+			"kibanaserver",
 			[]byte("dashboardspass"),
 			dashboardsHashOverride,
 		)
@@ -499,6 +501,7 @@ kibanaro:
 			[]byte(inputYaml),
 			[]byte("adminpass"),
 			"$2a$12$newhash",
+			"kibanaserver",
 			[]byte("dashboardspass"),
 			"$2a$12$newkibanahash",
 		)
@@ -546,6 +549,7 @@ customuser:
 			[]byte(inputYaml),
 			[]byte("adminpass"),
 			"$2a$12$adminhash",
+			"kibanaserver",
 			[]byte("dashboardspass"),
 			"$2a$12$dashhash",
 		)
@@ -588,6 +592,7 @@ kibanaserver:
 			[]byte(inputYaml),
 			[]byte("adminpass"),
 			"$2a$12$newhash",
+			"kibanaserver",
 			[]byte("dashboardspass"),
 			"$2a$12$newkibanahash",
 		)
@@ -610,6 +615,78 @@ kibanaserver:
 		}
 		Expect(roleStrings).To(ContainElement("other_role"))
 		Expect(roleStrings).To(ContainElement("admin"))
+	})
+
+	It("should inject the hash under a custom Dashboards username, not kibanaserver", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "adminhash"
+  reserved: true
+  backend_roles:
+    - "admin"
+`
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			"$2a$12$adminhash",
+			"mydashboardsuser",
+			[]byte("dashboardspass"),
+			"$2a$12$customuserhash",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The custom username must carry the hash, and "kibanaserver" must not be created.
+		Expect(output).ToNot(HaveKey("kibanaserver"))
+		custom, ok := output["mydashboardsuser"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(custom["hash"]).To(Equal("$2a$12$customuserhash"))
+	})
+})
+
+var _ = Describe("RolesMappingHasUser", func() {
+	It("returns true when the username is listed under a role's users", func() {
+		rolesMapping := `
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+kibana_server:
+  reserved: true
+  users:
+    - "kibanaserver"
+`
+		mapped, err := RolesMappingHasUser([]byte(rolesMapping), "kibanaserver")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped).To(BeTrue())
+	})
+
+	It("returns false when the username is not listed under any role", func() {
+		rolesMapping := `
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+all_access:
+  reserved: true
+  backend_roles:
+    - "admin"
+  users:
+    - "someoneelse"
+`
+		mapped, err := RolesMappingHasUser([]byte(rolesMapping), "kibanaserver")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped).To(BeFalse())
+	})
+
+	It("returns false on an empty document without error", func() {
+		mapped, err := RolesMappingHasUser([]byte(""), "kibanaserver")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped).To(BeFalse())
 	})
 })
 

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -714,7 +714,7 @@ kibanaserver:
 	})
 })
 
-var _ = Describe("RolesMappingHasUser", func() {
+var _ = Describe("RolesMappingAuthorizes", func() {
 	It("returns true when the username is listed under a role's users", func() {
 		rolesMapping := `
 _meta:
@@ -725,7 +725,7 @@ kibana_server:
   users:
     - "kibanaserver"
 `
-		mapped, err := RolesMappingHasUser([]byte(rolesMapping), "kibanaserver")
+		mapped, err := RolesMappingAuthorizes([]byte(rolesMapping), "kibanaserver", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mapped).To(BeTrue())
 	})
@@ -742,13 +742,13 @@ all_access:
   users:
     - "someoneelse"
 `
-		mapped, err := RolesMappingHasUser([]byte(rolesMapping), "kibanaserver")
+		mapped, err := RolesMappingAuthorizes([]byte(rolesMapping), "kibanaserver", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mapped).To(BeFalse())
 	})
 
 	It("returns false on an empty document without error", func() {
-		mapped, err := RolesMappingHasUser([]byte(""), "kibanaserver")
+		mapped, err := RolesMappingAuthorizes([]byte(""), "kibanaserver", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mapped).To(BeFalse())
 	})

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -648,6 +648,70 @@ admin:
 		Expect(ok).To(BeTrue())
 		Expect(custom["hash"]).To(Equal("$2a$12$customuserhash"))
 	})
+
+	It("should drop a leftover empty-hash kibanaserver when using a custom Dashboards username", func() {
+		defaults, err := defaultSecurityconfigData()
+		Expect(err).NotTo(HaveOccurred())
+		inputYaml := defaults["internal_users.yml"]
+		Expect(inputYaml).NotTo(BeEmpty())
+
+		result, err := applyUserHashes(
+			inputYaml,
+			[]byte("adminpass"),
+			"$2a$12$adminhash",
+			"mydashboardsuser",
+			[]byte("dashboardspass"),
+			"$2a$12$customuserhash",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(output).ToNot(HaveKey("kibanaserver"))
+		custom, ok := output["mydashboardsuser"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(custom["hash"]).To(Equal("$2a$12$customuserhash"))
+	})
+
+	It("should keep a leftover kibanaserver entry that already has a hash", func() {
+		inputYaml := `
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "adminhash"
+  reserved: true
+  backend_roles:
+    - "admin"
+kibanaserver:
+  hash: "$2a$12$existingkibanahash"
+  reserved: true
+  description: "kept"
+`
+		result, err := applyUserHashes(
+			[]byte(inputYaml),
+			[]byte("adminpass"),
+			"$2a$12$adminhash",
+			"mydashboardsuser",
+			[]byte("dashboardspass"),
+			"$2a$12$customuserhash",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(result, &output)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(output).To(HaveKey("kibanaserver"))
+		kibana, ok := output["kibanaserver"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(kibana["hash"]).To(Equal("$2a$12$existingkibanahash"))
+		custom, ok := output["mydashboardsuser"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(custom["hash"]).To(Equal("$2a$12$customuserhash"))
+	})
 })
 
 var _ = Describe("RolesMappingHasUser", func() {
@@ -687,6 +751,40 @@ all_access:
 		mapped, err := RolesMappingHasUser([]byte(""), "kibanaserver")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mapped).To(BeFalse())
+	})
+
+	It("returns true when a backend_role of the user is mapped", func() {
+		rolesMapping := `
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+all_access:
+  reserved: true
+  backend_roles:
+    - "admin"
+`
+		mapped, err := RolesMappingAuthorizes([]byte(rolesMapping), "admin", []string{"admin"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped).To(BeTrue())
+	})
+})
+
+var _ = Describe("DashboardsUserMapped", func() {
+	It("treats the user as mapped when internal_users backend_roles match roles_mapping", func() {
+		rolesMapping := []byte(`
+all_access:
+  backend_roles:
+    - "admin"
+`)
+		internalUsers := []byte(`
+admin:
+  hash: "x"
+  backend_roles:
+    - "admin"
+`)
+		mapped, err := DashboardsUserMapped(rolesMapping, internalUsers, "admin")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped).To(BeTrue())
 	})
 })
 
@@ -771,6 +869,76 @@ var _ = Describe("EnsureDashboardsCredentialsSecret", func() {
 		Expect(created).ToNot(BeNil())
 		Expect(created.StringData["username"]).To(Equal("kibanaserver"))
 		expectPolicyCompliant(created.StringData["password"])
+	})
+})
+
+var _ = Describe("DashboardsUsername", func() {
+	It("reads the username from the credentials secret without creating one", func() {
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "pwtest", Namespace: "pwtest"},
+			Spec: opensearchv1.ClusterSpec{
+				Dashboards: opensearchv1.DashboardsConfig{
+					OpensearchCredentialsSecret: corev1.LocalObjectReference{Name: "dash-creds"},
+				},
+			},
+		}
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().GetSecret("dash-creds", "pwtest").Return(corev1.Secret{
+			Data: map[string][]byte{"username": []byte("mydashboardsuser")},
+		}, nil).Once()
+
+		username, err := DashboardsUsername(mockClient, cr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(username).To(Equal("mydashboardsuser"))
+	})
+
+	It("defaults to kibanaserver when the username field is absent", func() {
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "pwtest", Namespace: "pwtest"},
+		}
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().GetSecret(GeneratedDashboardsCredentialsSecretName(cr), "pwtest").Return(corev1.Secret{
+			Data: map[string][]byte{"password": []byte("secret")},
+		}, nil).Once()
+
+		username, err := DashboardsUsername(mockClient, cr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(username).To(Equal("kibanaserver"))
+	})
+})
+
+var _ = Describe("BuildGeneratedSecurityConfigSecret", func() {
+	It("injects the hash under a custom Dashboards username from the credentials secret", func() {
+		cr := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "pwtest", Namespace: "pwtest"},
+			Spec: opensearchv1.ClusterSpec{
+				Dashboards: opensearchv1.DashboardsConfig{
+					OpensearchCredentialsSecret: corev1.LocalObjectReference{Name: "dash-creds"},
+				},
+			},
+		}
+		mockClient := k8smocks.NewMockK8sClient(GinkgoT())
+		mockClient.EXPECT().GetSecret("dash-creds", "pwtest").Return(corev1.Secret{
+			Data: map[string][]byte{
+				"username": []byte("mydashboardsuser"),
+				"password": []byte("dashboardspass"),
+			},
+		}, nil).Once()
+		notFound := &k8serrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+		mockClient.EXPECT().GetSecret(GeneratedSecurityConfigSecretName(cr), "pwtest").Return(corev1.Secret{}, notFound).Once()
+
+		secret, err := BuildGeneratedSecurityConfigSecret(mockClient, cr, &corev1.Secret{
+			Data: map[string][]byte{"password": []byte("adminpass")},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var output map[string]interface{}
+		err = yaml.Unmarshal(secret.Data["internal_users.yml"], &output)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).ToNot(HaveKey("kibanaserver"))
+		custom, ok := output["mydashboardsuser"].(map[interface{}]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(custom["hash"]).NotTo(BeEmpty())
 	})
 })
 

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -413,16 +413,13 @@ func (r *SecurityconfigReconciler) securityconfigSubpaths(instance *opensearchv1
 }
 
 // warnIfDashboardsUserUnmapped emits a Warning event when Dashboards is enabled and the
-// generated securityconfig secret carries a non-empty custom roles_mapping.yml that does not
-// list the Dashboards user under any role's "users". This is a heuristic (backend-role based
-// mappings are still valid and not checked) meant only to surface an otherwise silent failure
-// mode (crash-looping Dashboards with no cluster-level signal); it never blocks reconciliation.
+// Dashboards user is not authorized by roles_mapping.yml. That includes a custom
+// roles_mapping.yml that lists neither the user nor its backend_roles, and a custom
+// Dashboards username with no roles_mapping.yml in the generated secret (the image
+// default only maps kibanaserver). Hosts-based mappings are not checked. This never
+// blocks reconciliation.
 func (r *SecurityconfigReconciler) warnIfDashboardsUserUnmapped(configSecret *corev1.Secret, annotations map[string]string) {
 	if !r.instance.Spec.Dashboards.Enable {
-		return
-	}
-	rolesMapping := configSecret.Data["roles_mapping.yml"]
-	if len(rolesMapping) == 0 {
 		return
 	}
 	dashboardsUsername, err := helpers.DashboardsUsername(r.client, r.instance)
@@ -430,7 +427,22 @@ func (r *SecurityconfigReconciler) warnIfDashboardsUserUnmapped(configSecret *co
 		r.logger.Error(err, "Unable to determine Dashboards username for roles mapping check")
 		return
 	}
-	mapped, err := helpers.RolesMappingHasUser(rolesMapping, dashboardsUsername)
+	rolesMapping := configSecret.Data["roles_mapping.yml"]
+	if len(rolesMapping) == 0 {
+		if dashboardsUsername == "kibanaserver" {
+			return
+		}
+		r.recorder.AnnotatedEventf(
+			r.instance,
+			annotations,
+			"Warning",
+			"DashboardsUserUnmapped",
+			"Dashboards user %q is not kibanaserver and no custom roles_mapping.yml is present; the image default mapping only includes kibanaserver, so Dashboards may fail to authorize",
+			dashboardsUsername,
+		)
+		return
+	}
+	mapped, err := helpers.DashboardsUserMapped(rolesMapping, configSecret.Data["internal_users.yml"], dashboardsUsername)
 	if err != nil {
 		r.logger.Error(err, "Unable to parse roles_mapping.yml for Dashboards user mapping check")
 		return
@@ -443,7 +455,7 @@ func (r *SecurityconfigReconciler) warnIfDashboardsUserUnmapped(configSecret *co
 		annotations,
 		"Warning",
 		"DashboardsUserUnmapped",
-		"Dashboards user %q is not listed under any role's \"users\" in the custom roles_mapping.yml; Dashboards may fail to authorize unless it is mapped via backend_roles instead",
+		"Dashboards user %q is not listed under any role's users in the custom roles_mapping.yml, and none of its backend_roles are mapped; Dashboards may fail to authorize",
 		dashboardsUsername,
 	)
 }

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -205,6 +205,8 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
+	r.warnIfDashboardsUserUnmapped(&configSecret, annotations)
+
 	if applyViaDefaultInit {
 		if err := r.updateSecurityConfigComponentStatus(securityConfigStatusReady, "securityconfig applied via default init", nil); err != nil {
 			return ctrl.Result{}, err
@@ -408,6 +410,42 @@ func (r *SecurityconfigReconciler) securityconfigSubpaths(instance *opensearchv1
 	}
 
 	return nil
+}
+
+// warnIfDashboardsUserUnmapped emits a Warning event when Dashboards is enabled and the
+// generated securityconfig secret carries a non-empty custom roles_mapping.yml that does not
+// list the Dashboards user under any role's "users". This is a heuristic (backend-role based
+// mappings are still valid and not checked) meant only to surface an otherwise silent failure
+// mode (crash-looping Dashboards with no cluster-level signal); it never blocks reconciliation.
+func (r *SecurityconfigReconciler) warnIfDashboardsUserUnmapped(configSecret *corev1.Secret, annotations map[string]string) {
+	if !r.instance.Spec.Dashboards.Enable {
+		return
+	}
+	rolesMapping := configSecret.Data["roles_mapping.yml"]
+	if len(rolesMapping) == 0 {
+		return
+	}
+	dashboardsUsername, err := helpers.DashboardsUsername(r.client, r.instance)
+	if err != nil {
+		r.logger.Error(err, "Unable to determine Dashboards username for roles mapping check")
+		return
+	}
+	mapped, err := helpers.RolesMappingHasUser(rolesMapping, dashboardsUsername)
+	if err != nil {
+		r.logger.Error(err, "Unable to parse roles_mapping.yml for Dashboards user mapping check")
+		return
+	}
+	if mapped {
+		return
+	}
+	r.recorder.AnnotatedEventf(
+		r.instance,
+		annotations,
+		"Warning",
+		"DashboardsUserUnmapped",
+		"Dashboards user %q is not listed under any role's \"users\" in the custom roles_mapping.yml; Dashboards may fail to authorize unless it is mapped via backend_roles instead",
+		dashboardsUsername,
+	)
 }
 
 // BuildClusterSvcHostName builds the cluster host name as {svc-name}.{namespace}.svc.{dns-base}

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -794,6 +794,14 @@ done;`
 			}
 		}
 
+		setupDashboardsUsernameGet := func(mockClient *k8s.MockK8sClient, clusterName, username string) {
+			dashboardsSecretName := clusterName + "-dashboards-password"
+			mockClient.On("GetSecret", dashboardsSecretName, clusterName).Return(corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: dashboardsSecretName, Namespace: clusterName},
+				Data:        map[string][]byte{"username": []byte(username)},
+			}, nil)
+		}
+
 		It("emits a Warning event when a custom roles_mapping.yml does not map the Dashboards user", func() {
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
 			spec := opensearchv1.OpenSearchCluster{
@@ -802,7 +810,7 @@ done;`
 					Dashboards: opensearchv1.DashboardsConfig{Enable: true},
 				},
 			}
-			setupDashboardsCredentialsSecretMocks(mockClient, clusterName)
+			setupDashboardsUsernameGet(mockClient, clusterName, "kibanaserver")
 
 			recorder := record.NewFakeRecorder(1)
 			underTest := newReconciler(mockClient, recorder, &spec)
@@ -833,7 +841,7 @@ all_access:
 					Dashboards: opensearchv1.DashboardsConfig{Enable: true},
 				},
 			}
-			setupDashboardsCredentialsSecretMocks(mockClient, clusterName)
+			setupDashboardsUsernameGet(mockClient, clusterName, "kibanaserver")
 
 			recorder := record.NewFakeRecorder(1)
 			underTest := newReconciler(mockClient, recorder, &spec)
@@ -848,6 +856,40 @@ kibana_server:
   reserved: true
   users:
     - "kibanaserver"
+`),
+				},
+			}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Consistently(recorder.Events).ShouldNot(Receive())
+		})
+
+		It("does not emit an event when the Dashboards user is mapped via backend_roles", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					Dashboards: opensearchv1.DashboardsConfig{Enable: true},
+				},
+			}
+			setupDashboardsUsernameGet(mockClient, clusterName, "admin")
+
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{
+				Data: map[string][]byte{
+					"internal_users.yml": []byte(`
+admin:
+  hash: "x"
+  backend_roles:
+    - "admin"
+`),
+					"roles_mapping.yml": []byte(`
+all_access:
+  reserved: true
+  backend_roles:
+    - "admin"
 `),
 				},
 			}
@@ -878,16 +920,57 @@ kibana_server:
 			Consistently(recorder.Events).ShouldNot(Receive())
 		})
 
-		It("does nothing when roles_mapping.yml is not present in the secret", func() {
+		It("does nothing when roles_mapping.yml is not present and the username is kibanaserver", func() {
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
 			spec := opensearchv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec:       opensearchv1.ClusterSpec{Dashboards: opensearchv1.DashboardsConfig{Enable: true}},
 			}
+			setupDashboardsUsernameGet(mockClient, clusterName, "kibanaserver")
 			recorder := record.NewFakeRecorder(1)
 			underTest := newReconciler(mockClient, recorder, &spec)
 
 			configSecret := &corev1.Secret{Data: map[string][]byte{}}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Consistently(recorder.Events).ShouldNot(Receive())
+		})
+
+		It("emits a Warning event when a custom Dashboards username has no roles_mapping.yml", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec:       opensearchv1.ClusterSpec{Dashboards: opensearchv1.DashboardsConfig{Enable: true}},
+			}
+			setupDashboardsUsernameGet(mockClient, clusterName, "mydashboardsuser")
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{Data: map[string][]byte{}}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("DashboardsUserUnmapped")))
+		})
+
+		It("does not emit an event when a custom Dashboards username is listed under users", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec:       opensearchv1.ClusterSpec{Dashboards: opensearchv1.DashboardsConfig{Enable: true}},
+			}
+			setupDashboardsUsernameGet(mockClient, clusterName, "mydashboardsuser")
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{
+				Data: map[string][]byte{
+					"roles_mapping.yml": []byte(`
+kibana_server:
+  users:
+    - "mydashboardsuser"
+`),
+				},
+			}
 			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
 
 			Consistently(recorder.Events).ShouldNot(Receive())

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -782,4 +782,115 @@ done;`
 			Expect(mountPaths).To(ContainElement(ContainSubstring("internal_users.yml")))
 		})
 	})
+
+	Describe("warnIfDashboardsUserUnmapped", func() {
+		newReconciler := func(mockClient *k8s.MockK8sClient, recorder record.EventRecorder, instance *opensearchv1.OpenSearchCluster) *SecurityconfigReconciler {
+			return &SecurityconfigReconciler{
+				client:            mockClient,
+				reconcilerContext: &ReconcilerContext{},
+				recorder:          recorder,
+				instance:          instance,
+				logger:            log.FromContext(context.Background()),
+			}
+		}
+
+		It("emits a Warning event when a custom roles_mapping.yml does not map the Dashboards user", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					Dashboards: opensearchv1.DashboardsConfig{Enable: true},
+				},
+			}
+			setupDashboardsCredentialsSecretMocks(mockClient, clusterName)
+
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{
+				Data: map[string][]byte{
+					"roles_mapping.yml": []byte(`
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+all_access:
+  reserved: true
+  backend_roles:
+    - "admin"
+`),
+				},
+			}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("DashboardsUserUnmapped")))
+		})
+
+		It("does not emit an event when the Dashboards user is mapped", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					Dashboards: opensearchv1.DashboardsConfig{Enable: true},
+				},
+			}
+			setupDashboardsCredentialsSecretMocks(mockClient, clusterName)
+
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{
+				Data: map[string][]byte{
+					"roles_mapping.yml": []byte(`
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+kibana_server:
+  reserved: true
+  users:
+    - "kibanaserver"
+`),
+				},
+			}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Consistently(recorder.Events).ShouldNot(Receive())
+		})
+
+		It("does nothing when Dashboards is disabled", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec:       opensearchv1.ClusterSpec{Dashboards: opensearchv1.DashboardsConfig{Enable: false}},
+			}
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{
+				Data: map[string][]byte{
+					"roles_mapping.yml": []byte(`all_access:
+  users:
+    - "someoneelse"
+`),
+				},
+			}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Consistently(recorder.Events).ShouldNot(Receive())
+		})
+
+		It("does nothing when roles_mapping.yml is not present in the secret", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec:       opensearchv1.ClusterSpec{Dashboards: opensearchv1.DashboardsConfig{Enable: true}},
+			}
+			recorder := record.NewFakeRecorder(1)
+			underTest := newReconciler(mockClient, recorder, &spec)
+
+			configSecret := &corev1.Secret{Data: map[string][]byte{}}
+			underTest.warnIfDashboardsUserUnmapped(configSecret, map[string]string{})
+
+			Consistently(recorder.Events).ShouldNot(Receive())
+		})
+	})
 })


### PR DESCRIPTION
### Description

Fixes #1521. With `dashboards.enable: true` and a custom `security.config.securityConfigSecret`, the operator injects the Dashboards user's password hash into `internal_users.yml`, but every other file in the secret (including `roles_mapping.yml`) is applied verbatim.

**Root cause**

1. If the custom `roles_mapping.yml` does not map the Dashboards user to a role with cluster monitoring permissions (`kibana_server` by default), the user authenticates successfully but has no permissions, and Dashboards crash-loops with authorization errors such as `no permissions for [cluster:monitor/nodes/info]`. Nothing in the operator surfaced this: the securityconfig job succeeds, the cluster reports healthy, and there is no event, condition, or webhook check pointing at the cause.
2. `applyUserHashes` (`pkg/helpers/helpers.go`) always wrote the password hash into a hardcoded `kibanaserver` entry, regardless of the `username` configured via `dashboards.opensearchCredentialsSecret`. A custom Dashboards username therefore got no hash injected either, breaking authentication the same way with the same lack of feedback.

**What changed**

- `applyUserHashes` and the existing-hash lookup in `BuildGeneratedSecurityConfigSecret` now use the actual Dashboards username (from `opensearchCredentialsSecret`, defaulting to `kibanaserver`) instead of a hardcoded key. With a custom username, a leftover `kibanaserver` entry with an empty hash (as in the bundled defaults) is dropped rather than applied.
- The securityconfig reconciler now emits a `Warning` event (reason `DashboardsUserUnmapped`) on the `OpenSearchCluster` when Dashboards is enabled and either:
  - the generated secret carries a custom `roles_mapping.yml` that neither lists the Dashboards user under any role's `users` nor maps any of its `backend_roles` (from `internal_users.yml`), or
  - the Dashboards username is not `kibanaserver` and there is no custom `roles_mapping.yml` (the image default only maps `kibanaserver`).

  This is a heuristic (hosts-based mappings are not checked) and never blocks reconciliation.
- Documented the `roles_mapping.yml` requirement next to the existing "you don't need to provide password hashes" notes in the user guide, with an example snippet. `kibana_server` is a static role in the security plugin, so nothing is needed in `roles.yml`.
- Fixed the example securityconfig secrets, which mapped the Dashboards user to a nonexistent `dashboard_server` role instead of `kibana_server`.

**Tests**

- `pkg/helpers/helpers_test.go`: `applyUserHashes` injects the hash under a custom Dashboards username, drops an empty-hash leftover `kibanaserver`, and keeps one that has a hash; `BuildGeneratedSecurityConfigSecret` and `DashboardsUsername` read the custom username; `RolesMappingAuthorizes`/`DashboardsUserMapped` cover users, backend_roles, unmapped, and empty documents.
- `pkg/reconcilers/securityconfig_test.go`: `warnIfDashboardsUserUnmapped` cases for an unmapped custom `roles_mapping.yml` (event), mapped via `users` or `backend_roles` (no event), Dashboards disabled (no event), no `roles_mapping.yml` with `kibanaserver` (no event) or a custom username (event).
- `go build ./... && go vet ./...` and `go test ./pkg/helpers/... ./pkg/reconcilers/...` pass.

### Issues Resolved

Fixes #1521

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`) — not run; the `golangci-lint` binary panics in this environment, verified with `go vet` instead

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
