### PR TITLE
fix: don't let secondary-kind reconcilers clobber a concurrent status write

### DIFF
--- a/opensearch-operator/pkg/reconcilers/actiongroup.go
+++ b/opensearch-operator/pkg/reconcilers/actiongroup.go
@@ -76,7 +76,7 @@ func (r *ActionGroupReconciler) Reconcile() (retResult ctrl.Result, retErr error
 			if retErr == nil && retResult.RequeueAfter == 30*time.Second {
 				instance.Status.State = opensearchv1.OpensearchActionGroupCreated
 			}
-			if reason == opensearchActionGroupExists {
+			if reason == opensearchActionGroupExists && ptr.Deref(instance.Status.ExistingActionGroup, false) {
 				instance.Status.State = opensearchv1.OpensearchActionGroupIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/actiongroup.go
+++ b/opensearch-operator/pkg/reconcilers/actiongroup.go
@@ -160,7 +160,11 @@ func (r *ActionGroupReconciler) Reconcile() (retResult ctrl.Result, retErr error
 		if ptr.Deref(r.updateStatus, true) {
 			retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 				instance := object.(*opensearchv1.OpensearchActionGroup)
-				instance.Status.ExistingActionGroup = &exists
+				// A concurrent writer (e.g. the migration controller restoring
+				// the migrated status) may have set this already; don't clobber it.
+				if instance.Status.ExistingActionGroup == nil {
+					instance.Status.ExistingActionGroup = &exists
+				}
 			})
 			if retErr != nil {
 				reason = fmt.Sprintf("failed to update status: %s", retErr)

--- a/opensearch-operator/pkg/reconcilers/componenttemplate.go
+++ b/opensearch-operator/pkg/reconcilers/componenttemplate.go
@@ -172,7 +172,11 @@ func (r *ComponentTemplateReconciler) Reconcile() (result ctrl.Result, err error
 		if ptr.Deref(r.updateStatus, true) {
 			err = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 				instance := object.(*opensearchv1.OpensearchComponentTemplate)
-				instance.Status.ExistingComponentTemplate = &exists
+				// A concurrent writer (e.g. the migration controller restoring
+				// the migrated status) may have set this already; don't clobber it.
+				if instance.Status.ExistingComponentTemplate == nil {
+					instance.Status.ExistingComponentTemplate = &exists
+				}
 			})
 			if err != nil {
 				reason = fmt.Sprintf("failed to update status: %s", err)

--- a/opensearch-operator/pkg/reconcilers/componenttemplate.go
+++ b/opensearch-operator/pkg/reconcilers/componenttemplate.go
@@ -77,7 +77,7 @@ func (r *ComponentTemplateReconciler) Reconcile() (result ctrl.Result, err error
 			if err == nil && result.RequeueAfter == 30*time.Second {
 				instance.Status.State = opensearchv1.OpensearchComponentTemplateCreated
 			}
-			if reason == opensearchComponentTemplateExists {
+			if reason == opensearchComponentTemplateExists && ptr.Deref(instance.Status.ExistingComponentTemplate, false) {
 				instance.Status.State = opensearchv1.OpensearchComponentTemplateIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/indextemplate.go
+++ b/opensearch-operator/pkg/reconcilers/indextemplate.go
@@ -170,7 +170,11 @@ func (r *IndexTemplateReconciler) Reconcile() (result ctrl.Result, err error) {
 		if ptr.Deref(r.updateStatus, true) {
 			err = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 				instance := object.(*opensearchv1.OpensearchIndexTemplate)
-				instance.Status.ExistingIndexTemplate = &exists
+				// A concurrent writer (e.g. the migration controller restoring
+				// the migrated status) may have set this already; don't clobber it.
+				if instance.Status.ExistingIndexTemplate == nil {
+					instance.Status.ExistingIndexTemplate = &exists
+				}
 			})
 			if err != nil {
 				reason = fmt.Sprintf("failed to update status: %s", err)

--- a/opensearch-operator/pkg/reconcilers/indextemplate.go
+++ b/opensearch-operator/pkg/reconcilers/indextemplate.go
@@ -79,7 +79,7 @@ func (r *IndexTemplateReconciler) Reconcile() (result ctrl.Result, err error) {
 				instance.Status.State = opensearchv1.OpensearchIndexTemplateCreated
 				instance.Status.IndexTemplateName = templateName
 			}
-			if reason == opensearchIndexTemplateExists {
+			if reason == opensearchIndexTemplateExists && ptr.Deref(instance.Status.ExistingIndexTemplate, false) {
 				instance.Status.State = opensearchv1.OpensearchIndexTemplateIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -242,7 +242,13 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 	// If the ISM policy exists in OpenSearch cluster and was not created by the operator, update the status and return
 	if r.instance.Status.ExistingISMPolicy == nil || *r.instance.Status.ExistingISMPolicy {
 		retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
-			object.(*opensearchv1.OpenSearchISMPolicy).Status.ExistingISMPolicy = ptr.To(true)
+			instance := object.(*opensearchv1.OpenSearchISMPolicy)
+			// A concurrent writer (e.g. the migration controller restoring the
+			// migrated status) may have already marked this as managed by the
+			// operator; don't clobber it.
+			if instance.Status.ExistingISMPolicy == nil {
+				instance.Status.ExistingISMPolicy = ptr.To(true)
+			}
 		})
 		if retErr != nil {
 			reason = "failed to update custom resource object"
@@ -252,13 +258,15 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 				RequeueAfter: defaultRequeueAfter,
 			}, retErr
 		}
-		reason = "the ISM policy already exists in the OpenSearch cluster"
-		r.logger.Error(errors.New(opensearchIsmPolicyExists), reason)
-		r.recorder.Event(r.instance, "Warning", opensearchIsmPolicyExists, reason)
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: defaultRequeueAfter,
-		}, nil
+		if r.instance.Status.ExistingISMPolicy == nil || *r.instance.Status.ExistingISMPolicy {
+			reason = "the ISM policy already exists in the OpenSearch cluster"
+			r.logger.Error(errors.New(opensearchIsmPolicyExists), reason)
+			r.recorder.Event(r.instance, "Warning", opensearchIsmPolicyExists, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, nil
+		}
 	}
 
 	// Return if there are no changes

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -85,7 +85,7 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 				instance.Status.State = opensearchv1.OpensearchISMPolicyCreated
 				instance.Status.PolicyId = policyId
 			}
-			if reason == opensearchIsmPolicyExists {
+			if reason == opensearchIsmPolicyExists && ptr.Deref(instance.Status.ExistingISMPolicy, false) {
 				instance.Status.State = opensearchv1.OpensearchISMPolicyIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/ismpolicy_test.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -501,6 +502,55 @@ var _ = Describe("ism policy reconciler", func() {
 					}
 					Expect(len(events)).To(Equal(1))
 					Expect(events[0]).To(Equal(fmt.Sprintf("Warning %s the ISM policy already exists in the OpenSearch cluster", opensearchIsmPolicyExists)))
+				})
+			})
+
+			When("existing status is nil but a concurrent status write already set it", func() {
+				JustBeforeEach(func() {
+					reconciler.updateStatus = ptr.To(true)
+				})
+
+				BeforeEach(func() {
+					instance.Spec.DefaultState = "test-state"
+					instance.Spec.Description = "test-policy"
+					instance.Status.ExistingISMPolicy = nil
+					mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+						func(obj client.Object, f func(client.Object)) error {
+							f(obj)
+							return nil
+						},
+					).Once()
+					mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+						func(obj client.Object, f func(client.Object)) error {
+							obj.(*opensearchv1.OpenSearchISMPolicy).Status.ExistingISMPolicy = ptr.To(false)
+							f(obj)
+							return nil
+						},
+					).Once()
+					mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+						func(obj client.Object, f func(client.Object)) error {
+							f(obj)
+							return nil
+						},
+					)
+				})
+
+				It("takes the managed path instead of returning ignored", func() {
+					go func() {
+						defer GinkgoRecover()
+						defer close(recorder.Events)
+						_, err := reconciler.Reconcile()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(instance.Status.ExistingISMPolicy).ToNot(BeNil())
+						Expect(*instance.Status.ExistingISMPolicy).To(BeFalse())
+						Expect(instance.Status.State).ToNot(Equal(opensearchv1.OpensearchISMPolicyIgnored))
+					}()
+					var events []string
+					for msg := range recorder.Events {
+						events = append(events, msg)
+					}
+					Expect(events).To(ContainElement(fmt.Sprintf("Normal %s policy is in sync", opensearchAPIUnchanged)))
+					Expect(events).ToNot(ContainElement(fmt.Sprintf("Warning %s the ISM policy already exists in the OpenSearch cluster", opensearchIsmPolicyExists)))
 				})
 			})
 

--- a/opensearch-operator/pkg/reconcilers/role.go
+++ b/opensearch-operator/pkg/reconcilers/role.go
@@ -76,7 +76,7 @@ func (r *RoleReconciler) Reconcile() (retResult ctrl.Result, retErr error) {
 			if retErr == nil && retResult.Requeue {
 				instance.Status.State = opensearchv1.OpensearchRoleStateCreated
 			}
-			if reason == opensearchRoleExists {
+			if reason == opensearchRoleExists && ptr.Deref(instance.Status.ExistingRole, false) {
 				instance.Status.State = opensearchv1.OpensearchRoleIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/role.go
+++ b/opensearch-operator/pkg/reconcilers/role.go
@@ -160,7 +160,11 @@ func (r *RoleReconciler) Reconcile() (retResult ctrl.Result, retErr error) {
 		if ptr.Deref(r.updateStatus, true) {
 			retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 				instance := object.(*opensearchv1.OpensearchRole)
-				instance.Status.ExistingRole = &exists
+				// A concurrent writer (e.g. the migration controller restoring
+				// the migrated status) may have set this already; don't clobber it.
+				if instance.Status.ExistingRole == nil {
+					instance.Status.ExistingRole = &exists
+				}
 			})
 			if retErr != nil {
 				reason = fmt.Sprintf("failed to update status: %s", retErr)

--- a/opensearch-operator/pkg/reconcilers/snapshotpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/snapshotpolicy.go
@@ -228,7 +228,13 @@ func (r *SnapshotPolicyReconciler) Reconcile() (result ctrl.Result, err error) {
 	// If the Snapshot policy exists in OpenSearch cluster and was not created by the operator, update the status and return
 	if r.instance.Status.ExistingSnapshotPolicy == nil || *r.instance.Status.ExistingSnapshotPolicy {
 		err = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
-			object.(*opensearchv1.OpensearchSnapshotPolicy).Status.ExistingSnapshotPolicy = ptr.To(true)
+			instance := object.(*opensearchv1.OpensearchSnapshotPolicy)
+			// A concurrent writer (e.g. the migration controller restoring the
+			// migrated status) may have already marked this as managed by the
+			// operator; don't clobber it.
+			if instance.Status.ExistingSnapshotPolicy == nil {
+				instance.Status.ExistingSnapshotPolicy = ptr.To(true)
+			}
 		})
 		if err != nil {
 			reason = "failed to update custom resource object"
@@ -238,13 +244,15 @@ func (r *SnapshotPolicyReconciler) Reconcile() (result ctrl.Result, err error) {
 				RequeueAfter: defaultRequeueAfter,
 			}, err
 		}
-		reason = "the Snapshot policy already exists in the OpenSearch cluster"
-		r.logger.Error(errors.New(opensearchSnapshotPolicyExists), reason)
-		r.recorder.Event(r.instance, "Warning", opensearchSnapshotPolicyExists, reason)
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: defaultRequeueAfter,
-		}, nil
+		if r.instance.Status.ExistingSnapshotPolicy == nil || *r.instance.Status.ExistingSnapshotPolicy {
+			reason = "the Snapshot policy already exists in the OpenSearch cluster"
+			r.logger.Error(errors.New(opensearchSnapshotPolicyExists), reason)
+			r.recorder.Event(r.instance, "Warning", opensearchSnapshotPolicyExists, reason)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: defaultRequeueAfter,
+			}, nil
+		}
 	}
 
 	// Return if there are no changes

--- a/opensearch-operator/pkg/reconcilers/snapshotpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/snapshotpolicy.go
@@ -81,7 +81,7 @@ func (r *SnapshotPolicyReconciler) Reconcile() (result ctrl.Result, err error) {
 				instance.Status.State = opensearchv1.OpensearchSnapshotPolicyCreated
 				instance.Status.SnapshotPolicyName = policyName
 			}
-			if reason == opensearchSnapshotPolicyExists {
+			if reason == opensearchSnapshotPolicyExists && ptr.Deref(instance.Status.ExistingSnapshotPolicy, false) {
 				instance.Status.State = opensearchv1.OpensearchSnapshotPolicyIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/snapshotpolicy_test.go
+++ b/opensearch-operator/pkg/reconcilers/snapshotpolicy_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -310,6 +311,54 @@ var _ = Describe("snapshot policy reconciler", func() {
 					}
 					Expect(len(events)).To(Equal(1))
 					Expect(events[0]).To(Equal(fmt.Sprintf("Warning %s the Snapshot policy already exists in the OpenSearch cluster", opensearchSnapshotPolicyExists)))
+				})
+			})
+
+			When("existing status is nil but a concurrent status write already set it", func() {
+				JustBeforeEach(func() {
+					reconciler.updateStatus = ptr.To(true)
+				})
+
+				BeforeEach(func() {
+					instance.Spec.Description = ptr.To("test-policy-name sample description")
+					instance.Status.ExistingSnapshotPolicy = nil
+					mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+						func(obj client.Object, f func(client.Object)) error {
+							f(obj)
+							return nil
+						},
+					).Once()
+					mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+						func(obj client.Object, f func(client.Object)) error {
+							obj.(*opensearchv1.OpensearchSnapshotPolicy).Status.ExistingSnapshotPolicy = ptr.To(false)
+							f(obj)
+							return nil
+						},
+					).Once()
+					mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+						func(obj client.Object, f func(client.Object)) error {
+							f(obj)
+							return nil
+						},
+					)
+				})
+
+				It("takes the managed path instead of returning ignored", func() {
+					go func() {
+						defer GinkgoRecover()
+						defer close(recorder.Events)
+						_, err := reconciler.Reconcile()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(instance.Status.ExistingSnapshotPolicy).ToNot(BeNil())
+						Expect(*instance.Status.ExistingSnapshotPolicy).To(BeFalse())
+						Expect(instance.Status.State).ToNot(Equal(opensearchv1.OpensearchSnapshotPolicyIgnored))
+					}()
+					var events []string
+					for msg := range recorder.Events {
+						events = append(events, msg)
+					}
+					Expect(events).To(ContainElement(fmt.Sprintf("Normal %s policy is in sync", opensearchAPIUnchanged)))
+					Expect(events).ToNot(ContainElement(fmt.Sprintf("Warning %s the Snapshot policy already exists in the OpenSearch cluster", opensearchSnapshotPolicyExists)))
 				})
 			})
 

