### PR TITLE
webhook: reject unknown node pool roles and missing cluster-manager pool

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -267,25 +267,9 @@ func NewSTSForNodePool(
 		disksize = node.DiskSize
 	}
 
-	availableRoles := []string{
-		"master",
-		"data",
-		"data_content",
-		"data_hot",
-		"data_warm",
-		"data_cold",
-		"data_frozen",
-		"ingest",
-		"ml",
-		"remote_cluster_client",
-		"transform",
-		"cluster_manager",
-		"search",
-		"warm",
-	}
 	var selectedRoles []string
 	for _, role := range node.Roles {
-		if helpers.ContainsString(availableRoles, role) {
+		if helpers.ContainsString(helpers.ValidNodeRoles, role) {
 			role = helpers.MapClusterRole(role, cr.Spec.General.Version)
 			selectedRoles = append(selectedRoles, role)
 		}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -627,6 +627,26 @@ func SortedJsonKeys(obj *apiextensionsv1.JSON) (*apiextensionsv1.JSON, error) {
 	return &apiextensionsv1.JSON{Raw: rawBytes}, err
 }
 
+// ValidNodeRoles is the set of node pool roles the operator understands and renders into
+// node.roles. Shared by the StatefulSet builder (which silently drops anything not on this
+// list) and the validating webhook (which rejects it instead).
+var ValidNodeRoles = []string{
+	"master",
+	"data",
+	"data_content",
+	"data_hot",
+	"data_warm",
+	"data_cold",
+	"data_frozen",
+	"ingest",
+	"ml",
+	"remote_cluster_client",
+	"transform",
+	"cluster_manager",
+	"search",
+	"warm",
+}
+
 func ResolveClusterManagerRole(ver string) string {
 	masterRole := "master"
 	osVer, err := version.NewVersion(ver)

--- a/opensearch-operator/webhook/opensearch_cluster_webhook.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
@@ -49,6 +50,9 @@ func (v *OpenSearchClusterValidator) ValidateCreate(ctx context.Context, obj run
 	if err := validateNodePoolComponentUniqueness(cluster); err != nil {
 		return nil, err
 	}
+	if err := validateNodePools(cluster); err != nil {
+		return nil, err
+	}
 	return v.validateTlsConfig(cluster)
 }
 
@@ -62,6 +66,10 @@ func (v *OpenSearchClusterValidator) ValidateUpdate(ctx context.Context, oldObj,
 
 	// Validate no duplicate node pool component names (component is used for K8s resource names)
 	if err := validateNodePoolComponentUniqueness(newCluster); err != nil {
+		return nil, err
+	}
+
+	if err := validateNodePools(newCluster); err != nil {
 		return nil, err
 	}
 
@@ -109,6 +117,29 @@ func validateNodePoolComponentUniqueness(cluster *opensearchv1.OpenSearchCluster
 			return fmt.Errorf("duplicate node pool component name '%s': each node pool must have a unique component name (used for K8s resource naming)", component)
 		}
 		seen[component] = struct{}{}
+	}
+	return nil
+}
+
+// validateNodePools rejects unknown node pool roles (the StatefulSet builder silently drops
+// anything not on helpers.ValidNodeRoles) and clusters with no cluster-manager-eligible node
+// pool that has replicas >= 1 (such a cluster can never form a quorum).
+func validateNodePools(cluster *opensearchv1.OpenSearchCluster) error {
+	managerRole := helpers.ResolveClusterManagerRole(cluster.Spec.General.Version)
+	hasManager := false
+	for i := range cluster.Spec.NodePools {
+		pool := &cluster.Spec.NodePools[i]
+		for _, role := range pool.Roles {
+			if !helpers.ContainsString(helpers.ValidNodeRoles, role) {
+				return fmt.Errorf("node pool '%s' has unknown role '%s' (valid roles: %s)", pool.Component, role, strings.Join(helpers.ValidNodeRoles, ", "))
+			}
+		}
+		if pool.Replicas >= 1 && helpers.ContainsString(helpers.MapClusterRoles(pool.Roles, cluster.Spec.General.Version), managerRole) {
+			hasManager = true
+		}
+	}
+	if !hasManager {
+		return fmt.Errorf("at least one node pool must have the %s role and replicas >= 1", managerRole)
 	}
 	return nil
 }

--- a/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
@@ -65,6 +65,7 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 						{
 							Component: "masters",
 							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
 						},
 					},
 				},
