### PR TITLE
fix: only add migration finalizer when a legacy twin exists

### DIFF
--- a/opensearch-operator/controllers/migration_controller.go
+++ b/opensearch-operator/controllers/migration_controller.go
@@ -119,15 +119,23 @@ func (r *ClusterMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
-		// Add migration finalizer to new cluster if not present
-		// This ensures we can handle deletion even after main reconciler removes its finalizer
+		// Add migration finalizer to new cluster, but only if there is actually a
+		// legacy twin to migrate/clean up. Otherwise every cluster on a fresh
+		// install (no opensearch.opster.io twin at all) would pick up a
+		// finalizer that nothing will ever remove.
 		if !containsString(newCluster.Finalizers, MigrationFinalizer) {
-			newCluster.Finalizers = append(newCluster.Finalizers, MigrationFinalizer)
-			if err := r.Update(ctx, newCluster); err != nil {
+			hasTwin, err := genericHasLegacyTwin[opsterv1.OpenSearchCluster, *opsterv1.OpenSearchCluster](ctx, r.Client, req.NamespacedName, newCluster)
+			if err != nil {
 				return ctrl.Result{}, err
 			}
-			// Requeue to process deletion if needed
-			return ctrl.Result{Requeue: true}, nil
+			if hasTwin {
+				newCluster.Finalizers = append(newCluster.Finalizers, MigrationFinalizer)
+				if err := r.Update(ctx, newCluster); err != nil {
+					return ctrl.Result{}, err
+				}
+				// Requeue to process deletion if needed
+				return ctrl.Result{Requeue: true}, nil
+			}
 		}
 		// If new cluster exists and is not being deleted, continue to check old cluster
 	}
@@ -654,6 +662,29 @@ func (r *ComponentTemplateMigrationReconciler) SetupWithManager(mgr ctrl.Manager
 		Complete(r)
 }
 
+// genericHasLegacyTwin reports whether the new-group object has a legacy
+// (opensearch.opster.io) twin that the migration finalizer would need to
+// clean up: either the twin still exists, or the object's annotations record
+// that it was created by migrating one (covers the window after the legacy
+// twin has already been deleted).
+func genericHasLegacyTwin[OldType any, OldPtr interface {
+	*OldType
+	client.Object
+}](ctx context.Context, c client.Client, key types.NamespacedName, newResource client.Object) (bool, error) {
+	if annotations := newResource.GetAnnotations(); annotations != nil && annotations[MigratedFromAnnotation] != "" {
+		return true, nil
+	}
+	oldResource := OldPtr(new(OldType))
+	err := c.Get(ctx, key, oldResource)
+	if err == nil {
+		return true, nil
+	}
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 // Generic migration reconciler using generics
 func reconcileGenericMigration[OldType, NewType any, OldPtr interface {
 	*OldType
@@ -708,15 +739,23 @@ func reconcileGenericMigration[OldType, NewType any, OldPtr interface {
 			return ctrl.Result{}, nil
 		}
 
-		// Add migration finalizer to new resource if not present
-		// This ensures we can handle deletion even after main reconciler removes its finalizer
+		// Add migration finalizer to new resource, but only if there is actually a
+		// legacy twin to migrate/clean up. Otherwise every object on a fresh
+		// install (no opensearch.opster.io twins at all) would pick up a
+		// finalizer that nothing will ever remove.
 		if !containsString(newResource.GetFinalizers(), MigrationFinalizer) {
-			newResource.SetFinalizers(append(newResource.GetFinalizers(), MigrationFinalizer))
-			if err := c.Update(ctx, newResource); err != nil {
+			hasTwin, err := genericHasLegacyTwin[OldType, OldPtr](ctx, c, req.NamespacedName, newResource)
+			if err != nil {
 				return ctrl.Result{}, err
 			}
-			// Requeue to process deletion if needed
-			return ctrl.Result{Requeue: true}, nil
+			if hasTwin {
+				newResource.SetFinalizers(append(newResource.GetFinalizers(), MigrationFinalizer))
+				if err := c.Update(ctx, newResource); err != nil {
+					return ctrl.Result{}, err
+				}
+				// Requeue to process deletion if needed
+				return ctrl.Result{Requeue: true}, nil
+			}
 		}
 		// If new resource exists and is not being deleted, continue to check old resource
 	}

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -64,7 +64,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 	})
 
 	Describe("Reconcile - New Cluster Deletion", func() {
-		It("should add migration finalizer to new cluster", func() {
+		It("should add migration finalizer to new cluster that has a legacy twin", func() {
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldCluster)).To(Succeed())
+
 			newCluster := &opensearchv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
@@ -86,6 +94,31 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			updatedCluster := &opensearchv1.OpenSearchCluster{}
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
 			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeTrue())
+		})
+
+		It("should not add migration finalizer to a new cluster with no legacy twin", func() {
+			// Fresh installs never had an opensearch.opster.io twin, so there is
+			// nothing for the migration finalizer to clean up (#1544).
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			updatedCluster := &opensearchv1.OpenSearchCluster{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
+			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeFalse())
 		})
 
 		It("should not add migration finalizer to a new cluster that is being deleted", func() {
@@ -611,7 +644,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeFalse())
 		})
 
-		It("should add migration finalizer to a new resource that is not being deleted", func() {
+		It("should add migration finalizer to a new resource that has a legacy twin", func() {
+			oldUser := &opsterv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldUser)).To(Succeed())
+
 			newUser := &opensearchv1.OpensearchUser{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
@@ -626,6 +667,65 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			Expect(result.Requeue).To(BeTrue())
 
 			updatedUser := &opensearchv1.OpensearchUser{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeTrue())
+		})
+
+		It("should not add migration finalizer to a new resource with no legacy twin", func() {
+			// Fresh installs never had an opensearch.opster.io twin, so there is
+			// nothing for the migration finalizer to clean up (#1544).
+			newUser := &opensearchv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+
+			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
+			result, err := userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			updatedUser := &opensearchv1.OpensearchUser{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeFalse())
+		})
+
+		It("should add migration finalizer once a legacy twin appears after the new resource already existed", func() {
+			// Edge case: the new-group resource was created first (or existed with
+			// no twin), and a legacy opensearch.opster.io twin with the same
+			// name/namespace shows up afterwards.
+			newUser := &opensearchv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+
+			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
+			result, err := userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			updatedUser := &opensearchv1.OpensearchUser{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeFalse())
+
+			// Now the legacy twin appears.
+			oldUser := &opsterv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldUser)).To(Succeed())
+
+			result, err = userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
 			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeTrue())
 		})


### PR DESCRIPTION
### Description
`reconcileGenericMigration` and the cluster migration reconciler add the `opensearch.org/migration` finalizer to every `opensearch.org` object as soon as they see it (whenever `legacyAPI.enabled` is true, the chart default), even on fresh 3.x installs that never had a single `opensearch.opster.io` twin. The finalizer's only job is to delete the legacy twin when the new object is deleted, so on objects with no twin it just sits there forever, since only the operator process removes it. This causes finalizer buildup and stuck namespace deletion after the operator is uninstalled.

This change adds a `genericHasLegacyTwin` helper (shared by both the generic and cluster migration reconcilers) that only adds the finalizer when there is actually something to clean up:
- the object carries the `opensearch.org/migrated-from` annotation set during an actual migration, or
- a legacy (`opensearch.opster.io`) object with the same name/namespace currently exists (single by-name `Get`, not a list).

If a legacy twin is created after the new object already exists (unusual but possible), the finalizer still gets added on the next reconcile that observes it, since the check runs every time the finalizer is found missing.

Existing objects that already carry the finalizer are unaffected; the deletion path already treats a missing finalizer as "nothing to clean up" (see `#1417`), so no other change is needed.

### Issues Resolved
Closes #1544

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).