--- a/opensearch-operator/pkg/reconcilers/tenant.go
+++ b/opensearch-operator/pkg/reconcilers/tenant.go
@@ -162,7 +162,11 @@ func (r *TenantReconciler) Reconcile() (retResult ctrl.Result, retErr error) {
 		if ptr.Deref(r.updateStatus, true) {
 			retErr = r.client.UdateObjectStatus(r.instance, func(object client.Object) {
 				instance := object.(*opensearchv1.OpensearchTenant)
-				instance.Status.ExistingTenant = &exists
+				// A concurrent writer (e.g. the migration controller restoring
+				// the migrated status) may have set this already; don't clobber it.
+				if instance.Status.ExistingTenant == nil {
+					instance.Status.ExistingTenant = &exists
+				}
 			})
 			if retErr != nil {
 				reason = fmt.Sprintf("failed to update status: %s", retErr)

--- a/opensearch-operator/pkg/reconcilers/tenant.go
+++ b/opensearch-operator/pkg/reconcilers/tenant.go
@@ -78,7 +78,7 @@ func (r *TenantReconciler) Reconcile() (retResult ctrl.Result, retErr error) {
 			if retErr == nil && retResult.RequeueAfter == 30*time.Second {
 				instance.Status.State = opensearchv1.OpensearchTenantCreated
 			}
-			if reason == opensearchTenantExists {
+			if reason == opensearchTenantExists && ptr.Deref(instance.Status.ExistingTenant, false) {
 				instance.Status.State = opensearchv1.OpensearchTenantIgnored
 			}
 		})

--- a/opensearch-operator/pkg/reconcilers/tenant_test.go
+++ b/opensearch-operator/pkg/reconcilers/tenant_test.go
@@ -311,6 +311,53 @@ var _ = Describe("tenant reconciler", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(instance.Status.ExistingTenant).ToNot(BeNil())
 				Expect(*instance.Status.ExistingTenant).To(BeFalse())
+				Expect(instance.Status.State).ToNot(Equal(opensearchv1.OpensearchTenantIgnored))
+			})
+		})
+
+		When("probe marks existing but a concurrent write marks it managed before deferred status", func() {
+			// Residual race: this reconcile already decided the object was
+			// pre-existing (reason=exists) before the migration restore landed.
+			// The deferred status write must not stamp IGNORED over the
+			// concurrently-restored ExistingTenant=false.
+			JustBeforeEach(func() {
+				reconciler.updateStatus = ptr.To(true)
+			})
+
+			BeforeEach(func() {
+				instance.Status.ManagedCluster = &cluster.UID
+				transport.RegisterResponder(
+					http.MethodGet,
+					fmt.Sprintf(
+						"%s_plugins/_security/api/tenants/%s",
+						clusterUrl,
+						instance.Name,
+					),
+					httpmock.NewJsonResponderOrPanic(200, responses.GetTenantResponse{
+						instance.Name: requests.Tenant{Description: "test-description"},
+					}),
+				)
+				mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+					func(obj client.Object, f func(client.Object)) error {
+						f(obj)
+						return nil
+					},
+				).Once()
+				mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+					func(obj client.Object, f func(client.Object)) error {
+						obj.(*opensearchv1.OpensearchTenant).Status.ExistingTenant = ptr.To(false)
+						f(obj)
+						return nil
+					},
+				)
+			})
+
+			It("does not stamp IGNORED over the concurrently-written managed status", func() {
+				_, err := reconciler.Reconcile()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Status.ExistingTenant).ToNot(BeNil())
+				Expect(*instance.Status.ExistingTenant).To(BeFalse())
+				Expect(instance.Status.State).ToNot(Equal(opensearchv1.OpensearchTenantIgnored))
 			})
 		})
 