@@ -117,6 +118,13 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					General: opensearchv1.GeneralConfig{
 						Version: "2.19.4",
 					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
+						},
+					},
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
 							Transport: &opensearchv1.TlsConfigTransport{
@@ -147,6 +155,13 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 				Spec: opensearchv1.ClusterSpec{
 					General: opensearchv1.GeneralConfig{
 						Version: "2.19.4",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
+						},
 					},
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
@@ -179,6 +194,13 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					General: opensearchv1.GeneralConfig{
 						Version: "2.19.4",
 					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
+						},
+					},
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
 							Transport: &opensearchv1.TlsConfigTransport{
@@ -205,6 +227,13 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 				Spec: opensearchv1.ClusterSpec{
 					General: opensearchv1.GeneralConfig{
 						Version: "2.19.4",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
+						},
 					},
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
@@ -237,6 +266,13 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					General: opensearchv1.GeneralConfig{
 						Version: "2.19.4",
 					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
+						},
+					},
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
 							Transport: &opensearchv1.TlsConfigTransport{
@@ -267,6 +303,13 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					General: opensearchv1.GeneralConfig{
 						Version: "2.19.4",
 					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"cluster_manager"},
+						},
+					},
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
 							Transport: &opensearchv1.TlsConfigTransport{
@@ -287,6 +330,88 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 			warnings, err := validator.ValidateCreate(ctx, cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("admin secret name is not provided but http.tls generate is not true"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject a node pool with an unknown role", func() {
+			cluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "nodes",
+							Replicas:  3,
+							Roles:     []string{"cluster_manger", "data"}, // typo
+						},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("node pool 'nodes' has unknown role 'cluster_manger'"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject a cluster with no cluster-manager-eligible node pool with replicas >= 1", func() {
+			cluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "managers",
+							Replicas:  0,
+							Roles:     []string{"cluster_manager"},
+						},
+						{
+							Component: "data",
+							Replicas:  3,
+							Roles:     []string{"data"},
+						},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("at least one node pool must have the cluster_manager role and replicas >= 1"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow a cluster manager pool named 'master' on 1.x versions", func() {
+			cluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "1.3.18",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"master"},
+						},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(BeEmpty())
 		})
 	})
@@ -341,6 +466,8 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					NodePools: []opensearchv1.NodePool{
 						{
 							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"master"},
 							Persistence: &opensearchv1.PersistenceConfig{
 								PersistenceSource: opensearchv1.PersistenceSource{
 									PVC: &opensearchv1.PVCSource{
@@ -388,6 +515,8 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					NodePools: []opensearchv1.NodePool{
 						{
 							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"master"},
 							Persistence: &opensearchv1.PersistenceConfig{
 								PersistenceSource: opensearchv1.PersistenceSource{
 									PVC: &opensearchv1.PVCSource{
@@ -426,6 +555,8 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					NodePools: []opensearchv1.NodePool{
 						{
 							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"master"},
 						},
 						{
 							Component: "data",
@@ -480,7 +611,7 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 							Image: &image,
 						},
 					},
-					NodePools: []opensearchv1.NodePool{{Component: "masters"}},
+					NodePools: []opensearchv1.NodePool{{Component: "masters", Replicas: 3, Roles: []string{"cluster_manager"}}},
 				},
 			}
 			newCluster := oldCluster.DeepCopy()
@@ -505,7 +636,7 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 							Image: &oldImage,
 						},
 					},
-					NodePools: []opensearchv1.NodePool{{Component: "masters"}},
+					NodePools: []opensearchv1.NodePool{{Component: "masters", Replicas: 3, Roles: []string{"cluster_manager"}}},
 				},
 			}
 			newCluster := oldCluster.DeepCopy()
@@ -524,7 +655,7 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 					General: opensearchv1.GeneralConfig{
 						Version: "2.11.0",
 					},
-					NodePools: []opensearchv1.NodePool{{Component: "masters"}},
+					NodePools: []opensearchv1.NodePool{{Component: "masters", Replicas: 3, Roles: []string{"cluster_manager"}}},
 				},
 			}
 			newCluster := oldCluster.DeepCopy()


### PR DESCRIPTION
### Description
`nodePools[].roles` is an untyped `[]string` with no CRD enum, and the StatefulSet builder silently drops any role not on its hardcoded allowlist, so a typo like `cluster_manger` produces a node with fewer roles than intended and no admission error, log line, or event. Likewise nothing checked that at least one cluster-manager-eligible node pool has `replicas >= 1`, so a cluster whose only manager pool is scaled to 0 (or whose manager role is misspelled) is accepted; the bootstrap pod alone forms the cluster, gets deleted once `status.initialized` flips, and the remaining nodes are left with no cluster-manager-eligible node ("master not discovered").

This moves the role allowlist into `helpers.ValidNodeRoles` so `builders.NewSTSForNodePool` and the validating webhook share one source of truth, and adds `validateNodePools` to `OpenSearchClusterValidator`, called from both `ValidateCreate` and `ValidateUpdate` next to the existing `validateNodePoolComponentUniqueness` check:
- reject any role not in `helpers.ValidNodeRoles`, naming the offending pool and role
- reject a cluster where no node pool has the cluster-manager role (resolved and version-mapped the same way `builders.AllMastersReady` already does) with `replicas >= 1`

No CRD changes: the role list and the "at least one manager pool" rule are validated in the webhook only, matching the existing shape of `validateNodePoolComponentUniqueness` and friends in this file.

### Issues Resolved
Fixes #1529

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] `go build ./...` and `go vet ./...` pass clean (golangci-lint could not be run in this environment)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsPRCud4cYSQVDc3jzkdmD