### PR TITLE
fix: patch instead of full-update legacy CR metadata during migration

### DIFF
--- a/opensearch-operator/controllers/migration_controller.go
+++ b/opensearch-operator/controllers/migration_controller.go
@@ -144,8 +144,14 @@ func (r *ClusterMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		// Add finalizer if not present
 		if !containsString(oldCluster.Finalizers, MigrationFinalizer) {
+			// Patch only metadata.finalizers instead of a full-object Update: a full
+			// Update round-trips oldCluster.Spec through the typed Go struct, which
+			// drops any zero-valued field with `omitempty` (e.g. dashboards.replicas: 0)
+			// and lets the CRD re-default it, making the legacy validating webhook see
+			// a spec change and reject the write (see #1540).
+			patch := client.MergeFrom(oldCluster.DeepCopy())
 			oldCluster.Finalizers = append(oldCluster.Finalizers, MigrationFinalizer)
-			if err := r.Update(ctx, oldCluster); err != nil {
+			if err := r.Patch(ctx, oldCluster, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -361,11 +367,14 @@ func (r *ClusterMigrationReconciler) handleNewClusterDeletion(ctx context.Contex
 	// This allows handleOldClusterDeletion to distinguish between:
 	// 1. Old CR manually deleted before migration (should wait for migration)
 	// 2. Old CR deleted because new CR was deleted (should allow deletion)
+	// Patch only metadata.annotations instead of a full-object Update - see the
+	// comment on the finalizer patch above (#1540).
+	patch := client.MergeFrom(oldCluster.DeepCopy())
 	if oldCluster.Annotations == nil {
 		oldCluster.Annotations = make(map[string]string)
 	}
 	oldCluster.Annotations[DeletedByNewResourceAnnotation] = "true"
-	if err := r.Update(ctx, oldCluster); err != nil {
+	if err := r.Patch(ctx, oldCluster, patch); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -735,8 +744,11 @@ func reconcileGenericMigration[OldType, NewType any, OldPtr interface {
 
 		// Add finalizer if not present
 		if !containsString(oldResource.GetFinalizers(), MigrationFinalizer) {
+			// Patch only metadata.finalizers - see the comment on the equivalent
+			// OpenSearchCluster patch above (#1540).
+			patch := client.MergeFrom(oldResource.DeepCopyObject().(OldPtr))
 			oldResource.SetFinalizers(append(oldResource.GetFinalizers(), MigrationFinalizer))
-			if err := c.Update(ctx, oldResource); err != nil {
+			if err := c.Patch(ctx, oldResource, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -890,13 +902,16 @@ func handleGenericNewDeletion[OldType, NewType any, OldPtr interface {
 	// This allows handleGenericDeletion to distinguish between:
 	// 1. Old resource manually deleted before migration (should wait for migration)
 	// 2. Old resource deleted because new resource was deleted (should allow deletion)
+	// Patch only metadata.annotations - see the comment on the equivalent
+	// OpenSearchCluster patch above (#1540).
+	patch := client.MergeFrom(oldResource.DeepCopyObject().(OldPtr))
 	if oldResource.GetAnnotations() == nil {
 		oldResource.SetAnnotations(make(map[string]string))
 	}
 	annotations := oldResource.GetAnnotations()
 	annotations[DeletedByNewResourceAnnotation] = "true"
 	oldResource.SetAnnotations(annotations)
-	if err := c.Update(ctx, oldResource); err != nil {
+	if err := c.Patch(ctx, oldResource, patch); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/opensearch-operator/controllers/migration_controller.go
+++ b/opensearch-operator/controllers/migration_controller.go
@@ -401,10 +401,11 @@ func (r *ClusterMigrationReconciler) handleOldClusterDeletion(ctx context.Contex
 				if oldCluster.Annotations != nil && oldCluster.Annotations[DeletedByNewResourceAnnotation] == "true" {
 					// Old cluster deletion was triggered by new cluster deletion - safe to allow
 					logger.Info("Old cluster deletion triggered by new cluster deletion, allowing deletion", "name", oldCluster.Name)
-					// Remove all finalizers (migration finalizer and old finalizers)
+					// Patch only metadata.finalizers
+					patch := client.MergeFrom(oldCluster.DeepCopy())
 					oldCluster.Finalizers = removeString(oldCluster.Finalizers, MigrationFinalizer)
 					oldCluster.Finalizers = removeString(oldCluster.Finalizers, OldClusterFinalizer)
-					if err := r.Update(ctx, oldCluster); err != nil {
+					if err := r.Patch(ctx, oldCluster, patch); err != nil {
 						return ctrl.Result{}, err
 					}
 					return ctrl.Result{}, nil
@@ -419,10 +420,11 @@ func (r *ClusterMigrationReconciler) handleOldClusterDeletion(ctx context.Contex
 
 		// New cluster exists, safe to remove finalizers and allow deletion
 		logger.Info("Removing finalizers from old cluster", "name", oldCluster.Name)
-		// Remove all finalizers (migration finalizer and old finalizers)
+		// Patch only metadata.finalizers
+		patch := client.MergeFrom(oldCluster.DeepCopy())
 		oldCluster.Finalizers = removeString(oldCluster.Finalizers, MigrationFinalizer)
 		oldCluster.Finalizers = removeString(oldCluster.Finalizers, OldClusterFinalizer)
-		if err := r.Update(ctx, oldCluster); err != nil {
+		if err := r.Patch(ctx, oldCluster, patch); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -945,11 +947,12 @@ func handleGenericDeletion[OldType, NewType any, OldPtr interface {
 				if annotations != nil && annotations[DeletedByNewResourceAnnotation] == "true" {
 					// Old resource deletion was triggered by new resource deletion - safe to allow
 					logger.Info("Old resource deletion triggered by new resource deletion, allowing deletion", "kind", resourceKind, "name", req.Name)
-					// Remove all finalizers (migration finalizer and old finalizers)
+					// Patch only metadata.finalizers
+					patch := client.MergeFrom(oldResource.DeepCopyObject().(OldPtr))
 					finalizers := removeString(oldResource.GetFinalizers(), MigrationFinalizer)
 					finalizers = removeString(finalizers, OldResourceFinalizer)
 					oldResource.SetFinalizers(finalizers)
-					if err := c.Update(ctx, oldResource); err != nil {
+					if err := c.Patch(ctx, oldResource, patch); err != nil {
 						return ctrl.Result{}, err
 					}
 					return ctrl.Result{}, nil
@@ -964,11 +967,13 @@ func handleGenericDeletion[OldType, NewType any, OldPtr interface {
 
 		// New resource exists, safe to remove finalizers and allow deletion
 		logger.Info("Removing finalizers from old resource", "kind", resourceKind, "name", req.Name)
-		// Remove all finalizers (migration finalizer and old finalizers)
+		// Patch only metadata.finalizers - see the equivalent OpenSearchCluster
+		// finalizer-add comment above (#1540).
+		patch := client.MergeFrom(oldResource.DeepCopyObject().(OldPtr))
 		finalizers := removeString(oldResource.GetFinalizers(), MigrationFinalizer)
 		finalizers = removeString(finalizers, OldResourceFinalizer)
 		oldResource.SetFinalizers(finalizers)
-		if err := c.Update(ctx, oldResource); err != nil {
+		if err := c.Patch(ctx, oldResource, patch); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var _ = Describe("ClusterMigrationReconciler", func() {
@@ -262,6 +264,66 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			updatedCluster := &opsterv1.OpenSearchCluster{}
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
 			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeTrue())
+		})
+
+		// Regression test for #1540: a legacy CR with dashboards.replicas explicitly
+		// stored as 0 (dashboards disabled) is rejected by the legacy validating
+		// webhook if the finalizer is added via a full-object Update, because the
+		// zero value is dropped by `omitempty` on the typed round-trip and the CRD
+		// re-defaults it to 1, making the webhook see a (fake) spec change. The
+		// reconciler must add the finalizer via a metadata-only Patch instead, which
+		// never touches spec and so can never trigger this false positive.
+		It("should add the migration finalizer via a metadata-only patch, not a full-object update", func() {
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					Dashboards: opsterv1.DashboardsConfig{
+						Enable:   true,
+						Replicas: 0, // dashboards disabled; the value that trips CRD re-defaulting on a full Update
+					},
+				},
+				Status: opsterv1.ClusterStatus{
+					Phase: opsterv1.PhaseRunning,
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldCluster)).To(Succeed())
+
+			// Simulate the legacy validating webhook: any full-object Update is
+			// denied (as it would be in a real cluster once the round-tripped spec
+			// no longer matches byte-for-byte), while a Patch is only allowed if it
+			// never touches spec.
+			watchClient, ok := fakeClient.(client.WithWatch)
+			Expect(ok).To(BeTrue())
+			reconciler.Client = interceptor.NewClient(watchClient, interceptor.Funcs{
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					// Only the legacy (opensearch.opster.io) CR is guarded by the
+					// legacy validating webhook; leave opensearch.org writes alone.
+					if _, ok := obj.(*opsterv1.OpenSearchCluster); ok {
+						return fmt.Errorf("admission webhook \"vopensearchcluster.opensearch.opster.io\" denied the request: Direct updates to old API group OpenSearchCluster resources are not allowed")
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					data, err := patch.Data(obj)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).NotTo(ContainSubstring(`"spec"`), "finalizer patch must not touch spec: %s", string(data))
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedCluster := &opsterv1.OpenSearchCluster{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
+			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeTrue())
+			Expect(updatedCluster.Spec.Dashboards.Replicas).To(Equal(int32(0)))
 		})
 	})
 

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -267,12 +267,12 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 		})
 
 		// Regression test for #1540: a legacy CR with dashboards.replicas explicitly
-		// stored as 0 (dashboards disabled) is rejected by the legacy validating
-		// webhook if the finalizer is added via a full-object Update, because the
-		// zero value is dropped by `omitempty` on the typed round-trip and the CRD
-		// re-defaults it to 1, making the webhook see a (fake) spec change. The
-		// reconciler must add the finalizer via a metadata-only Patch instead, which
-		// never touches spec and so can never trigger this false positive.
+		// stored as 0 is rejected by the legacy validating webhook if the finalizer
+		// is added via a full-object Update, because the zero value is dropped by
+		// `omitempty` on the typed round-trip and the CRD re-defaults it to 1, making
+		// the webhook see a (fake) spec change. The reconciler must add the finalizer
+		// via a metadata-only Patch instead, which never touches spec and so can
+		// never trigger this false positive.
 		It("should add the migration finalizer via a metadata-only patch, not a full-object update", func() {
 			oldCluster := &opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -285,7 +285,7 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 					},
 					Dashboards: opsterv1.DashboardsConfig{
 						Enable:   true,
-						Replicas: 0, // dashboards disabled; the value that trips CRD re-defaulting on a full Update
+						Replicas: 0, // explicit zero; the value that trips CRD re-defaulting on a full Update
 					},
 				},
 				Status: opsterv1.ClusterStatus{
@@ -357,6 +357,69 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			updatedCluster := &opsterv1.OpenSearchCluster{}
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
 			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeFalse())
+		})
+
+		// Regression for #1540: finalizer removal must also be a metadata-only Patch.
+		// DeletionTimestamp would let a full Update past the webhook, but Update still
+		// re-defaults omitempty zeros on the dying object.
+		It("should remove finalizers via a metadata-only patch when new cluster exists", func() {
+			now := metav1.Now()
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{MigrationFinalizer, OldClusterFinalizer},
+				},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					Dashboards: opsterv1.DashboardsConfig{
+						Enable:   true,
+						Replicas: 0,
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldCluster)).To(Succeed())
+
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+
+			watchClient, ok := fakeClient.(client.WithWatch)
+			Expect(ok).To(BeTrue())
+			reconciler.Client = interceptor.NewClient(watchClient, interceptor.Funcs{
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if _, ok := obj.(*opsterv1.OpenSearchCluster); ok {
+						return fmt.Errorf("admission webhook \"vopensearchcluster.opensearch.opster.io\" denied the request: Direct updates to old API group OpenSearchCluster resources are not allowed")
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					data, err := patch.Data(obj)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).NotTo(ContainSubstring(`"spec"`), "finalizer removal patch must not touch spec: %s", string(data))
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			// Re-fetch so the in-memory object matches what the interceptor-backed client sees
+			Expect(reconciler.Get(ctx, req.NamespacedName, oldCluster)).To(Succeed())
+
+			result, err := reconciler.handleOldClusterDeletion(ctx, oldCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			updatedCluster := &opsterv1.OpenSearchCluster{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
+			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeFalse())
+			Expect(containsString(updatedCluster.Finalizers, OldClusterFinalizer)).To(BeFalse())
+			Expect(updatedCluster.Spec.Dashboards.Replicas).To(Equal(int32(0)))
 		})
 
 		It("should allow deletion when annotation indicates new cluster deletion", func() {


### PR DESCRIPTION
### Description
The migration controller's finalizer/annotation writes on the legacy `opensearch.opster.io` CR used a full-object `Update`. That round-trips `Spec` through the typed Go struct, which drops any zero-valued field marked `omitempty` (e.g. `dashboards.replicas: 0`) and lets the CRD re-default it on the way back in. The legacy validating webhook (`isStatusOnlyUpdate` in `webhook/legacy_webhook_helpers.go`) does a byte-level comparison of old vs. new spec, sees what looks like a spec change, and rejects the write - so the migration finalizer is never added and migration never starts for any cluster with such a field explicitly stored as its zero value.

This switches the metadata-only writes on legacy CRs (finalizer add, deletion-tracking annotation add - covering both the `OpenSearchCluster` migration path and the generic resource migration path used for User/Role/etc.) from a full-object `Update` to a `client.MergeFrom` patch scoped to metadata. The spec is never re-serialized through the Go type for these writes, so the webhook always sees a metadata-only update regardless of which field carries a `+kubebuilder:default` marker.

### Issues Resolved
Closes #1540

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).