--- a/opensearch-operator/pkg/reconcilers/tenant_test.go
+++ b/opensearch-operator/pkg/reconcilers/tenant_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -256,6 +257,60 @@ var _ = Describe("tenant reconciler", func() {
 				Expect(len(events)).To(Equal(2))
 				Expect(events[0]).To(Equal("Normal UnitTest exists is true"))
 				Expect(events[1]).To(Equal("Normal UnitTest exists is false"))
+			})
+		})
+
+		When("existing status is nil but a concurrent status write already set it", func() {
+			// Regression test for the migration race: the migration controller
+			// creates the twin with an empty status and restores the real status
+			// afterwards via UdateObjectStatus. If this reconciler's own "does it
+			// already exist in Opensearch" probe races that restore, it must not
+			// clobber the concurrently-written value.
+			JustBeforeEach(func() {
+				reconciler.updateStatus = ptr.To(true)
+			})
+
+			BeforeEach(func() {
+				instance.Status.ManagedCluster = &cluster.UID
+				tenantRequest := requests.Tenant{
+					Description: "test-description",
+				}
+				transport.RegisterResponder(
+					http.MethodGet,
+					fmt.Sprintf(
+						"%s_plugins/_security/api/tenants/%s",
+						clusterUrl,
+						instance.Name,
+					),
+					httpmock.NewJsonResponderOrPanic(200, responses.GetTenantResponse{
+						instance.Name: tenantRequest,
+					}),
+				)
+				// The first UdateObjectStatus call is the reconciler's "does it
+				// already exist in Opensearch" probe; simulate the migration
+				// controller's status restore landing right before it runs.
+				mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+					func(obj client.Object, f func(client.Object)) error {
+						obj.(*opensearchv1.OpensearchTenant).Status.ExistingTenant = ptr.To(false)
+						f(obj)
+						return nil
+					},
+				).Once()
+				// Later UdateObjectStatus calls (e.g. the deferred reason/state
+				// write) behave normally.
+				mockClient.EXPECT().UdateObjectStatus(mock.Anything, mock.Anything).RunAndReturn(
+					func(obj client.Object, f func(client.Object)) error {
+						f(obj)
+						return nil
+					},
+				)
+			})
+
+			It("keeps the concurrently-written value instead of marking it existing", func() {
+				_, err := reconciler.Reconcile()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Status.ExistingTenant).ToNot(BeNil())
+				Expect(*instance.Status.ExistingTenant).To(BeFalse())
 			})
 		})
 


### PR DESCRIPTION
### Description
`createGenericNewFromOld` (`controllers/migration_controller.go`) has to create the migrated `opensearch.org` twin with an empty status (the status subresource is ignored on `Create`) and restore the real status afterwards via `UdateObjectStatus`. The twin's per-kind controller watches with a plain `For(...).Owns(...)` (no predicate), so it can reconcile on the `Create` event before that status restore lands.

When it does: the reconciler reads a stale `Existing<Kind> == nil`, probes Opensearch, finds the object the legacy CR already created there, and unconditionally writes `existing=true` (or, for the ISM/snapshot policy reconcilers, treats a still-nil value as "existing" and never notices a concurrent write already marked it managed). That `IGNORED`/`existing*: true` state never self-corrects: spec edits stop applying, `Delete()` short-circuits and leaves the Opensearch object behind, and it compounds with other issues on adoption.

`UdateObjectStatus` already re-`Get`s the object right before invoking its closure (retry-on-conflict), so by the time the closure runs it can see a status write that landed concurrently. This PR:

- guards each closure so it only sets `Existing<Kind>` when the freshly-read value is still `nil`;
- for the ISM/snapshot policy reconcilers (where `nil` is treated as "existing"), re-checks the freshly-read value before returning the ignored state, so a concurrent write that already marked the object managed takes the normal update path instead;
- only stamps `State=IGNORED` in the deferred status write when the freshly-read `Existing<Kind>` is `true`, so a reconcile that decided "already exists" just before the restore landed doesn't paint `IGNORED` over the restored managed status.

A genuinely new object is unaffected: `nil -> probed value` still happens exactly as before. Only a concurrent write (i.e. the migration controller's status restore) is now preserved instead of clobbered.

Applies to the `actiongroup`, `componenttemplate`, `indextemplate`, `ismpolicy`, `role`, `snapshotpolicy` and `tenant` reconcilers — the shape shared by every "secondary kind" reconciler reachable from the migration path. `userrolebinding` has no `Existing*` field and is unaffected.

Tests drive the race deterministically by having the mocked `UdateObjectStatus` set `Existing<Kind>=false` before invoking the closure: for tenant (probe and deferred-write races) and for the ISM/snapshot policy re-check (verified to fail if the re-check is removed).

### Issues Resolved
Fixes #1543

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`go vet ./...`; `bin/golangci-lint` is broken in this environment)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
